### PR TITLE
Use renderSubtreeIntoContainer in CellMeasurer

### DIFF
--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -1,7 +1,6 @@
 /** @flow */
 import React, { Component, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
-import ReactDOMServer from 'react-dom/server'
 
 /**
  * Measures a Grid cell's contents by rendering them in a way that is not visible to the user.
@@ -169,12 +168,17 @@ export default class CellMeasurer extends Component {
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).
     this._renderAndMount()
 
-    this._div.innerHTML = ReactDOMServer.renderToString(rendered)
+    ReactDOM.unstable_renderSubtreeIntoContainer(
+      this, rendered, this._div)
 
-    return {
+    const measurements = {
       height: clientHeight && this._div.clientHeight,
       width: clientWidth && this._div.clientWidth
     }
+
+    ReactDOM.unmountComponentAtNode(this._div)
+
+    return measurements
   }
 
   _renderAndMount () {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -370,6 +370,8 @@ export default class Grid extends Component {
     } else {
       this._scrollbarSizeMeasured = true
     }
+
+    this.calculateChildrenToRender()
   }
 
   componentWillUnmount () {
@@ -445,34 +447,31 @@ export default class Grid extends Component {
       scrollToIndex: this.props.scrollToRow,
       updateScrollOffsetForScrollToIndex: () => this._updateScrollTopForScrollToRow(nextProps, nextState)
     })
+
+    this.calculateChildrenToRender(nextProps, nextState)
   }
 
-  render () {
+  calculateChildrenToRender (props = this.props, state = this.state) {
     const {
-      autoHeight,
       cellClassName,
       cellRenderer,
       cellRangeRenderer,
       cellStyle,
-      className,
       columnCount,
       height,
-      noContentRenderer,
       overscanColumnCount,
       overscanRowCount,
       rowCount,
-      style,
-      tabIndex,
       width
-    } = this.props
+    } = props
 
     const {
       isScrolling,
       scrollLeft,
       scrollTop
-    } = this.state
+    } = state
 
-    let childrenToDisplay = []
+    this._childrenToDisplay = []
 
     // Render only enough columns and rows to cover the visible area of the grid.
     if (height > 0 && width > 0) {
@@ -520,7 +519,7 @@ export default class Grid extends Component {
       this._rowStartIndex = overscanRowIndices.overscanStartIndex
       this._rowStopIndex = overscanRowIndices.overscanStopIndex
 
-      childrenToDisplay = cellRangeRenderer({
+      this._childrenToDisplay = cellRangeRenderer({
         cellCache: this._cellCache,
         cellClassName: this._wrapCellClassNameGetter(cellClassName),
         cellRenderer,
@@ -538,6 +537,22 @@ export default class Grid extends Component {
         verticalOffsetAdjustment
       })
     }
+  }
+
+  render () {
+    const {
+      autoHeight,
+      className,
+      columnCount,
+      height,
+      noContentRenderer,
+      style,
+      tabIndex,
+      width } = this.props
+
+    const { isScrolling } = this.state
+
+    const childrenToDisplay = this._childrenToDisplay
 
     const gridStyle = {
       height: autoHeight ? 'auto' : height,


### PR DESCRIPTION
:wave: howdy, This is a bit more intrusive then I was hoping but it does work :)

The original issue with rSIC is that it react doesn’t like when you do things like render new components while a `render()` method is firing: “render() should be pure”. To address this I moved the childrenToDisplay calculations in Grid to right _before_ each render which avoids the warning. This seems safe to me and my understanding of how the update cycle works.

I didn’t make any attempt to adjust Collection to handle this, I am assuming you probably don’t want to use this HoC in that context anyway yeah?