### PR TITLE
Avoid setting scrollTop when autoHeight prop present

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -292,7 +292,7 @@ export default class Grid extends Component {
    * 1) New scroll-to-cell props have been set
    */
   componentDidUpdate (prevProps, prevState) {
-    const { height, scrollToAlignment, scrollToColumn, scrollToRow, width } = this.props
+    const { autoHeight, height, scrollToAlignment, scrollToColumn, scrollToRow, width } = this.props
     const { scrollLeft, scrollPositionChangeReason, scrollTop } = this.state
 
     // Make sure requested changes to :scrollLeft or :scrollTop get applied.
@@ -300,7 +300,7 @@ export default class Grid extends Component {
     // And to discard any pending async changes to the scroll position that may have happened in the meantime (e.g. on a separate scrolling thread).
     // So we only set these when we require an adjustment of the scroll position.
     // See issue #2 for more information.
-    if (scrollPositionChangeReason === SCROLL_POSITION_CHANGE_REASONS.REQUESTED) {
+    if (!autoHeight && scrollPositionChangeReason === SCROLL_POSITION_CHANGE_REASONS.REQUESTED) {
       if (
         scrollLeft >= 0 &&
         scrollLeft !== prevState.scrollLeft &&

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -478,15 +478,26 @@ describe('Grid', () => {
   describe(':scrollLeft and :scrollTop properties', () => {
     it('should render correctly when an initial :scrollLeft and :scrollTop properties are specified', () => {
       let columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex
-      render(getMarkup({
+      render(getMarkup())
+      const rendered = findDOMNode(render(getMarkup({
         onSectionRendered: params => ({ columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } = params),
         scrollLeft: 250,
         scrollTop: 100
-      }))
+      })))
+      expect(rendered.scrollTop).toEqual(100)
       expect(rowStartIndex).toEqual(5)
       expect(rowStopIndex).toEqual(9)
       expect(columnStartIndex).toEqual(5)
       expect(columnStopIndex).toEqual(8)
+    })
+
+    it('should not set :scrollLeft or :scrollTop when using :autoHeight', () => {
+      const rendered = findDOMNode(render(getMarkup({
+        autoHeight: true,
+        scrollLeft: 250,
+        scrollTop: 100
+      })))
+      expect(rendered.scrollTop).toEqual(0)
     })
 
     it('should render correctly when :scrollLeft and :scrollTop properties are updated', () => {

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -4,6 +4,12 @@ import ReactDOM from 'react-dom'
 import shallowCompare from 'react-addons-shallow-compare'
 import raf from 'raf'
 
+/**
+ * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.
+ * This improves performance and makes scrolling smoother.
+ */
+const IS_SCROLLING_TIMEOUT = 150
+
 export default class WindowScroller extends Component {
   static propTypes = {
     /**
@@ -35,6 +41,7 @@ export default class WindowScroller extends Component {
 
     this._onScrollWindow = this._onScrollWindow.bind(this)
     this._onResizeWindow = this._onResizeWindow.bind(this)
+    this._originalBodyPointerEvents = null
   }
 
   componentDidMount () {
@@ -95,6 +102,18 @@ export default class WindowScroller extends Component {
     onResize({ height })
   }
 
+  _enablePointerEventsAfterDelay () {
+    if (this._disablePointerEventsTimeoutId) {
+      clearTimeout(this._disablePointerEventsTimeoutId)
+    }
+
+    this._disablePointerEventsTimeoutId = setTimeout(() => {
+      this._disablePointerEventsTimeoutId = null
+      document.body.style.pointerEvents = this._originalBodyPointerEvents
+      this._originalBodyPointerEvents = null
+    }, IS_SCROLLING_TIMEOUT)
+  }
+
   _onScrollWindow (event) {
     const { onScroll } = this.props
 
@@ -106,6 +125,12 @@ export default class WindowScroller extends Component {
     const scrollTop = Math.max(0, scrollY - this._positionFromTop)
 
     this._setNextState({ scrollTop })
+
+    if (this._originalBodyPointerEvents === null) {
+      this._originalBodyPointerEvents = document.body.style.pointerEvents
+      document.body.style.pointerEvents = 'none'
+      this._enablePointerEventsAfterDelay()
+    }
 
     onScroll({ scrollTop })
   }


### PR DESCRIPTION
Fixes #281 

This pull request seeks to avoid setting `scrollTop` in the `Grid` component `componentDidUpdate` when `autoHeight` is true. This is especially relevant in the context of `WindowScroller`, where because the height of the `Grid` expands automatically, `scrollTop` will always be zero.

__This pull request is in-progress. Specifically in consideration of:__

- The tests are failing. `scrollTop` on the rendered element always seems to be zero in tests, even when we'd expect it to be assigned. Perhaps I'm not hooking in at the right point in lifecycle? Or something with the test environment setup.
- Includes a commit for experimental `pointer-events` assigning on the `body` element when scrolling under `WindowScroller`. There's a bit of duplication between here and `Grid` that might warrant some clean-up, and totally lacks tests. Okay with dropping this commit altogether, but figured it was worth exploring.