### PR TITLE
Added column and row locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
+    "dom-helpers": "^2.4.0",
     "raf": "^3.1.0",
     "react-pure-render": "^1.0.2"
   },

--- a/source/Grid/Grid.example.css
+++ b/source/Grid/Grid.example.css
@@ -19,6 +19,7 @@
 
 .evenRow,
 .oddRow {
+  background-color: white;
   border-bottom: 1px solid #e0e0e0;
 }
 .oddRow {

--- a/source/Grid/Grid.example.js
+++ b/source/Grid/Grid.example.js
@@ -29,7 +29,9 @@ export default class GridExample extends Component {
       rowsCount: 1000,
       scrollToColumn: undefined,
       scrollToRow: undefined,
-      useDynamicRowHeight: false
+      useDynamicRowHeight: false,
+      lockedColumnCount: 1,
+      lockedRowCount: 0
     }
 
     this._getColumnWidth = this._getColumnWidth.bind(this)
@@ -51,6 +53,8 @@ export default class GridExample extends Component {
     const {
       columnsCount,
       height,
+      lockedRowCount,
+      lockedColumnCount,
       overscanColumnsCount,
       overscanRowsCount,
       rowHeight,
@@ -126,6 +130,18 @@ export default class GridExample extends Component {
             value={rowHeight}
           />
           <LabeledInput
+            label='Locked columns'
+            name='lockedColumnCount'
+            onChange={event => this.setState({ lockedColumnCount: parseInt(event.target.value, 10) || 0 })}
+            value={lockedColumnCount}
+          />
+          <LabeledInput
+            label='Locked rows'
+            name='lockedRowCount'
+            onChange={event => this.setState({ lockedRowCount: parseInt(event.target.value, 10) || 0 })}
+            value={lockedRowCount}
+          />
+          <LabeledInput
             label='Overscan columns'
             name='overscanColumnsCount'
             onChange={event => this.setState({ overscanColumnsCount: parseInt(event.target.value, 10) || 0 })}
@@ -146,6 +162,8 @@ export default class GridExample extends Component {
               columnWidth={this._getColumnWidth}
               columnsCount={columnsCount}
               height={height}
+              rowsLocked={lockedRowCount}
+              columnsLocked={lockedColumnCount}
               noContentRenderer={this._noContentRenderer}
               overscanColumnsCount={overscanColumnsCount}
               overscanRowsCount={overscanRowsCount}

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -11,6 +11,7 @@ describe('Grid', () => {
   function getMarkup ({
     className,
     columnsCount = NUM_COLUMNS,
+    columnsLocked,
     columnWidth = 50,
     height = 100,
     noContentRenderer,
@@ -19,6 +20,7 @@ describe('Grid', () => {
     overscanColumnsCount = 0,
     overscanRowsCount = 0,
     rowHeight = 20,
+    rowsLocked,
     rowsCount = NUM_ROWS,
     scrollLeft = undefined,
     scrollToColumn,
@@ -39,6 +41,7 @@ describe('Grid', () => {
         className={className}
         columnsCount={columnsCount}
         columnWidth={columnWidth}
+        columnsLocked={columnsLocked}
         height={height}
         noContentRenderer={noContentRenderer}
         onSectionRendered={onSectionRendered}
@@ -48,6 +51,7 @@ describe('Grid', () => {
         renderCell={renderCell}
         rowHeight={rowHeight}
         rowsCount={rowsCount}
+        rowsLocked={rowsLocked}
         scrollLeft={scrollLeft}
         scrollToColumn={scrollToColumn}
         scrollToRow={scrollToRow}

--- a/source/demo/Application.js
+++ b/source/demo/Application.js
@@ -22,7 +22,7 @@ const HIGH_ORDER_COMPONENTS = ['AutoSizer', 'ColumnSizer', 'InfiniteLoader', 'Sc
 const list = Immutable.List(generateRandomList())
 
 class Application extends Component {
-  shouldComponentUpdate = shouldPureComponentUpdate
+  shouldComponentUpdate = shouldPureComponentUpdate;
 
   constructor (props) {
     super(props)

--- a/source/styles.css
+++ b/source/styles.css
@@ -21,6 +21,15 @@
   position: absolute;
 }
 
+.Grid__cell--locked-row,
+.Grid__cell--locked-column {
+  z-index: 5; 
+}
+
+.Grid__cell--locked-row.Grid__cell--locked-column {
+  z-index: 10;
+}
+
 /* FlexTable default theme */
 
 .FlexTable {

--- a/source/utils.js
+++ b/source/utils.js
@@ -107,9 +107,15 @@ export function findNearestCell ({
 findNearestCell.EQUAL_OR_LOWER = 1
 findNearestCell.EQUAL_OR_HIGHER = 2
 
-export function getOverscanIndices ({ cellsCount, overscanCellsCount, startIndex, stopIndex }) {
+export function getOverscanIndices ({ cellsCount, cellsLocked, overscanCellsCount, startIndex, stopIndex }) {
+  let start = Math.max(0, startIndex - overscanCellsCount)
+
+  if (start < cellsLocked) {
+    start = start + (cellsLocked - start)
+  }
+
   return {
-    overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
+    overscanStartIndex: Math.max(0, start),
     overscanStopIndex: Math.min(cellsCount - 1, stopIndex + overscanCellsCount)
   }
 }
@@ -157,6 +163,7 @@ export function getUpdatedOffsetForIndex ({
 export function getVisibleCellIndices ({
   cellsCount,
   cellMetadata,
+  cellsLocked,
   containerSize,
   currentOffset
 }) {
@@ -189,6 +196,13 @@ export function getVisibleCellIndices ({
     stop++
 
     currentOffset += cellMetadata[stop].size
+  }
+
+  cellsLocked = cellsLocked || 0
+
+  if (start < cellsLocked) {
+    start = start + (cellsLocked - start)
+    stop = Math.max(stop, start)
   }
 
   return {

--- a/source/utils.test.js
+++ b/source/utils.test.js
@@ -336,10 +336,11 @@ describe('getUpdatedOffsetForIndex', () => {
 })
 
 describe('getVisibleCellIndices', () => {
-  function testHelper (currentOffset, cellMetadata = getCellMetadata()) {
+  function testHelper (currentOffset, cellsLocked = 0, cellMetadata = getCellMetadata()) {
     return getVisibleCellIndices({
       cellsCount: cellMetadata.length,
       cellMetadata,
+      cellsLocked,
       containerSize: 50,
       currentOffset
     })
@@ -349,6 +350,18 @@ describe('getVisibleCellIndices', () => {
     const { start, stop } = testHelper(0)
     expect(start).toEqual(0)
     expect(stop).toEqual(3)
+  })
+
+  it('should handle locked cells offset', () => {
+    const { start, stop } = testHelper(0, 1)
+    expect(start).toEqual(1)
+    expect(stop).toEqual(3)
+  })
+
+  it('should handle locked cells offset', () => {
+    const { start, stop } = testHelper(0, 4)
+    expect(start).toEqual(4)
+    expect(stop).toEqual(4)
   })
 
   it('should handle scrolled to the middle', () => {
@@ -479,9 +492,10 @@ describe('updateScrollIndexHelper', () => {
 })
 
 describe('getOverscanIndices', () => {
-  function testHelper (cellsCount, startIndex, stopIndex, overscanCellsCount) {
+  function testHelper (cellsCount, startIndex, stopIndex, overscanCellsCount, cellsLocked) {
     return getOverscanIndices({
       cellsCount,
+      cellsLocked,
       overscanCellsCount,
       startIndex,
       stopIndex
@@ -505,6 +519,13 @@ describe('getOverscanIndices', () => {
   it('should not overscan beyond the start of the list', () => {
     expect(testHelper(100, 5, 15, 10)).toEqual({
       overscanStartIndex: 0,
+      overscanStopIndex: 25
+    })
+  })
+
+  it('should not overscan beyond the first locked index', () => {
+    expect(testHelper(100, 5, 15, 10, 2)).toEqual({
+      overscanStartIndex: 2,
       overscanStopIndex: 25
     })
   })

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,16 @@
   position: absolute;
 }
 
+.Grid__cell--locked-row,
+.Grid__cell--locked-column {
+  z-index: 5;
+}
+
+.Grid__cell--locked-row.Grid__cell--locked-column {
+  z-index: 10;
+}
+
+
 /* FlexTable default theme */
 
 .FlexTable {


### PR DESCRIPTION
Heyo!

I added the ability to freeze rows and columns a la Excel. I realize this may be a bit high level for a library such as this but I thought it was a good idea for a few reasons:

1. relatively low complexity, just specifying a different offset
2. low to no perf impact on folks that don't use it and (in my tests) really minimal impact on those that do.
3. difficult to implement from the outside, ScrollSync sort of gets you there, but issues like #131 make it a more complicated. More relevant though when freezing columns you really want the scrollbar to span the entire horizonal width, not just the non-frozen section.