### PR TITLE
Maybe this is a typo of rowGetter in v7.0.5.

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -80,7 +80,7 @@ ReactDOM.render(
     headerHeight={20}
     rowHeight={30}
     rowCount={list.length}
-    rowGetter={index => list[index]}
+    rowGetter={({index}) => list[index]}
   >
     <FlexColumn
       label='Name'


### PR DESCRIPTION
Hi,

First of all, thanks for all your great and hard work. :D

I am new to react-virtualized, and I installed version 7.0.5. 

I follow FlexTable.md and try to render a simplest FlexTable example but it not worked.

After study Version 7 Roadmap, I change the rowGetter as following:

```
rowGetter={index => list[index]}

to

rowGetter={({index}) => list[index]}
```

Hope this could be helpful.