### PR TITLE
Moved rowGetter outside of the column-creation map to remove unnecessary function calls

### DIFF
--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -316,13 +316,14 @@ export default class FlexTable extends Component {
     const { scrollbarWidth } = this.state
 
     const rowClass = rowClassName instanceof Function ? rowClassName(rowIndex) : rowClassName
+    const rowData = rowGetter(rowIndex)
 
     const renderedRow = React.Children.map(
       children,
       (column, columnIndex) => this._createColumn(
         column,
         columnIndex,
-        rowGetter(rowIndex),
+        rowData,
         rowIndex
       )
     )


### PR DESCRIPTION
Resolves #172