### PR TITLE
Fixed `CellMeasurer` throws "Only a ReactOwner can have refs" error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 7.11.6
+Fixed `CellMeasurer` throws "Only a ReactOwner can have refs" error.
+
 ##### 7.11.5
 Small change to inline styles for `Grid` to work around obscure bug where an initial scroll offset prop is specified before external CSS stylesheets have loaded.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "7.11.5",
+  "version": "7.11.6",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "jsnext:main": "dist/es/index.js",

--- a/source/Collection/Collection.js
+++ b/source/Collection/Collection.js
@@ -61,7 +61,7 @@ export default class Collection extends Component {
 
   /** See Collection#recomputeCellSizesAndPositions */
   recomputeCellSizesAndPositions () {
-    this.refs.CollectionView.recomputeCellSizesAndPositions()
+    this._collectionView.recomputeCellSizesAndPositions()
   }
 
   /** React lifecycle methods */
@@ -72,7 +72,9 @@ export default class Collection extends Component {
     return (
       <CollectionView
         cellLayoutManager={this}
-        ref='CollectionView'
+        ref={(ref) => {
+          this._collectionView = ref
+        }}
         {...props}
       />
     )

--- a/source/Collection/Collection.test.js
+++ b/source/Collection/Collection.test.js
@@ -45,7 +45,7 @@ describe('Collection', () => {
 
   function simulateScroll ({ collection, scrollLeft, scrollTop }) {
     const target = { scrollLeft, scrollTop }
-    collection.refs.CollectionView.refs.scrollingContainer = target // HACK to work around _onScroll target check
+    collection._collectionView._scrollingContainer = target // HACK to work around _onScroll target check
     Simulate.scroll(findDOMNode(collection), { target })
   }
 
@@ -159,20 +159,20 @@ describe('Collection', () => {
   describe(':scrollToCell', () => {
     it('should scroll to the top/left', () => {
       const grid = render(getMarkup({ scrollToCell: 0 }))
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(0)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(0)
+      expect(grid._collectionView.state.scrollLeft).toEqual(0)
+      expect(grid._collectionView.state.scrollTop).toEqual(0)
     })
 
     it('should scroll over to the middle', () => {
       const grid = render(getMarkup({ scrollToCell: 7 }))
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(1)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(1)
+      expect(grid._collectionView.state.scrollLeft).toEqual(1)
+      expect(grid._collectionView.state.scrollTop).toEqual(1)
     })
 
     it('should scroll to the bottom/right', () => {
       const grid = render(getMarkup({ scrollToCell: 9 }))
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(2)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(2)
+      expect(grid._collectionView.state.scrollLeft).toEqual(2)
+      expect(grid._collectionView.state.scrollTop).toEqual(2)
     })
 
     it('should honor the specified :scrollToAlignment', () => {
@@ -182,8 +182,8 @@ describe('Collection', () => {
         width: SECTION_SIZE
       }))
       // Minimum amount of scrolling ("auto") would be 0,0
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(2)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(1)
+      expect(grid._collectionView.state.scrollLeft).toEqual(2)
+      expect(grid._collectionView.state.scrollTop).toEqual(1)
 
       grid = render(getMarkup({
         scrollToAlignment: 'end',
@@ -191,8 +191,8 @@ describe('Collection', () => {
         width: SECTION_SIZE
       }))
       // This cell would already by visible by "auto" rules
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(1)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(0)
+      expect(grid._collectionView.state.scrollLeft).toEqual(1)
+      expect(grid._collectionView.state.scrollTop).toEqual(0)
 
       grid = render(getMarkup({
         scrollToAlignment: 'center',
@@ -200,22 +200,22 @@ describe('Collection', () => {
         width: SECTION_SIZE
       }))
       // This cell would already by visible by "auto" rules
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(1)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(0)
+      expect(grid._collectionView.state.scrollLeft).toEqual(1)
+      expect(grid._collectionView.state.scrollTop).toEqual(0)
     })
 
     it('should scroll to a cell just added', () => {
       let grid = render(getMarkup({
         cellCount: 4
       }))
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(0)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(0)
+      expect(grid._collectionView.state.scrollLeft).toEqual(0)
+      expect(grid._collectionView.state.scrollTop).toEqual(0)
       grid = render(getMarkup({
         cellCount: 8,
         scrollToCell: 7
       }))
-      expect(grid.refs.CollectionView.state.scrollLeft).toEqual(1)
-      expect(grid.refs.CollectionView.state.scrollTop).toEqual(1)
+      expect(grid._collectionView.state.scrollLeft).toEqual(1)
+      expect(grid._collectionView.state.scrollTop).toEqual(1)
     })
   })
 

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -191,16 +191,16 @@ export default class CollectionView extends Component {
       if (
         scrollLeft >= 0 &&
         scrollLeft !== prevState.scrollLeft &&
-        scrollLeft !== this.refs.scrollingContainer.scrollLeft
+        scrollLeft !== this._scrollingContainer.scrollLeft
       ) {
-        this.refs.scrollingContainer.scrollLeft = scrollLeft
+        this._scrollingContainer.scrollLeft = scrollLeft
       }
       if (
         scrollTop >= 0 &&
         scrollTop !== prevState.scrollTop &&
-        scrollTop !== this.refs.scrollingContainer.scrollTop
+        scrollTop !== this._scrollingContainer.scrollTop
       ) {
-        this.refs.scrollingContainer.scrollTop = scrollTop
+        this._scrollingContainer.scrollTop = scrollTop
       }
     }
 
@@ -338,7 +338,9 @@ export default class CollectionView extends Component {
 
     return (
       <div
-        ref='scrollingContainer'
+        ref={(ref) => {
+          this._scrollingContainer = ref
+        }}
         aria-label={this.props['aria-label']}
         className={cn('Collection', className)}
         onScroll={this._onScroll}
@@ -493,7 +495,7 @@ export default class CollectionView extends Component {
     // In certain edge-cases React dispatches an onScroll event with an invalid target.scrollLeft / target.scrollTop.
     // This invalid event can be detected by comparing event.target to this component's scrollable DOM element.
     // See issue #404 for more information.
-    if (event.target !== this.refs.scrollingContainer) {
+    if (event.target !== this._scrollingContainer) {
       return
     }
 

--- a/source/FlexTable/FlexTable.js
+++ b/source/FlexTable/FlexTable.js
@@ -198,17 +198,17 @@ export default class FlexTable extends Component {
   }
 
   forceUpdateGrid () {
-    this.refs.Grid.forceUpdate()
+    this._grid.forceUpdate()
   }
 
   /** See Grid#measureAllCells */
   measureAllRows () {
-    this.refs.Grid.measureAllCells()
+    this._grid.measureAllCells()
   }
 
   /** See Grid#recomputeGridSize */
   recomputeRowHeights (index = 0) {
-    this.refs.Grid.recomputeGridSize({
+    this._grid.recomputeGridSize({
       rowIndex: index
     })
     this.forceUpdateGrid()
@@ -284,7 +284,9 @@ export default class FlexTable extends Component {
           noContentRenderer={noRowsRenderer}
           onScroll={this._onScroll}
           onSectionRendered={this._onSectionRendered}
-          ref='Grid'
+          ref={(ref) => {
+            this._grid = ref
+          }}
           scrollbarWidth={scrollbarWidth}
           scrollToRow={scrollToIndex}
           style={gridStyle}
@@ -534,7 +536,7 @@ export default class FlexTable extends Component {
   }
 
   _setScrollbarWidth () {
-    const Grid = findDOMNode(this.refs.Grid)
+    const Grid = findDOMNode(this._grid)
     const clientWidth = Grid.clientWidth || 0
     const offsetWidth = Grid.offsetWidth || 0
     const scrollbarWidth = offsetWidth - clientWidth

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -186,9 +186,9 @@ describe('FlexTable', () => {
         rowHeight: () => 20,
         width: 0
       }))
-      expect(rendered.refs.Grid._rowSizeAndPositionManager.getTotalSize()).toEqual(150)
+      expect(rendered._grid._rowSizeAndPositionManager.getTotalSize()).toEqual(150)
       rendered.measureAllRows()
-      expect(rendered.refs.Grid._rowSizeAndPositionManager.getTotalSize()).toEqual(200)
+      expect(rendered._grid._rowSizeAndPositionManager.getTotalSize()).toEqual(200)
     })
   })
 
@@ -442,7 +442,7 @@ describe('FlexTable', () => {
         noRowsRenderer: () => <div>No rows!</div>,
         rowCount: 0
       }))
-      const bodyDOMNode = findDOMNode(rendered.refs.Grid)
+      const bodyDOMNode = findDOMNode(rendered._grid)
       expect(bodyDOMNode.textContent).toEqual('No rows!')
     })
 
@@ -450,7 +450,7 @@ describe('FlexTable', () => {
       const rendered = render(getMarkup({
         rowCount: 0
       }))
-      const bodyDOMNode = findDOMNode(rendered.refs.Grid)
+      const bodyDOMNode = findDOMNode(rendered._grid)
       expect(bodyDOMNode.textContent).toEqual('')
     })
   })
@@ -829,8 +829,8 @@ describe('FlexTable', () => {
       const target = {
         scrollTop: 100
       }
-      rendered.refs.Grid.refs.scrollingContainer = target // HACK to work around _onScroll target check
-      Simulate.scroll(findDOMNode(rendered.refs.Grid), { target })
+      rendered._grid._scrollingContainer = target // HACK to work around _onScroll target check
+      Simulate.scroll(findDOMNode(rendered._grid), { target })
       expect(onScrollCalls.length).toEqual(2)
       expect(onScrollCalls[1]).toEqual({
         clientHeight: 80,

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -310,9 +310,9 @@ export default class Grid extends Component {
       if (
         scrollLeft >= 0 &&
         scrollLeft !== prevState.scrollLeft &&
-        scrollLeft !== this.refs.scrollingContainer.scrollLeft
+        scrollLeft !== this._scrollingContainer.scrollLeft
       ) {
-        this.refs.scrollingContainer.scrollLeft = scrollLeft
+        this._scrollingContainer.scrollLeft = scrollLeft
       }
 
       // @TRICKY :autoHeight property instructs Grid to leave :scrollTop management to an external HOC (eg WindowScroller).
@@ -321,9 +321,9 @@ export default class Grid extends Component {
         !autoHeight &&
         scrollTop >= 0 &&
         scrollTop !== prevState.scrollTop &&
-        scrollTop !== this.refs.scrollingContainer.scrollTop
+        scrollTop !== this._scrollingContainer.scrollTop
       ) {
-        this.refs.scrollingContainer.scrollTop = scrollTop
+        this._scrollingContainer.scrollTop = scrollTop
       }
     }
 
@@ -574,7 +574,9 @@ export default class Grid extends Component {
 
     return (
       <div
-        ref='scrollingContainer'
+        ref={(ref) => {
+          this._scrollingContainer = ref
+        }}
         aria-label={this.props['aria-label']}
         className={cn('Grid', className)}
         onScroll={this._onScroll}
@@ -796,7 +798,7 @@ export default class Grid extends Component {
     // In certain edge-cases React dispatches an onScroll event with an invalid target.scrollLeft / target.scrollTop.
     // This invalid event can be detected by comparing event.target to this component's scrollable DOM element.
     // See issue #404 for more information.
-    if (event.target !== this.refs.scrollingContainer) {
+    if (event.target !== this._scrollingContainer) {
       return
     }
 

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -23,7 +23,7 @@ describe('Grid', () => {
     scrollTop = 0
   }) {
     const target = { scrollLeft, scrollTop }
-    grid.refs.scrollingContainer = target // HACK to work around _onScroll target check
+    grid._scrollingContainer = target // HACK to work around _onScroll target check
     Simulate.scroll(findDOMNode(grid), { target })
   }
 

--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -114,17 +114,17 @@ export default class VirtualScroll extends Component {
   }
 
   forceUpdateGrid () {
-    this.refs.Grid.forceUpdate()
+    this._grid.forceUpdate()
   }
 
   /** See Grid#measureAllCells */
   measureAllRows () {
-    this.refs.Grid.measureAllCells()
+    this._grid.measureAllCells()
   }
 
   /** See Grid#recomputeGridSize */
   recomputeRowHeights (index = 0) {
-    this.refs.Grid.recomputeGridSize({
+    this._grid.recomputeGridSize({
       rowIndex: index
     })
     this.forceUpdateGrid()
@@ -152,7 +152,9 @@ export default class VirtualScroll extends Component {
         noContentRenderer={noRowsRenderer}
         onScroll={this._onScroll}
         onSectionRendered={this._onSectionRendered}
-        ref='Grid'
+        ref={(ref) => {
+          this._grid = ref
+        }}
         scrollToRow={scrollToIndex}
       />
     )

--- a/source/VirtualScroll/VirtualScroll.test.js
+++ b/source/VirtualScroll/VirtualScroll.test.js
@@ -403,7 +403,7 @@ describe('VirtualScroll', () => {
       const target = {
         scrollTop: 100
       }
-      rendered.refs.Grid.refs.scrollingContainer = target // HACK to work around _onScroll target check
+      rendered._grid._scrollingContainer = target // HACK to work around _onScroll target check
       Simulate.scroll(findDOMNode(rendered), { target })
       expect(onScrollCalls[onScrollCalls.length - 1]).toEqual({
         clientHeight: 100,
@@ -422,9 +422,9 @@ describe('VirtualScroll', () => {
         rowHeight: () => 20,
         width: 0
       }))
-      expect(rendered.refs.Grid._rowSizeAndPositionManager.getTotalSize()).toEqual(150)
+      expect(rendered._grid._rowSizeAndPositionManager.getTotalSize()).toEqual(150)
       rendered.measureAllRows()
-      expect(rendered.refs.Grid._rowSizeAndPositionManager.getTotalSize()).toEqual(200)
+      expect(rendered._grid._rowSizeAndPositionManager.getTotalSize()).toEqual(200)
     })
   })
 


### PR DESCRIPTION
Resolves #235