### PR TITLE
Move shallow compare addon to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,11 +134,11 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "dom-helpers": "^2.4.0",
-    "raf": "^3.1.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
+    "raf": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
https://twitter.com/theridgway/status/719627580731629568

I think if you have it in dependencies you can end up with multiple versions?