### PR TITLE
feat(VirtualScroll): ScrollToIndexFromTop and ScrollToIndexFromBot

### DIFF
--- a/docs/VirtualScroll.md
+++ b/docs/VirtualScroll.md
@@ -14,6 +14,8 @@ Describes the header and cell contents of a table column
 | rowRenderer | Function | ✓ | Responsbile for rendering a row given an index. Rendered rows must have a unique `key` attribute. |
 | rowsCount | Number | ✓ | Number of rows in list. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |
+| scrollToIndexFromTop | Boolean |  | A Boolean that determines whether the scrollToIndex will be forcefully from top: `scrollToIndexFromTop: {true}`|
+| scrollToIndexFromBot | Boolean |  | A Boolean that determines whether the scrollToIndex will be forcefully from bot: `scrollToIndexFromBot: {true}`|
 
 ### Public Methods
 

--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -49,12 +49,18 @@ export default class VirtualScroll extends Component {
     /** Number of rows in list. */
     rowsCount: PropTypes.number.isRequired,
     /** Row index to ensure visible (by forcefully scrolling if necessary) */
-    scrollToIndex: PropTypes.number
+    scrollToIndex: PropTypes.number,
+    /** if you want the scrollToIndex property to forcefully show from top make this prop true*/
+    scrollToIndexFromTop: PropTypes.bool,
+    /** if you want the scrollToIndex property to forcefully show from bottom make this prop true*/
+    scrollToIndexFromBot: PropTypes.bool
   }
 
   static defaultProps = {
     noRowsRenderer: () => null,
-    onRowsRendered: () => null
+    onRowsRendered: () => null,
+    scrollToIndexFromTop: false,
+    scrollToIndexFromBot: false
   }
 
   constructor (props, context) {
@@ -383,7 +389,7 @@ export default class VirtualScroll extends Component {
         containerSize: height,
         currentOffset: scrollTop,
         targetIndex: scrollToIndex
-      })
+      }, this.props.scrollToIndexFromTop, this.props.scrollToIndexFromBot)
 
       if (scrollTop !== calculatedScrollTop) {
         this.setState({ scrollTop: calculatedScrollTop })

--- a/source/utils.js
+++ b/source/utils.js
@@ -50,7 +50,7 @@ export function getUpdatedOffsetForIndex ({
   containerSize,
   currentOffset,
   targetIndex
-}) {
+  }, scrollToIndexFromTop, scrollToIndexFromBot) {
   if (cellMetadata.length === 0) {
     return 0
   }
@@ -62,9 +62,16 @@ export function getUpdatedOffsetForIndex ({
   const minOffset = maxOffset - containerSize + datum.size
   const newOffset = Math.max(minOffset, Math.min(maxOffset, currentOffset))
 
+  if (scrollToIndexFromTop) {
+    return maxOffset
+  }
+
+  if (scrollToIndexFromBot) {
+    return minOffset
+  }
+
   return newOffset
 }
-
 /**
  * Determines the range of cells to display for a given offset in order to fill the specified container.
  *


### PR DESCRIPTION
Change getUpdatedOffsetForIndex func to return max/min when ScrollToIndexFromTop/ScrollToIndexFromBot props are configured.

Sometimes you want to control the exact line that will be presented when scrolling to a certain line number. This small change allows you to control whether you want it from top or from bottom.
* These props are optional and doesn't change anything if you decide not to use them.