### PR TITLE
Forced inline style to overwrite calculated ones if present

### DIFF
--- a/source/Collection/Collection.test.js
+++ b/source/Collection/Collection.test.js
@@ -154,6 +154,17 @@ describe('Collection', () => {
       })))
       expect(rendered.style.overflowY).not.toEqual('hidden')
     })
+
+    it('should accept styles that overwrite calculated ones', () => {
+      const rendered = findDOMNode(render(getMarkup({
+        height: 4 + scrollbarSize - 1,
+        style: {
+          overflowY: 'hidden'
+        },
+        width: 1
+      })))
+      expect(rendered.style.overflowY).toEqual('hidden')
+    })
   })
 
   describe(':scrollToCell', () => {

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -319,7 +319,6 @@ export default class CollectionView extends Component {
     } = cellLayoutManager.getTotalSize()
 
     const collectionStyle = {
-      ...style,
       height,
       width
     }
@@ -345,7 +344,10 @@ export default class CollectionView extends Component {
         className={cn('Collection', className)}
         onScroll={this._onScroll}
         role='grid'
-        style={collectionStyle}
+        style={{
+          ...collectionStyle,
+          ...style
+        }}
         tabIndex={0}
       >
         {childrenToDisplay.length > 0 &&

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -540,7 +540,6 @@ export default class Grid extends Component {
     }
 
     const gridStyle = {
-      ...style,
       height: autoHeight ? 'auto' : height,
       width
     }
@@ -581,7 +580,10 @@ export default class Grid extends Component {
         className={cn('Grid', className)}
         onScroll={this._onScroll}
         role='grid'
-        style={gridStyle}
+        style={{
+          ...gridStyle,
+          ...style
+        }}
         tabIndex={tabIndex}
       >
         {childrenToDisplay.length > 0 &&

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -157,6 +157,21 @@ describe('Grid', () => {
       })))
       expect(rendered.style.overflowY).not.toEqual('hidden')
     })
+
+    it('should accept styles that overwrite calculated ones', () => {
+      const rendered = findDOMNode(render(getMarkup({
+        columnCount: 4,
+        height: 100 + scrollbarSize - 1,
+        rowCount: 5,
+        style: {
+          overflowY: 'hidden',
+          overflowX: 'hidden'
+        },
+        width: 200 - 1
+      })))
+      expect(rendered.style.overflowY).toEqual('hidden')
+      expect(rendered.style.overflowX).toEqual('hidden')
+    })
   })
 
   /** Tests scrolling via initial props */


### PR DESCRIPTION
Currently inline styles passed to Grid overwrites passed styles via prop, i think the expected behaviour is to always respect the user's styles