### PR TITLE
Fixed sortBy field name in FlexTable example

### DIFF
--- a/source/FlexTable/FlexTable.example.js
+++ b/source/FlexTable/FlexTable.example.js
@@ -55,7 +55,7 @@ export default class FlexTableExample extends Component {
     const { list, ...props } = this.props
     const sortedList = this._isSortEnabled()
       ? list
-        .sortBy(index => list.getIn([index, sortBy]))
+        .sortBy(el => el[sortBy])
         .update(list =>
           sortDirection === SortDirection.DESC
             ? list.reverse()


### PR DESCRIPTION
Current demo does not use Immutable.List.sortBy correctly.

https://bvaughn.github.io/react-virtualized/?component=FlexTable