### PR TITLE
Support server-side rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.1",
-    "detect-element-resize": "0.0.1",
-    "element-resize-event": "^2.0.3",
     "raf": "^3.1.0",
     "react-pure-render": "^1.0.2"
   },

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -1,6 +1,5 @@
 /** @flow */
 import React, { Component, PropTypes } from 'react'
-import detectElementResize from '../vendor/detectElementResize'
 import shouldPureComponentUpdate from 'react-pure-render/function'
 import styles from './AutoSizer.css'
 
@@ -30,13 +29,16 @@ export default class AutoSizer extends Component {
   }
 
   componentDidMount () {
-    detectElementResize.addResizeListener(this._parentNode, this._onResize)
+    // Defer requiring resize handler in order to support server-side rendering.
+    // See issue #41
+    this._detectElementResize = require('../vendor/detectElementResize')
+    this._detectElementResize.addResizeListener(this._parentNode, this._onResize)
 
     this._onResize()
   }
 
   componentWillUnmount () {
-    detectElementResize.removeResizeListener(this._parentNode, this._onResize)
+    this._detectElementResize.removeResizeListener(this._parentNode, this._onResize)
   }
 
   render () {


### PR DESCRIPTION
Defer references to `window` and `document` until `componentDidMount` to ensure that they aren't accessed in the context of the server.

Related to issue #41