### PR TITLE
Fixed several a11y issues for FlexTable

### DIFF
--- a/source/FlexTable/FlexColumn.js
+++ b/source/FlexTable/FlexColumn.js
@@ -85,6 +85,9 @@ export default class Column extends Component {
   }
 
   static propTypes = {
+    /** Optional aria-label value to set on the column header */
+    'aria-label': PropTypes.string,
+
     /** Optional CSS class to apply to cell */
     cellClassName: PropTypes.string,
 

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -199,6 +199,7 @@ export default class FlexTable extends Component {
         )}
 
         <Grid
+          aria-label={this.props['aria-label']}
           ref='Grid'
           className={'FlexTable__Grid'}
           columnWidth={width}
@@ -296,10 +297,13 @@ export default class FlexTable extends Component {
 
     return (
       <div
+        aria-label={column.props['aria-label'] || label || dataKey}
         key={`Header-Col${columnIndex}`}
         className={classNames}
         style={style}
         onClick={onClick}
+        role="gridcell"
+		tabIndex="0"
       >
         {renderedHeader}
       </div>
@@ -337,6 +341,8 @@ export default class FlexTable extends Component {
           height: this._getRowHeight(rowIndex),
           paddingRight: scrollbarWidth
         }}
+		role="row"
+		tabIndex="0"
       >
         {renderedRow}
       </div>

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -303,7 +303,7 @@ export default class FlexTable extends Component {
         style={style}
         onClick={onClick}
         role="gridcell"
-		tabIndex="0"
+        tabIndex="0"
       >
         {renderedHeader}
       </div>
@@ -341,8 +341,8 @@ export default class FlexTable extends Component {
           height: this._getRowHeight(rowIndex),
           paddingRight: scrollbarWidth
         }}
-		role="row"
-		tabIndex="0"
+        role="row"
+        tabIndex="0"
       >
         {renderedRow}
       </div>

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -13,6 +13,8 @@ import SortDirection from './SortDirection'
  */
 export default class FlexTable extends Component {
   static propTypes = {
+    'aria-label': PropTypes.string,
+
     /** One or more FlexColumns describing the data displayed in this row */
     children: (props, propName, componentName) => {
       const children = React.Children.toArray(props.children)
@@ -302,8 +304,8 @@ export default class FlexTable extends Component {
         className={classNames}
         style={style}
         onClick={onClick}
-        role="gridcell"
-        tabIndex="0"
+        role='gridcell'
+        tabIndex='0'
       >
         {renderedHeader}
       </div>
@@ -341,8 +343,8 @@ export default class FlexTable extends Component {
           height: this._getRowHeight(rowIndex),
           paddingRight: scrollbarWidth
         }}
-        role="row"
-        tabIndex="0"
+        role='row'
+        tabIndex='0'
       >
         {renderedRow}
       </div>


### PR DESCRIPTION
When using the FlexTable component with react-a11y (https://github.com/reactjs/react-a11y) enabled, we see a ton of warning messages about bad a11y practices.

This PR addresses some low-hanging fruit:

- Adds support for passing through the `aria-label` prop to the Grid child component
- Adds support for passing through the `aria-label` prop to each column header (and will try to set a default value if one isn't provided by using either the `label` or the `dataKey` value)
- Sets `role` and `tabIndex` values for column headers and rows since those must be defined for any element with `onClick`