### PR TITLE
Only hide overflow vertically or horizontally

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -463,8 +463,12 @@ export default class Grid extends Component {
     // Force browser to hide scrollbars when we know they aren't necessary.
     // Otherwise once scrollbars appear they may not disappear again.
     // For more info see issue #116
-    if (totalColumnsWidth <= width && totalRowsHeight <= height) {
-      gridStyle.overflow = 'hidden'
+    if (totalColumnsWidth <= width) {
+      gridStyle.overflowX = 'hidden'
+    }
+
+    if (totalRowsHeight <= height) {
+      gridStyle.overflowY = 'hidden'
     }
 
     return (

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -100,6 +100,18 @@ describe('Grid', () => {
     })
   })
 
+  describe('hide scrollbars based on number of children rendered', () => {
+    it('should set overflow-x on Grid container if columns <= available space', () => {
+      const node = findDOMNode(renderGrid({ columnsCount: 4 }))
+      expect(node.style.overflowX).toEqual('hidden')
+    })
+
+    it('should set overflow-y on Grid container if rows <= available space', () => {
+      const node = findDOMNode(renderGrid({ rowsCount: 5 }))
+      expect(node.style.overflowY).toEqual('hidden')
+    })
+  })
+
   /** Tests scrolling via initial props */
   describe(':scrollToColumn and :scrollToRow', () => {
     it('should scroll to the left', () => {


### PR DESCRIPTION
I split the if statement into horizontal and vertical checks as I have a grid that uses infinite scrolling so even though my horizontal width was `<=` the available space my vertical height was always false and the overflow never gets hidden.

### Todo
- [x] tests