### PR TITLE
Add row level events 'onRowMouseOver' and 'onRowMouseOut'

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -18,6 +18,8 @@ This component expects explicit width, height, and padding parameters.
 | noRowsRenderer |  | Function | Callback used to render placeholder content when :rowCount is 0 |
 | onHeaderClick |  | Function | Callback invoked when a user clicks on a table header. `(dataKey: string, columnData: any): void` |
 | onRowClick |  | Function | Callback invoked when a user clicks on a table row. `({ index: number }): void` |
+| onRowMouseOver |  | Function | Callback invoked when a user moves the mouse over a table row. `({ index: number }): void` |
+| onRowMouseOut |  | Function | Callback invoked when the mouse leaves a table row. `({ index: number }): void` |
 | onRowsRendered |  | Function | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
 | overscanRowCount |  | Number | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number: number, scrollTop: number }): void` |

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -65,6 +65,18 @@ export default class FlexTable extends Component {
     onRowClick: PropTypes.func,
 
     /**
+     * Callback invoked when a user moves the mouse over a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOver: PropTypes.func,
+
+    /**
+     * Callback invoked when the mouse leaves a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOut: PropTypes.func,
+
+    /**
      * Callback invoked with information about the slice of rows that were just rendered.
      * ({ startIndex, stopIndex }): void
      */
@@ -382,6 +394,8 @@ export default class FlexTable extends Component {
     const {
       children,
       onRowClick,
+      onRowMouseOver,
+      onRowMouseOut,
       rowClassName,
       rowGetter,
       rowStyle
@@ -403,11 +417,19 @@ export default class FlexTable extends Component {
 
     const a11yProps = {}
 
-    if (onRowClick) {
+    if (onRowClick || onRowMouseOver || onRowMouseOut) {
       a11yProps['aria-label'] = 'row'
       a11yProps.role = 'row'
       a11yProps.tabIndex = 0
-      a11yProps.onClick = () => onRowClick({ index })
+      if (onRowClick) {
+        a11yProps.onClick = () => onRowClick({index})
+      }
+      if (onRowMouseOver) {
+        a11yProps.onMouseOver = () => onRowMouseOver({index})
+      }
+      if (onRowMouseOut) {
+        a11yProps.onMouseOut = () => onRowMouseOut({index})
+      }
     }
 
     return (

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -46,6 +46,8 @@ describe('FlexTable', () => {
     noRowsRenderer,
     onHeaderClick,
     onRowClick,
+    onRowMouseOver,
+    onRowMouseOut,
     onRowsRendered,
     onScroll,
     overscanRowCount = 0,
@@ -74,6 +76,8 @@ describe('FlexTable', () => {
         noRowsRenderer={noRowsRenderer}
         onHeaderClick={onHeaderClick}
         onRowClick={onRowClick}
+        onRowMouseOver={onRowMouseOver}
+        onRowMouseOut={onRowMouseOut}
         onRowsRendered={onRowsRendered}
         onScroll={onScroll}
         overscanRowCount={overscanRowCount}
@@ -517,6 +521,29 @@ describe('FlexTable', () => {
       Simulate.click(rows[0])
       Simulate.click(rows[3])
       expect(onRowClickCalls).toEqual([0, 3])
+    })
+  })
+
+  describe('onRowMouseOver/Out', () => {
+    it('should call :onRowMouseOver and :onRowMouseOut with the correct :rowIndex when the mouse is moved over rows', () => {
+      let onRowMouseOverCalls = []
+      let onRowMouseOutCalls = []
+      const rendered = findDOMNode(render(getMarkup({
+        onRowMouseOver: ({ index }) => onRowMouseOverCalls.push(index),
+        onRowMouseOut: ({ index }) => onRowMouseOutCalls.push(index)
+      })))
+
+      const simulateMouseOver = (from, to) => {
+        Simulate.mouseOut(from, { relatedTarget: to })
+        Simulate.mouseOver(to, { relatedTarget: from })
+      }
+
+      const rows = rendered.querySelectorAll('.FlexTable__row')
+      simulateMouseOver(rows[0], rows[1])
+      simulateMouseOver(rows[1], rows[2])
+      simulateMouseOver(rows[2], rows[3])
+      expect(onRowMouseOverCalls).toEqual([1, 2, 3])
+      expect(onRowMouseOutCalls).toEqual([0, 1, 2])
     })
   })
 


### PR DESCRIPTION
Hi Brian,

first of all thanks for this great lib. Attached please find my proposed changes (including test and docs) for adding mouseOver and mouseOut events to FlexTable. My goal is to support row highlighting of tables based on mouse position.

Best regards,
  Thomas
