### PR TITLE
(AutoSizer) Fix incorrect event removal in detectElementResize.js

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -149,7 +149,7 @@ var removeResizeListener = function(element, fn){
   else {
     element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
     if (!element.__resizeListeners__.length) {
-        element.removeEventListener('scroll', scrollListener);
+        element.removeEventListener('scroll', scrollListener, true);
         element.__resizeTriggers__ = !element.removeChild(element.__resizeTriggers__);
     }
   }


### PR DESCRIPTION
There is a logic issue related to the incorect event removal in detectElementResize.js.

### Bug scenario

1. AutoSizer element is mounted to the container
2. AutoSizer element is unmounted from the container
3. Custom component (with some scrollable elements like `<select>`) is rendered inside the container
4. Multiple `TypeError: expand is undefined error` console errors appears in result of any scroll actions inside the custom component.

It affects Firefox, and not affects Chrome.  Error appears multiplie times in result of wheel movement, and only one time after the keydown press.
Both components mounted to the container by react-router

### Reason

onScroll events are not actually removed after the AutoSizer component unmounting.

How the events are added:
`element.addEventListener('scroll', scrollListener, true)`
(**true** flag set to **useCaption** option)

How events are removed:
`element.removeEventListener('scroll', scrollListener);`
(no flag set to **useCaption** option, default is **false**)

according to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener):
> Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.

So the event removal have no effect.

## Fix
`element.removeEventListener('scroll', scrollListener, true);`
should be used  instead of
`element.removeEventListener('scroll', scrollListener);`

P.S javascript-detect-element-resize repo seems dead, so I placed a fix here (since the detectElementResize.js copy is used in the project)
P.P.S Bug live example may be a little time-consuming for this small issue. I can still make it if required.
