### PR TITLE
Implement named parameters in certain functions and clean up

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -21,7 +21,7 @@ This component expects explicit width, height, and padding parameters.
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight, scrollHeight, scrollTop }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `(rowIndex: number): string`. Note that for the header row an index of `-1` is provided. |
 | rowGetter | Function | ✓ | Callback responsible for returning a data row given an index. `(index: int): any` |
-| rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `(index: number): number` |
+| rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | rowCount | Number | ✓ | Number of rows in table. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |
 | scrollTop | Number |  | Vertical offset |

--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -20,7 +20,7 @@ This component expects explicit width, height, and padding parameters.
 | overscanRowCount |  | Number | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight, scrollHeight, scrollTop }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `(rowIndex: number): string`. Note that for the header row an index of `-1` is provided. |
-| rowGetter | Function | ✓ | Callback responsible for returning a data row given an index. `(index: int): any` |
+| rowGetter | Function | ✓ | Callback responsible for returning a data row given an index. `({ index: int }): any` |
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | rowCount | Number | ✓ | Number of rows in table. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |

--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -25,7 +25,7 @@ This component expects explicit width, height, and padding parameters.
 | rowCount | Number | ✓ | Number of rows in table. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |
 | scrollTop | Number |  | Vertical offset |
-| sort | Function |  | Sort function to be called if a sortable header is clicked. `(dataKey: string, sortDirection: SortDirection): void` |
+| sort | Function |  | Sort function to be called if a sortable header is clicked. `({ dataKey: string, sortDirection: SortDirection }): void` |
 | sortBy | String |  | Data is currently sorted by this `dataKey` (if it is sorted at all) |
 | sortDirection | [SortDirection](SortDirection.md) |  | Data is currently sorted in this direction (if it is sorted at all) |
 | width | Number | ✓ | Width of the table |

--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -19,7 +19,7 @@ Only a small number of cells are rendered based on the horizontal and vertical s
 | overscanColumnCount |  | Number | Number of columns to render before/after the visible slice of the grid. This can help reduce flickering during scrolling on certain browers/devices. |
 | overscanRowCount |  | Number | Number of rows to render above/below the visible slice of the grid. This can help reduce flickering during scrolling on certain browers/devices. |
 | rowCount | Number | ✓ | Number of rows in grid. |
-| rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `(index: number): number` |
+| rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | scrollLeft | Number |  | Horizontal offset |
 | scrollToColumn | Number |  | Column index to ensure visible (by forcefully scrolling if necessary) |
 | scrollToRow | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |

--- a/source/FlexTable/FlexTable.example.js
+++ b/source/FlexTable/FlexTable.example.js
@@ -65,7 +65,7 @@ export default class FlexTableExample extends Component {
         )
       : list
 
-    const rowGetter = index => this._getDatum(sortedList, index)
+    const rowGetter = ({ index }) => this._getDatum(sortedList, index)
 
     return (
       <ContentBox {...props}>

--- a/source/FlexTable/FlexTable.example.js
+++ b/source/FlexTable/FlexTable.example.js
@@ -275,7 +275,7 @@ export default class FlexTableExample extends Component {
     }
   }
 
-  _sort (sortBy, sortDirection) {
+  _sort ({ dataKey: sortBy, sortDirection }) {
     this.setState({ sortBy, sortDirection })
   }
 

--- a/source/FlexTable/FlexTable.example.js
+++ b/source/FlexTable/FlexTable.example.js
@@ -211,7 +211,7 @@ export default class FlexTableExample extends Component {
     return list.get(index % list.size)
   }
 
-  _getRowHeight (index) {
+  _getRowHeight ({ index }) {
     const { list } = this.props
 
     return this._getDatum(list, index).size

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -83,7 +83,7 @@ export default class FlexTable extends Component {
 
     /**
      * Callback responsible for returning a data row given an index.
-     * (index: number): any
+     * ({ index: number }): any
      */
     rowGetter: PropTypes.func.isRequired,
 
@@ -337,7 +337,7 @@ export default class FlexTable extends Component {
     const { scrollbarWidth } = this.state
 
     const rowClass = rowClassName instanceof Function ? rowClassName(rowIndex) : rowClassName
-    const rowData = rowGetter(rowIndex)
+    const rowData = rowGetter({ index: rowIndex })
 
     const renderedRow = React.Children.toArray(children).map(
       (column, columnIndex) => this._createColumn(

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -89,7 +89,7 @@ export default class FlexTable extends Component {
 
     /**
      * Either a fixed row height (number) or a function that returns the height of a row given its index.
-     * (index: number): number
+     * ({ index: number }): number
      */
     rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
 
@@ -408,7 +408,7 @@ export default class FlexTable extends Component {
     const { rowHeight } = this.props
 
     return rowHeight instanceof Function
-      ? rowHeight(rowIndex)
+      ? rowHeight({ index: rowIndex })
       : rowHeight
   }
 

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -104,7 +104,7 @@ export default class FlexTable extends Component {
 
     /**
      * Sort function to be called if a sortable header is clicked.
-     * (dataKey: string, sortDirection: SortDirection): void
+     * ({ dataKey: string, sortDirection: SortDirection }): void
      */
     sort: PropTypes.func,
 
@@ -295,7 +295,10 @@ export default class FlexTable extends Component {
         : SortDirection.DESC
 
       const onClick = () => {
-        sortEnabled && sort(dataKey, newSortDirection)
+        sortEnabled && sort({
+          dataKey,
+          sortDirection: newSortDirection
+        })
         onHeaderClick && onHeaderClick(dataKey, columnData)
       }
 

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -19,12 +19,12 @@ describe('FlexTable', () => {
   const list = Immutable.fromJS(array)
 
   // Works with an Immutable List of Maps
-  function immutableRowGetter (index) {
+  function immutableRowGetter ({ index }) {
     return list.get(index)
   }
 
   // Works with an Array of Objects
-  function vanillaRowGetter (index) {
+  function vanillaRowGetter ({ index }) {
     return array[index]
   }
 

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -311,7 +311,7 @@ describe('FlexTable', () => {
       sortDirections.forEach(sortDirection => {
         const sortCalls = []
         const rendered = findDOMNode(render(getMarkup({
-          sort: (dataKey, newSortDirection) => sortCalls.push({dataKey, newSortDirection}),
+          sort: ({dataKey, sortDirection: newSortDirection}) => sortCalls.push({dataKey, newSortDirection}),
           sortBy: 'name',
           sortDirection
         })))
@@ -330,7 +330,7 @@ describe('FlexTable', () => {
     it('should call sort with the correct arguments when a new sort-by column header is clicked', () => {
       const sortCalls = []
       const rendered = findDOMNode(render(getMarkup({
-        sort: (dataKey, newSortDirection) => sortCalls.push({dataKey, newSortDirection}),
+        sort: ({dataKey, sortDirection: newSortDirection}) => sortCalls.push({dataKey, newSortDirection}),
         sortBy: 'email',
         sortDirection: SortDirection.ASC
       })))
@@ -347,7 +347,7 @@ describe('FlexTable', () => {
     it('should call sort when a column header is activated via ENTER or SPACE key', () => {
       const sortCalls = []
       const rendered = findDOMNode(render(getMarkup({
-        sort: (dataKey, newSortDirection) => sortCalls.push({dataKey, newSortDirection}),
+        sort: ({dataKey, sortDirection: newSortDirection}) => sortCalls.push({dataKey, newSortDirection}),
         sortBy: 'name'
       })))
       const nameColumn = rendered.querySelector('.FlexTable__headerColumn:first-of-type')
@@ -392,7 +392,7 @@ describe('FlexTable', () => {
       const sortCalls = []
       const rendered = findDOMNode(render(getMarkup({
         headerRenderer: (params) => 'custom header',
-        sort: (sortKey, sortDirection) => sortCalls.push([sortKey, sortDirection]),
+        sort: ({dataKey: sortKey, sortDirection}) => sortCalls.push([sortKey, sortDirection]),
         sortBy: 'name',
         sortDirection: SortDirection.ASC
       })))

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -182,14 +182,14 @@ describe('FlexTable', () => {
     })
 
     it('should support a :rowHeight function', () => {
-      const rowHeight = (index) => 10 + index * 10
+      const rowHeight = ({ index }) => 10 + index * 10
       const rendered = findDOMNode(render(getMarkup({
         rowHeight,
         rowCount: 3
       })))
       const rows = rendered.querySelectorAll('.FlexTable__row')
       Array.from(rows).forEach((row, index) => {
-        expect(Number.parseInt(row.style.height, 10)).toEqual(rowHeight(index))
+        expect(Number.parseInt(row.style.height, 10)).toEqual(rowHeight({ index }))
       })
     })
 
@@ -209,7 +209,7 @@ describe('FlexTable', () => {
   describe('recomputeRowHeights', () => {
     it('should recompute row heights and other values when called', () => {
       let highestRowIndex = 0
-      const rowHeight = (index) => {
+      const rowHeight = ({ index }) => {
         highestRowIndex = Math.max(index, highestRowIndex)
         return 10
       }

--- a/source/Grid/Grid.example.js
+++ b/source/Grid/Grid.example.js
@@ -188,7 +188,7 @@ export default class GridExample extends Component {
     return row % 2 === 0 ? styles.evenRow : styles.oddRow
   }
 
-  _getRowHeight (index) {
+  _getRowHeight ({ index }) {
     return this._getDatum(index).size
   }
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -109,7 +109,7 @@ export default class Grid extends Component {
 
     /**
      * Either a fixed row height (number) or a function that returns the height of a row given its index.
-     * Should implement the following interface: (index: number): number
+     * Should implement the following interface: ({ index: number }): number
      */
     rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
 

--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -98,11 +98,6 @@ export default class VirtualScroll extends Component {
 
     const classNames = cn('VirtualScroll', className)
 
-    // @TODO version-7 Remove this wrapper once Grid's :rowHeight signature has been updated
-    const wrappedRowHeight = typeof rowHeight === 'function'
-      ? index => rowHeight({ index })
-      : rowHeight
-
     return (
       <Grid
         ref='Grid'
@@ -121,7 +116,7 @@ export default class VirtualScroll extends Component {
         })}
         overscanRowCount={overscanRowCount}
         cellRenderer={({ columnIndex, rowIndex }) => rowRenderer({ index: rowIndex })}
-        rowHeight={wrappedRowHeight}
+        rowHeight={rowHeight}
         rowCount={rowCount}
         scrollToRow={scrollToIndex}
         scrollTop={scrollTop}

--- a/source/utils/TestHelper.js
+++ b/source/utils/TestHelper.js
@@ -15,6 +15,6 @@ export function getCellMetadata () {
   ]
   return initCellMetadata({
     cellCount: cellSizes.length,
-    size: index => cellSizes[index]
+    size: ({ index }) => cellSizes[index]
   })
 }

--- a/source/utils/initCellMetadata.js
+++ b/source/utils/initCellMetadata.js
@@ -12,13 +12,13 @@ export default function initCellMetadata ({
 }) {
   const sizeGetter = size instanceof Function
     ? size
-    : index => size
+    : ({ index }) => size
 
   const cellMetadata = []
   let offset = 0
 
   for (var i = 0; i < cellCount; i++) {
-    let size = sizeGetter(i)
+    let size = sizeGetter({ index: i })
 
     if (size == null || isNaN(size)) {
       throw Error(`Invalid size returned for cell ${i} of value ${size}`)


### PR DESCRIPTION
Modify FlexTable#sort, FlexTable#rowHeight, FlexTable#rowDataGetter, Grid#rowHeight to use named parameters.  Had to clean up TODO in VirtualScroll#rowHeight as well.