### PR TITLE
Fix initial scroll on Collection component

### DIFF
--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -135,6 +135,10 @@ export default class CollectionView extends Component {
 
     this._scrollbarSize = getScrollbarSize()
 
+    if (scrollLeft >= 0 || scrollTop >= 0) {
+      this._setScrollPosition({ scrollLeft, scrollTop })
+    }
+
     // Update onSectionRendered callback.
     this._invokeOnSectionRenderedHelper()
 
@@ -196,13 +200,9 @@ export default class CollectionView extends Component {
   }
 
   componentWillMount () {
-    const { cellLayoutManager, scrollLeft, scrollTop } = this.props
+    const { cellLayoutManager } = this.props
 
     cellLayoutManager.calculateSizeAndPositionData()
-
-    if (scrollLeft >= 0 || scrollTop >= 0) {
-      this._setScrollPosition({ scrollLeft, scrollTop })
-    }
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
Setting initial scroll on a Collection component is not working properly. Cells are rendered in the right place but scrolling container remains the same. This PR fix that.

I've tried to duplicate the same logic found in Grid component, in which initial scrolls works as expected.