### PR TITLE
Add onHeaderClick callback to FlexColumn

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -15,6 +15,7 @@ This component expects explicit width, height, and padding parameters.
 | height | Number | ✓ | Fixed/available height for out DOM element |
 | horizontalPadding | Number |  | Horizontal padding of outer DOM element |
 | noRowsRenderer |  | Function | Callback used to render placeholder content when :rowsCount is 0 |
+| onHeaderClick |  | Function | Callback invoked when a user clicks on a table header. `(dataKey: string): void` |
 | onRowClick |  | Function | Callback invoked when a user clicks on a table row. `(rowIndex: number): void` |
 | onRowsRendered |  | Function | Callback invoked with information about the slice of rows that were just rendered: `({ startIndex, stopIndex }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `(rowIndex: number): string`. Note that for the header row an index of `-1` is provided. |

--- a/source/FlexTable/FlexColumn.js
+++ b/source/FlexTable/FlexColumn.js
@@ -45,8 +45,7 @@ export default class Column extends Component {
     cellDataGetter: defaultCellDataGetter,
     cellRenderer: defaultCellRenderer,
     flexGrow: 0,
-    flexShrink: 1,
-    onHeaderClick: () => null
+    flexShrink: 1
   }
 
   static propTypes = {

--- a/source/FlexTable/FlexColumn.js
+++ b/source/FlexTable/FlexColumn.js
@@ -68,11 +68,6 @@ export default class Column extends Component {
     dataKey: PropTypes.any.isRequired,
     /** If sort is enabled for the table at large, disable it for this column */
     disableSort: PropTypes.bool,
-    /**
-    * Optional callback when this column's header is clicked.
-    * (): void
-    */
-    onHeaderClick: PropTypes.func,
     /** Flex grow style; defaults to 0 */
     flexGrow: PropTypes.number,
     /** Flex shrink style; defaults to 1 */

--- a/source/FlexTable/FlexColumn.js
+++ b/source/FlexTable/FlexColumn.js
@@ -45,7 +45,8 @@ export default class Column extends Component {
     cellDataGetter: defaultCellDataGetter,
     cellRenderer: defaultCellRenderer,
     flexGrow: 0,
-    flexShrink: 1
+    flexShrink: 1,
+    onHeaderClick: () => null
   }
 
   static propTypes = {
@@ -67,6 +68,11 @@ export default class Column extends Component {
     dataKey: PropTypes.any.isRequired,
     /** If sort is enabled for the table at large, disable it for this column */
     disableSort: PropTypes.bool,
+    /**
+    * Optional callback when this column's header is clicked.
+    * (): void
+    */
+    onHeaderClick: PropTypes.func,
     /** Flex grow style; defaults to 0 */
     flexGrow: PropTypes.number,
     /** Flex shrink style; defaults to 1 */

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -52,9 +52,15 @@ export default class FlexTable extends Component {
     /** Optional renderer to be used in place of table body rows when rowsCount is 0 */
     noRowsRenderer: PropTypes.func,
     /**
+    * Optional callback when a column's header is clicked.
+    * (dataKey: string): void
+    */
+    onHeaderClick: PropTypes.func,
+    /**
      * Callback invoked when a user clicks on a table row.
      * (rowIndex: number): void
      */
+
     onRowClick: PropTypes.func,
     /**
      * Callback invoked with information about the slice of rows that were just rendered.
@@ -97,6 +103,7 @@ export default class FlexTable extends Component {
     disableHeader: false,
     horizontalPadding: 0,
     noRowsRenderer: () => null,
+    onHeaderClick: () => null,
     onRowClick: () => null,
     onRowsRendered: () => null,
     verticalPadding: 0
@@ -237,9 +244,9 @@ export default class FlexTable extends Component {
   }
 
   _createHeader (column, columnIndex) {
-    const { headerClassName, sort, sortBy, sortDirection } = this.props
+    const { headerClassName, onHeaderClick, sort, sortBy, sortDirection } = this.props
     const { styleSheet } = this.state
-    const { dataKey, disableSort, label, onHeaderClick } = column.props
+    const { dataKey, disableSort, label } = column.props
     const showSortIndicator = sortBy === dataKey
     const sortEnabled = !disableSort && sort
 
@@ -263,7 +270,7 @@ export default class FlexTable extends Component {
       : SortDirection.DESC
     const onClick = () => {
       sortEnabled && sort(dataKey, newSortDirection)
-      onHeaderClick()
+      onHeaderClick(dataKey)
     }
 
     return (

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -239,7 +239,7 @@ export default class FlexTable extends Component {
   _createHeader (column, columnIndex) {
     const { headerClassName, sort, sortBy, sortDirection } = this.props
     const { styleSheet } = this.state
-    const { dataKey, disableSort, label } = column.props
+    const { dataKey, disableSort, label, onHeaderClick } = column.props
     const showSortIndicator = sortBy === dataKey
     const sortEnabled = !disableSort && sort
 
@@ -261,7 +261,10 @@ export default class FlexTable extends Component {
     const newSortDirection = sortBy !== dataKey || sortDirection === SortDirection.DESC
       ? SortDirection.ASC
       : SortDirection.DESC
-    const onClick = () => sortEnabled && sort(dataKey, newSortDirection)
+    const onClick = () => {
+      sortEnabled && sort(dataKey, newSortDirection)
+      onHeaderClick()
+    }
 
     return (
       <div

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -44,8 +44,8 @@ describe('FlexTable', () => {
     headerClassName = undefined,
     headerHeight = 20,
     height = 100,
-    onHeaderClick = undefined,
     noRowsRenderer = undefined,
+    onHeaderClick = undefined,
     onRowClick = undefined,
     onRowsRendered = undefined,
     rowClassName = undefined,
@@ -66,6 +66,7 @@ describe('FlexTable', () => {
         headerHeight={headerHeight}
         height={height}
         noRowsRenderer={noRowsRenderer}
+        onHeaderClick={onHeaderClick}
         onRowClick={onRowClick}
         onRowsRendered={onRowsRendered}
         rowClassName={rowClassName}
@@ -85,8 +86,6 @@ describe('FlexTable', () => {
           cellRenderer={cellRenderer}
           cellDataGetter={cellDataGetter}
           disableSort={disableSort}
-          onHeaderClick={onHeaderClick}
-
         />
         <FlexColumn
           label='Email'
@@ -329,30 +328,32 @@ describe('FlexTable', () => {
   })
 
   describe('onHeaderClick', () => {
-    it('should call :onHeaderClick when a column header is clicked and sorting is disabled', () => {
-      let onHeaderClickCalls = 0
+    it('should call :onHeaderClick with the correct arguments when a column header is clicked and sorting is disabled', () => {
+      let onHeaderClickCalls = []
       const table = renderTable({
         disableSort: true,
-        onHeaderClick: () => onHeaderClickCalls++
+        onHeaderClick: (dataKey) => onHeaderClickCalls.push({dataKey})
       })
       const tableDOMNode = findDOMNode(table)
       const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
 
       Simulate.click(nameColumn)
-      expect(onHeaderClickCalls).toEqual(1)
+      expect(onHeaderClickCalls.length).toEqual(1)
+      expect(onHeaderClickCalls[0].dataKey).toEqual('name')
     })
 
-    it('should call :onHeaderClick when a column header is clicked and sorting is enabled', () => {
-      let onHeaderClickCalls = 0
+    it('should call :onHeaderClick with the correct arguments when a column header is clicked and sorting is enabled', () => {
+      let onHeaderClickCalls = []
       const table = renderTable({
         disableSort: false,
-        onHeaderClick: () => onHeaderClickCalls++
+        onHeaderClick: (dataKey) => onHeaderClickCalls.push({dataKey})
       })
       const tableDOMNode = findDOMNode(table)
       const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
 
       Simulate.click(nameColumn)
-      expect(onHeaderClickCalls).toEqual(1)
+      expect(onHeaderClickCalls.length).toEqual(1)
+      expect(onHeaderClickCalls[0].dataKey).toEqual('name')
     })
   })
 

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -44,6 +44,7 @@ describe('FlexTable', () => {
     headerClassName = undefined,
     headerHeight = 20,
     height = 100,
+    onHeaderClick = undefined,
     noRowsRenderer = undefined,
     onRowClick = undefined,
     onRowsRendered = undefined,
@@ -84,6 +85,8 @@ describe('FlexTable', () => {
           cellRenderer={cellRenderer}
           cellDataGetter={cellDataGetter}
           disableSort={disableSort}
+          onHeaderClick={onHeaderClick}
+
         />
         <FlexColumn
           label='Email'
@@ -325,6 +328,34 @@ describe('FlexTable', () => {
     })
   })
 
+  describe('onHeaderClick', () => {
+    it('should call :onHeaderClick when a column header is clicked and sorting is disabled', () => {
+      let onHeaderClickCalls = 0
+      const table = renderTable({
+        disableSort: true,
+        onHeaderClick: () => onHeaderClickCalls++
+      })
+      const tableDOMNode = findDOMNode(table)
+      const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
+
+      Simulate.click(nameColumn)
+      expect(onHeaderClickCalls).toEqual(1)
+    })
+
+    it('should call :onHeaderClick when a column header is clicked and sorting is enabled', () => {
+      let onHeaderClickCalls = 0
+      const table = renderTable({
+        disableSort: false,
+        onHeaderClick: () => onHeaderClickCalls++
+      })
+      const tableDOMNode = findDOMNode(table)
+      const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
+
+      Simulate.click(nameColumn)
+      expect(onHeaderClickCalls).toEqual(1)
+    })
+  })
+
   describe('onRowClick', () => {
     it('should call :onRowClick with the correct :rowIndex when a row is clicked', () => {
       const onRowClickCalls = []
@@ -338,6 +369,7 @@ describe('FlexTable', () => {
       expect(onRowClickCalls).toEqual([0, 3])
     })
   })
+
   describe('rowClassName', () => {
     it('should render a static classname given :rowClassName as a string', () => {
       const staticClassName = 'staticClass'


### PR DESCRIPTION
This isn't a complete PR, but I wanted to start a discussion about the feature. 

For my project I need some external side effects to occur when clicking the header of a particular column, which are not related to sorting. This adds a prop `onHeaderClick` to FlexColumn that fires regardless of whether sorting is disabled, and in addition to any `sort` callback.

Questions:
* Does the API make sense? Would this be better placed on the FlexTable level (like sort) and get the column data as args?
* If the prop stays at the Column level, what args would be useful in the callback?