### PR TITLE
Default <FlexTable>'s :headerHeight prop to 0

### DIFF
--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -44,7 +44,7 @@ export default class FlexTable extends Component {
     /** Optional CSS class to apply to all column headers */
     headerClassName: PropTypes.string,
     /** Fixed height of header row */
-    headerHeight: PropTypes.number.isRequired,
+    headerHeight: PropTypes.number,
     /** Fixed/available height for out DOM element */
     height: PropTypes.number.isRequired,
     /** Horizontal padding of outer DOM element */
@@ -108,6 +108,7 @@ export default class FlexTable extends Component {
 
   static defaultProps = {
     disableHeader: false,
+    headerHeight: 0,
     horizontalPadding: 0,
     noRowsRenderer: () => null,
     onHeaderClick: () => null,

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -44,7 +44,7 @@ export default class FlexTable extends Component {
     /** Optional CSS class to apply to all column headers */
     headerClassName: PropTypes.string,
     /** Fixed height of header row */
-    headerHeight: PropTypes.number,
+    headerHeight: PropTypes.number.isRequired,
     /** Fixed/available height for out DOM element */
     height: PropTypes.number.isRequired,
     /** Horizontal padding of outer DOM element */


### PR DESCRIPTION
So that :headerHeight does not have to be specified when :disableHeader
is true.