### PR TITLE
Load React UMD Build with add-ons for playground

### DIFF
--- a/playground/helper.js
+++ b/playground/helper.js
@@ -45,6 +45,6 @@ function loadReact () {
       : `https://cdnjs.cloudflare.com/ajax/libs/react/${matches[1]}`
   }
 
-  loadScript(`${baseDir}/react.min.js`);
+  loadScript(`${baseDir}/react-with-addons.min.js`);
   loadScript(`${baseDir}/react-dom.min.js`);
 }


### PR DESCRIPTION
Since `react-addons-shallow-compare` is an external dependency, I believe you need to load the React UMD build with add-ons.