### PR TITLE
Replace phantoms with phantomjs-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "karma-sourcemap-loader": "^0.3.6",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "phantomjs": "^2.1.7",
+    "phantomjs-prebuilt": "^2.1.7",
     "postcss": "^5.0.14",
     "postcss-cli": "^2.3.3",
     "postcss-loader": "^0.9.1",


### PR DESCRIPTION
Fixes npm deprecation warning:

> npm WARN deprecated phantomjs@2.1.7: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt

Otherwise the following gives an error:

```sh
$ rm -rf node_modules
$ npm i
$ npm test
```
