### PR TITLE
Fix FlexTable doc table format

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -15,13 +15,13 @@ This component expects explicit width, height, and padding parameters.
 | headerHeight | Number | ✓ | Fixed height of header row |
 | headerStyle | Object |  | Optional custom inline style to attach to table header columns. |
 | height | Number | ✓ | Fixed/available height for out DOM element |
-| noRowsRenderer |  | Function | Callback used to render placeholder content when :rowCount is 0 |
-| onHeaderClick |  | Function | Callback invoked when a user clicks on a table header. `(dataKey: string, columnData: any): void` |
-| onRowClick |  | Function | Callback invoked when a user clicks on a table row. `({ index: number }): void` |
-| onRowMouseOut |  | Function | Callback invoked when the mouse leaves a table row. `({ index: number }): void` |
-| onRowMouseOver |  | Function | Callback invoked when a user moves the mouse over a table row. `({ index: number }): void` |
-| onRowsRendered |  | Function | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
-| overscanRowCount |  | Number | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
+| noRowsRenderer | Function |  | Callback used to render placeholder content when :rowCount is 0 |
+| onHeaderClick | Function |  | Callback invoked when a user clicks on a table header. `(dataKey: string, columnData: any): void` |
+| onRowClick | Function |  | Callback invoked when a user clicks on a table row. `({ index: number }): void` |
+| onRowMouseOut | Function | | Callback invoked when the mouse leaves a table row. `({ index: number }): void` |
+| onRowMouseOver | Function |  | Callback invoked when a user moves the mouse over a table row. `({ index: number }): void` |
+| onRowsRendered | Function |  | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
+| overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number: number, scrollTop: number }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `({ index: number }): string`. Note that for the header row an index of `-1` is provided. |
 | rowCount | Number | ✓ | Number of rows in table. |


### PR DESCRIPTION
Fix some of the wrong positioned rows in FlexTable doc:
![image](https://cloud.githubusercontent.com/assets/6076919/15997611/b5b0c066-3168-11e6-8b60-2cd3b25c0cd6.png)
