### PR TITLE
Grid docs example: get columnsCount from first row

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -68,7 +68,7 @@ ReactDOM.render(
     height={300}
     columnWidth={100}
     rowHeight={30}
-    columnsCount={list.length}
+    columnsCount={list[0].length}
     rowsCount={list.length}
     renderCell={({ columnIndex, rowIndex }) => list[rowIndex][columnIndex]}
   />,


### PR DESCRIPTION
Assuming I've read the example correctly, I think it makes more sense to populate `columnsCount` from the first row of the list, rather than the number of rows (with the assumption that there's at least one row).