### PR TITLE
How to expand a row on click (repro case in playground)

### DIFF
--- a/playground/expand.html
+++ b/playground/expand.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+  <title>foo</title>
+  <link rel="stylesheet" type="text/css" href="../styles.css" />
+  <style type="text/css">
+    body, html, #mount {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont,  "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",  "Fira Sans", "Droid Sans", "Helvetica Neue",  sans-serif;
+      font-size: 12px;
+      overflow: hidden
+    }
+    * {
+      box-sizing: border-box;
+    }
+    .container {
+      width: 100%;
+      height: 100%;
+    }
+    .expand {
+      border: 1px solid #eee;
+      border-radius: 0.5rem;
+    }
+    .item {
+      border-bottom: 1px solid #eee;
+      padding: 0.5rem;
+    }
+    .item:hover {
+      background-color: #eee;
+    }
+  </style>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.2/react.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.2/react-dom.js"></script>
+  <script src="../dist/umd/react-virtualized.js"></script>
+</head>
+<body>
+  <div id="mount"></div>
+  <script src="expand.js" class="expand"></script>
+</body>
+</html>

--- a/playground/expand.js
+++ b/playground/expand.js
@@ -1,0 +1,130 @@
+function rowRenderer(params) {
+  var datum = chatHistory[params.index]
+
+  return React.createElement(
+    'div',
+    {
+      className: 'item'
+    },
+    React.createElement(
+      'strong',
+      null,
+      datum.name
+    ),
+    ':',
+    datum.text
+  )
+}
+
+function cellRenderer(params) {
+  return rowRenderer({
+    index: params.rowIndex
+  })
+}
+
+var virtualScroll
+var mostRecentWidth
+var self
+
+var App = React.createClass({
+  getInitialState: function () {
+    self = this
+    return { selectedRowIndex: -1 }
+  },
+  render: function () {
+    return React.createElement(
+      'div',
+      {
+        className: 'container'
+      },
+      React.createElement(
+        ReactVirtualized.AutoSizer,
+        {},
+        function (autoSizerParams) {
+          if (mostRecentWidth && mostRecentWidth !== autoSizerParams.width) {
+            virtualScroll.recomputeRowHeights()
+          }
+
+          mostRecentWidth = autoSizerParams.width
+
+          return React.createElement(
+            ReactVirtualized.FlexTable,
+            {
+              disableHeader: true,
+              onRowClick: ({ index}) => {
+                console.debug('rowClick: ' + index)
+                self.setState({ selectedRowIndex: index })
+              },
+              rowHeight: ({index}) => index === self.state.selectedRowIndex ? 100 : 20,
+              rowGetter: ({index}) => chatHistory[index],
+              rowCount: chatHistory.length,
+              height: autoSizerParams.height,
+              width: autoSizerParams.width
+            },
+            React.createElement(
+              ReactVirtualized.FlexColumn,
+              {
+                label: 'Name',
+                dataKey: 'name',
+                width: 200
+              }),
+            React.createElement(
+              ReactVirtualized.FlexColumn,
+              {
+                label: 'Text',
+                dataKey: 'text',
+                width: autoSizerParams.width,
+                flexGrow: 2
+              }
+            )
+          )
+        }
+      )
+    )
+  }
+})
+
+var NAMES = ['Peter Brimer', 'Tera Gaona', 'Kandy Liston', 'Lonna Wrede', 'Kristie Yard', 'Raul Host', 'Yukiko Binger', 'Velvet Natera', 'Donette Ponton', 'Loraine Grim', 'Shyla Mable', 'Marhta Sing', 'Alene Munden', 'Holley Pagel', 'Randell Tolman', 'Wilfred Juneau', 'Naida Madson', 'Marine Amison', 'Glinda Palazzo', 'Lupe Island', 'Cordelia Trotta', 'Samara Berrier', 'Era Stepp', 'Malka Spradlin', 'Edward Haner', 'Clemencia Feather', 'Loretta Rasnake', 'Dana Hasbrouck', 'Sanda Nery', 'Soo Reiling', 'Apolonia Volk', 'Liliana Cacho', 'Angel Couchman', 'Yvonne Adam', 'Jonas Curci', 'Tran Cesar', 'Buddy Panos', 'Rosita Ells', 'Rosalind Tavares', 'Renae Keehn', 'Deandrea Bester', 'Kelvin Lemmon', 'Guadalupe Mccullar', 'Zelma Mayers', 'Laurel Stcyr', 'Edyth Everette', 'Marylin Shevlin', 'Hsiu Blackwelder', 'Mark Ferguson', 'Winford Noggle', 'Shizuko Gilchrist', 'Roslyn Cress', 'Nilsa Lesniak', 'Agustin Grant', 'Earlie Jester', 'Libby Daigle', 'Shanna Maloy', 'Brendan Wilken', 'Windy Knittel', 'Alice Curren', 'Eden Lumsden', 'Klara Morfin', 'Sherryl Noack', 'Gala Munsey', 'Stephani Frew', 'Twana Anthony', 'Mauro Matlock', 'Claudie Meisner', 'Adrienne Petrarca', 'Pearlene Shurtleff', 'Rachelle Piro', 'Louis Cocco', 'Susann Mcsweeney', 'Mandi Kempker', 'Ola Moller', 'Leif Mcgahan', 'Tisha Wurster', 'Hector Pinkett', 'Benita Jemison', 'Kaley Findley', 'Jim Torkelson', 'Freda Okafor', 'Rafaela Markert', 'Stasia Carwile', 'Evia Kahler', 'Rocky Almon', 'Sonja Beals', 'Dee Fomby', 'Damon Eatman', 'Alma Grieve', 'Linsey Bollig', 'Stefan Cloninger', 'Giovanna Blind', 'Myrtis Remy', 'Marguerita Dostal', 'Junior Baranowski', 'Allene Seto', 'Margery Caves', 'Nelly Moudy', 'Felix Sailer']
+var SENTENCES = [
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  'Phasellus vulputate odio commodo tortor sodales, et vehicula ipsum viverra.',
+  'Cras tincidunt nisi in urna molestie varius.',
+  'Curabitur ac enim dictum arcu varius fermentum vel sodales dui.',
+  'Ut tristique augue at congue molestie.',
+  'Cras eget enim nec odio feugiat tristique eu quis ante.',
+  'Phasellus eget enim vitae nunc luctus sodales a eu erat.',
+  'Nulla bibendum quam id velit blandit dictum.',
+  'Donec dignissim mi ac libero feugiat, vitae lacinia odio viverra.',
+  'Praesent vel lectus venenatis, elementum mauris vitae, ullamcorper nulla.',
+  'Quisque sollicitudin nulla nec tellus feugiat hendrerit.',
+  'Vestibulum a eros accumsan, lacinia eros non, pretium diam.',
+  'Donec ornare felis et dui hendrerit, eget bibendum nibh interdum.',
+  'Donec nec diam vel tellus egestas lobortis.',
+  'Sed ornare nisl sit amet dolor pellentesque, eu fermentum leo interdum.',
+  'Sed eget mauris condimentum, molestie justo eu, feugiat felis.',
+  'Sed luctus justo vitae nibh bibendum blandit.',
+  'Nulla ac eros vestibulum, mollis ante eu, rutrum nulla.',
+  'Sed cursus magna ut vehicula rutrum.'
+]
+
+var chatHistory = []
+
+for (var i = 0; i < 1000; i++) {
+  var name = NAMES[Math.floor(Math.random() * NAMES.length)]
+  var sentences = Math.ceil(Math.random() * 5)
+  var texts = []
+
+  for (var x = 0; x < sentences; x++) {
+    texts.push(SENTENCES[Math.floor(Math.random() * SENTENCES.length)])
+  }
+
+  chatHistory.push({
+    name,
+    text: texts.join(' ')
+  })
+}
+
+ReactDOM.render(
+  React.createElement(App),
+  document.querySelector('#mount')
+)


### PR DESCRIPTION
Hi,

I'm doing a log viewer and want to expand a row upon mouse click, to show more details in that entry. I tried a naive approach by updating `selectedRowIndex` state of parent of `FlexTable`, and the row does change height, but the neighbor rows do not update so they overlap each other. 

If I initialize the state so `selectedRowIndex: 2`, it does correctly adjust all rows on initial render, but when clicking subsequent rows it fails to render properly.

Any idea how I can accomplish this?

Repro case: https://github.com/anjdreas/react-virtualized/blob/expand-bug-repro/playground/expand.js

Summary of implementation:
```
            ReactVirtualized.FlexTable,
            {
              onRowClick: ({ index}) => {
                self.setState({ selectedRowIndex: index })
              },
              rowHeight: ({index}) => index === self.state.selectedRowIndex ? 100 : 20,
```

Screenshot:
![image](https://cloud.githubusercontent.com/assets/787816/15804669/41114166-2b11-11e6-82c4-d0cdf05ecbb3.png)
