### PR TITLE
Fix conditional in VirtualScroll

### DIFF
--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -124,7 +124,7 @@ export default class VirtualScroll extends Component {
       height !== prevProps.height ||
       !prevProps.rowHeight ||
       (
-        rowHeight instanceof Number &&
+        typeof rowHeight === 'number' &&
         rowHeight !== prevProps.rowHeight
       )
     )


### PR DESCRIPTION
```js
var x = 1
x instanceof Number
// false
```

You could do a stricter type check if you really wanted to handle Number objects...

```js
typeof value == 'number' || (!!value && typeof value === 'object' && Object.prototype.toString.call(value) === '[object Number]')
```

I don't think you should bother, though, there's no reason to be passing in Number objects here.