### PR TITLE
Avoid extra conditional checks with function params

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -628,9 +628,9 @@ export default class Grid extends Component {
       : () => size
   }
 
-  _updateScrollLeftForScrollToColumn (props = null, state = null) {
-    const { columnCount, scrollToColumn, width } = props || this.props
-    const { scrollLeft } = state || this.state
+  _updateScrollLeftForScrollToColumn (props = this.props, state = this.state) {
+    const { columnCount, scrollToColumn, width } = props
+    const { scrollLeft } = state
 
     if (scrollToColumn >= 0 && columnCount > 0) {
       const targetIndex = Math.max(0, Math.min(columnCount - 1, scrollToColumn))
@@ -653,9 +653,9 @@ export default class Grid extends Component {
     }
   }
 
-  _updateScrollTopForScrollToRow (props = null, state = null) {
-    const { height, rowCount, scrollToRow } = props || this.props
-    const { scrollTop } = state || this.state
+  _updateScrollTopForScrollToRow (props = this.props, state = this.state) {
+    const { height, rowCount, scrollToRow } = props
+    const { scrollTop } = state
 
     if (scrollToRow >= 0 && rowCount > 0) {
       const targetIndex = Math.max(0, Math.min(rowCount - 1, scrollToRow))


### PR DESCRIPTION
Assigning null and then doing `x || this.x` means you end up doing an extra check that's not really needed. You always have `this.state` and `this.props`, and both `_updateScrollLeftForScrollToColumn` and `_updateScrollTopForScrollToRow` are never called with falsy values. (If it were possible for em to get called with falsy values, you'd probably wanna skip the `= null` in the function param instead.)