### PR TITLE
Set shouldPureComponentUpdate on the prototype

### DIFF
--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -25,8 +25,6 @@ export const SortDirection = {
  * This component expects explicit width, height, and padding parameters.
  */
 export default class FlexTable extends Component {
-  shouldComponentUpdate = shouldPureComponentUpdate
-
   static defaultProps = {
     disableHeader: false,
     horizontalPadding: 0,
@@ -282,6 +280,7 @@ export default class FlexTable extends Component {
     return flex.join(' ')
   }
 }
+FlexTable.prototype.shouldComponentUpdate = shouldPureComponentUpdate
 
 /**
  * Displayed beside a header to indicate that a FlexTable is currently sorted by this column.

--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -20,8 +20,6 @@ const IS_SCROLLING_TIMEOUT = 150
  * container.
  */
 export default class VirtualScroll extends Component {
-  shouldComponentUpdate = shouldPureComponentUpdate
-
   static propTypes = {
     /** Optional CSS class name */
     className: PropTypes.string,
@@ -394,3 +392,4 @@ export default class VirtualScroll extends Component {
     })
   }
 }
+VirtualScroll.prototype.shouldComponentUpdate = shouldPureComponentUpdate


### PR DESCRIPTION
Dunno if it has any real effect on performance, but this lets you avoid having to reassign it per instance.