### PR TITLE
pass columnData to onHeaderClick handler

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -15,7 +15,7 @@ This component expects explicit width, height, and padding parameters.
 | height | Number | ✓ | Fixed/available height for out DOM element |
 | horizontalPadding | Number |  | Horizontal padding of outer DOM element |
 | noRowsRenderer |  | Function | Callback used to render placeholder content when :rowsCount is 0 |
-| onHeaderClick |  | Function | Callback invoked when a user clicks on a table header. `(dataKey: string): void` |
+| onHeaderClick |  | Function | Callback invoked when a user clicks on a table header. `(dataKey: string, columnData: any): void` |
 | onRowClick |  | Function | Callback invoked when a user clicks on a table row. `(rowIndex: number): void` |
 | onRowsRendered |  | Function | Callback invoked with information about the slice of rows that were just rendered: `({ startIndex, stopIndex }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `(rowIndex: number): string`. Note that for the header row an index of `-1` is provided. |

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -214,7 +214,7 @@ export default class FlexTable extends Component {
 
   _createHeader (column, columnIndex) {
     const { headerClassName, onHeaderClick, sort, sortBy, sortDirection } = this.props
-    const { dataKey, disableSort, label } = column.props
+    const { dataKey, disableSort, label, columnData } = column.props
     const showSortIndicator = sortBy === dataKey
     const sortEnabled = !disableSort && sort
 
@@ -237,7 +237,7 @@ export default class FlexTable extends Component {
       : SortDirection.DESC
     const onClick = () => {
       sortEnabled && sort(dataKey, newSortDirection)
-      onHeaderClick(dataKey)
+      onHeaderClick(dataKey, columnData)
     }
 
     return (

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -82,6 +82,7 @@ describe('FlexTable', () => {
         <FlexColumn
           label='Name'
           dataKey='name'
+          columnData={ {data: 123} }
           width={50}
           cellRenderer={cellRenderer}
           cellDataGetter={cellDataGetter}
@@ -332,7 +333,7 @@ describe('FlexTable', () => {
       let onHeaderClickCalls = []
       const table = renderTable({
         disableSort: true,
-        onHeaderClick: (dataKey) => onHeaderClickCalls.push({dataKey})
+        onHeaderClick: (dataKey, columnData) => onHeaderClickCalls.push({dataKey, columnData})
       })
       const tableDOMNode = findDOMNode(table)
       const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
@@ -340,13 +341,14 @@ describe('FlexTable', () => {
       Simulate.click(nameColumn)
       expect(onHeaderClickCalls.length).toEqual(1)
       expect(onHeaderClickCalls[0].dataKey).toEqual('name')
+      expect(onHeaderClickCalls[0].columnData.data).toEqual(123)
     })
 
     it('should call :onHeaderClick with the correct arguments when a column header is clicked and sorting is enabled', () => {
       let onHeaderClickCalls = []
       const table = renderTable({
         disableSort: false,
-        onHeaderClick: (dataKey) => onHeaderClickCalls.push({dataKey})
+        onHeaderClick: (dataKey, columnData) => onHeaderClickCalls.push({dataKey, columnData})
       })
       const tableDOMNode = findDOMNode(table)
       const nameColumn = tableDOMNode.querySelector('.FlexTable__headerColumn:first-of-type')
@@ -354,6 +356,7 @@ describe('FlexTable', () => {
       Simulate.click(nameColumn)
       expect(onHeaderClickCalls.length).toEqual(1)
       expect(onHeaderClickCalls[0].dataKey).toEqual('name')
+      expect(onHeaderClickCalls[0].columnData.data).toEqual(123)
     })
   })
 


### PR DESCRIPTION
I realized it would also be convenient and probably expected to have access to columnData in this handler. For me it's needed because i have more than one column with the same dataKey (one renders a checkbox bound to the item and one renders the item itself)