### PR TITLE
Move react-dom to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,9 @@
     "classnames": "^2.2.3",
     "raf": "^3.1.0",
     "react-pure-render": "^1.0.2"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "postcss-loader": "^0.8.0",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
+    "react-dom": "^0.14.3",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.0.1",
@@ -113,9 +114,5 @@
     "classnames": "^2.2.3",
     "raf": "^3.1.0",
     "react-pure-render": "^1.0.2"
-  },
-  "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.3"
   }
 }


### PR DESCRIPTION
`npm install` on a fresh clone resulted in this error:

```
f at Fernandos-MacBook-Pro in ~/Software Development/react-virtualized (master●)
$ rm -rf node_modules && npm i

npm WARN deprecated autoprefixer-loader@3.2.0: Please use postcss-loader instead of autoprefixer-loader
npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0
npm WARN deprecated npmconf@2.1.1: this package has been reintegrated into npm and is now out of date with respect to npm

> fsevents@1.0.7 install /Users/f/Software Development/react-virtualized/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

[fsevents] Success: "/Users/f/Software Development/react-virtualized/node_modules/fsevents/lib/binding/Release/node-v47-darwin-x64/fse.node" is installed via remote

> phantomjs@1.9.19 install /Users/f/Software Development/react-virtualized/node_modules/phantomjs
> node install.js

PhantomJS not found on PATH
Download already available at /var/folders/p1/x42tm77n0nx4y8y_45b7n3bw0000gn/T/phantomjs/phantomjs-1.9.8-macosx.zip
Verified checksum of previously downloaded file
Extracting zip contents
Removing /Users/f/Software Development/react-virtualized/node_modules/phantomjs/lib/phantom
Copying extracted folder /var/folders/p1/x42tm77n0nx4y8y_45b7n3bw0000gn/T/phantomjs/phantomjs-1.9.8-macosx.zip-extract-1455154284750/phantomjs-1.9.8-macosx -> /Users/f/Software Development/react-virtualized/node_modules/phantomjs/lib/phantom
Writing location.js file
Done. Phantomjs binary available at /Users/f/Software Development/react-virtualized/node_modules/phantomjs/lib/phantom/bin/phantomjs

> spawn-sync@1.0.15 postinstall /Users/f/Software Development/react-virtualized/node_modules/spawn-sync
> node postinstall


> react-virtualized@4.9.0 prepublish /Users/f/Software Development/react-virtualized
> npm run build


> react-virtualized@4.9.0 prebuild /Users/f/Software Development/react-virtualized
> npm run lint


> react-virtualized@4.9.0 lint /Users/f/Software Development/react-virtualized
> standard


> react-virtualized@4.9.0 build /Users/f/Software Development/react-virtualized
> npm run build:css && npm run build:dist && npm run build:demo


> react-virtualized@4.9.0 build:css /Users/f/Software Development/react-virtualized
> postcss --use autoprefixer source/styles.css > styles.css


> react-virtualized@4.9.0 build:dist /Users/f/Software Development/react-virtualized
> npm run clean:dist && NODE_ENV=production webpack --config webpack.config.dist.js --bail


> react-virtualized@4.9.0 clean:dist /Users/f/Software Development/react-virtualized
> rimraf dist

Hash: 3f98736f02ccbf0d0266
Version: webpack 1.12.13
Time: 2471ms
                   Asset    Size  Chunks             Chunk Names
    react-virtualized.js  141 kB       0  [emitted]  react-virtualized
react-virtualized.js.map  293 kB       0  [emitted]  react-virtualized
    + 24 hidden modules

WARNING in react-virtualized.js from UglifyJs
Side effects in initialization of unused variable props [./source/AutoSizer/AutoSizer.js:51,65]
Condition always true [./~/classnames/index.js:40,2]
Dropping unreachable code [./~/classnames/index.js:46,0]
Side effects in initialization of unused variable props [./source/InfiniteLoader/InfiniteLoader.js:85,40]

> react-virtualized@4.9.0 build:demo /Users/f/Software Development/react-virtualized
> npm run clean:demo && NODE_ENV=production webpack --config webpack.config.demo.js -p --bail


> react-virtualized@4.9.0 clean:demo /Users/f/Software Development/react-virtualized
> rimraf build

ModuleNotFoundError: Module not found: Error: Cannot resolve module 'react-dom' in /Users/f/Software Development/react-virtualized/source/demo
    at /Users/f/Software Development/react-virtualized/node_modules/webpack/lib/Compilation.js:229:38
    at onDoneResolving (/Users/f/Software Development/react-virtualized/node_modules/webpack/lib/NormalModuleFactory.js:29:20)
    at /Users/f/Software Development/react-virtualized/node_modules/webpack/lib/NormalModuleFactory.js:85:20
    at /Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:726:13
    at /Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:52:16
    at done (/Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:241:17)
    at /Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:44:16
    at /Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:723:17
    at /Users/f/Software Development/react-virtualized/node_modules/async/lib/async.js:167:37
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:24:19
    at onResolved (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:38:18)
    at innerCallback (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:94:11)
    at loggingCallbackWrapper (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
    at /Users/f/Software Development/react-virtualized/node_modules/tapable/lib/Tapable.js:134:6
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:54:23
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:191:15
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/ModulesInDirectoriesPlugin.js:45:26
    at loggingCallbackWrapper (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
    at /Users/f/Software Development/react-virtualized/node_modules/tapable/lib/Tapable.js:134:6
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:122:33
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:191:15
    at applyPluginsParallelBailResult.createInnerCallback.log (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:110:4)
    at loggingCallbackWrapper (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/createInnerCallback.js:21:19)
    at /Users/f/Software Development/react-virtualized/node_modules/tapable/lib/Tapable.js:134:6
    at Tapable.<anonymous> (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/FileAppendPlugin.js:31:26)
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/Resolver.js:191:15
    at /Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/FileAppendPlugin.js:28:12
    at Storage.finished (/Users/f/Software Development/react-virtualized/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at FSReqWrap.oncomplete (fs.js:82:15)
resolve module react-dom in /Users/f/Software Development/react-virtualized/source/demo
  looking for modules in /Users/f/Software Development/react-virtualized/node_modules
    /Users/f/Software Development/react-virtualized/node_modules/react-dom doesn't exist (module as directory)
    resolve 'file' react-dom in /Users/f/Software Development/react-virtualized/node_modules
      resolve file
        /Users/f/Software Development/react-virtualized/node_modules/react-dom doesn't exist
        /Users/f/Software Development/react-virtualized/node_modules/react-dom.web.js doesn't exist
        /Users/f/Software Development/react-virtualized/node_modules/react-dom.webpack.js doesn't exist
        /Users/f/Software Development/react-virtualized/node_modules/react-dom.js doesn't exist
        /Users/f/Software Development/react-virtualized/node_modules/react-dom.json doesn't exist

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/f/.nvm/versions/node/v5.0.0/bin/node" "/Users/f/.nvm/versions/node/v5.0.0/bin/npm" "run" "build:demo"
npm ERR! node v5.0.0
npm ERR! npm  v3.3.12
npm ERR! code ELIFECYCLE
npm ERR! react-virtualized@4.9.0 build:demo: `npm run clean:demo && NODE_ENV=production webpack --config webpack.config.demo.js -p --bail`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-virtualized@4.9.0 build:demo script 'npm run clean:demo && NODE_ENV=production webpack --config webpack.config.demo.js -p --bail'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-virtualized package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run clean:demo && NODE_ENV=production webpack --config webpack.config.demo.js -p --bail
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-virtualized
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/f/Software Development/react-virtualized/npm-debug.log

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/f/.nvm/versions/node/v5.0.0/bin/node" "/Users/f/.nvm/versions/node/v5.0.0/bin/npm" "run" "build"
npm ERR! node v5.0.0
npm ERR! npm  v3.3.12
npm ERR! code ELIFECYCLE
npm ERR! react-virtualized@4.9.0 build: `npm run build:css && npm run build:dist && npm run build:demo`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-virtualized@4.9.0 build script 'npm run build:css && npm run build:dist && npm run build:demo'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-virtualized package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run build:css && npm run build:dist && npm run build:demo
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-virtualized
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/f/Software Development/react-virtualized/npm-debug.log

npm WARN EPEERINVALID react-virtualized@4.9.0 requires a peer of react-dom@^0.14.3 but none was installed.
npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/f/.nvm/versions/node/v5.0.0/bin/node" "/Users/f/.nvm/versions/node/v5.0.0/bin/npm" "i"
npm ERR! node v5.0.0
npm ERR! npm  v3.3.12
npm ERR! code ELIFECYCLE
npm ERR! react-virtualized@4.9.0 prepublish: `npm run build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-virtualized@4.9.0 prepublish script 'npm run build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-virtualized package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run build
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-virtualized
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/f/Software Development/react-virtualized/npm-debug.log
```

Moving the peer dependencies to dev dependencies fixed it.