### PR TITLE
Check horizontal scrollbar width and adjust inner scroll container

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -11,6 +11,7 @@ import {
 import cn from 'classnames'
 import raf from 'raf'
 import React, { Component, PropTypes } from 'react'
+import { findDOMNode } from 'react-dom'
 import shouldPureComponentUpdate from 'react-pure-render/function'
 
 /**
@@ -141,7 +142,8 @@ export default class Grid extends Component {
       computeGridMetadataOnNextUpdate: false,
       isScrolling: false,
       scrollLeft: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      scrollbarWidth: 0
     }
 
     // Invokes onSectionRendered callback only when start/stop row or column indices change
@@ -223,6 +225,8 @@ export default class Grid extends Component {
 
     // Update onRowsRendered callback
     this._invokeOnGridRenderedHelper()
+
+    this._setScrollbarWidth()
   }
 
   componentDidUpdate (prevProps, prevState) {
@@ -283,6 +287,8 @@ export default class Grid extends Component {
 
     // Update onRowsRendered callback if start/stop indices have changed
     this._invokeOnGridRenderedHelper()
+
+    this._setScrollbarWidth()
   }
 
   componentWillMount () {
@@ -522,10 +528,11 @@ export default class Grid extends Component {
 
   _getColumnWidth (index) {
     const { columnWidth } = this.props
+    const { scrollbarWidth } = this.state
 
     return columnWidth instanceof Function
-      ? columnWidth(index)
-      : columnWidth
+      ? columnWidth(index) - scrollbarWidth
+      : columnWidth - scrollbarWidth
   }
 
   _getRowHeight (index) {
@@ -542,7 +549,7 @@ export default class Grid extends Component {
     }
 
     const datum = this._columnMetadata[this._columnMetadata.length - 1]
-    return datum.offset + datum.size
+    return (datum.offset + datum.size) - this.state.scrollbarWidth
   }
 
   _getTotalRowsHeight () {
@@ -658,6 +665,15 @@ export default class Grid extends Component {
         })
       }
     }
+  }
+
+  _setScrollbarWidth () {
+    const Grid = findDOMNode(this.refs.scrollingContainer)
+    const clientWidth = Grid.clientWidth || 0
+    const offsetWidth = Grid.offsetWidth || 0
+    const scrollbarWidth = offsetWidth - clientWidth
+
+    this.setState({ scrollbarWidth })
   }
 
   /* ---------------------------- Event handlers ---------------------------- */


### PR DESCRIPTION
This PR checks the width of the scrollbar and shrinks the internal scroll containers width to remove scrollbarWidth. We avoid setting overflow and potentially cutting off content, a user can set overflow via custom className if they need to hide scrollbars in a fixed grid header scenario.

Alternate to #133

No scrollbars when all columns fit:
<img width="499" alt="screen shot 2016-03-01 at 11 19 39" src="https://cloud.githubusercontent.com/assets/143402/13413555/9814e318-df9f-11e5-8391-724acff1e18c.png">

Scrollbars when columns don't fit:
<img width="499" alt="screen shot 2016-03-01 at 11 19 54" src="https://cloud.githubusercontent.com/assets/143402/13413556/9820c8a4-df9f-11e5-8be9-2d0d437df99d.png">

Double line content:
<img width="497" alt="screen shot 2016-03-01 at 11 27 40" src="https://cloud.githubusercontent.com/assets/143402/13413708/c62eb82c-dfa0-11e5-95b4-f78518aefe78.png">

<img width="498" alt="screen shot 2016-03-01 at 11 27 56" src="https://cloud.githubusercontent.com/assets/143402/13413709/c63d85f0-dfa0-11e5-8beb-ca073df825cb.png">