### PR TITLE
Only run codecov when CI environment variable is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "standard",
     "prebuild": "npm run lint",
     "postpublish": "npm run deploy",
-    "posttest": "codecov",
+    "posttest": "[ -z \"$CI\" ] || codecov",
     "prepublish": "npm run build",
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev.js",
     "test": "npm run lint && npm run test:unit",


### PR DESCRIPTION
`npm run test` makes `codecov` run. That should probably only happen when it's in a CI environment. This PR changes it to be a noop when `CI` environment variable is missing.