### PR TITLE
fix InfiniteLoader example

### DIFF
--- a/docs/InfiniteLoader.md
+++ b/docs/InfiniteLoader.md
@@ -31,7 +31,7 @@ import ReactDOM from 'react-dom';
 import { InfiniteLoader, VirtualScroll } from 'react-virtualized';
 import 'react-virtualized/styles.css'; // only needs to be imported once
 
-const list = {};
+const list = [];
 
 function isRowLoaded (index) {
   return !!list[index];


### PR DESCRIPTION
Just a little thing i noticed while setting this up -- list was initialized {} which doesn't have a "length" property