### PR TITLE
Add property forceRecomputeRowHeights to VirtualScroll

### DIFF
--- a/source/VirtualScroll/VirtualScroll.js
+++ b/source/VirtualScroll/VirtualScroll.js
@@ -62,7 +62,14 @@ export default class VirtualScroll extends Component {
      */
     rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
 
-    /** Responsbile for rendering a row given an index; ({ index: number }): node */
+    /**
+     * Force to recompute row height on component receive new props. It may be usefull when you have a
+     * function in rowHeight property and you change internal values in that function and need's to rerender
+     * the component with the new height getter.
+     */
+    forceRecomputeRowHeights: PropTypes.bool,
+
+    /** Responsible for rendering a row given an index; ({ index: number }): node */
     rowRenderer: PropTypes.func.isRequired,
 
     /** Optional custom CSS class for individual rows */
@@ -100,6 +107,7 @@ export default class VirtualScroll extends Component {
     onScroll: () => null,
     overscanRowCount: 10,
     scrollToAlignment: 'auto',
+    forceRecomputeRowHeights: false,
     style: {}
   }
 
@@ -162,6 +170,12 @@ export default class VirtualScroll extends Component {
 
   shouldComponentUpdate (nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState)
+  }
+
+  componentWillReceiveProps (newProps) {
+    if (newProps.forceRecomputeRowHeights) {
+      this.recomputeRowHeights(0)
+    }
   }
 
   _cellRenderer ({ columnIndex, isScrolling, rowIndex }) {


### PR DESCRIPTION
Virtual Scroll doesn't update row heigh properly when using a function. 

This happens only when you are using a function in the rowHeight prop and you change something in that function. For example when the row height is dinamic and the function changes when the user do something. I tried to find out how to make this work properly and finally I found that the easiest way for me is to add a new property forceRecomputeRowHeights and, if that prop is true, call the method recomputeRowHeights on componentWillReceiveProps. I know isn't the best way but from now is my best idea, with that change it works properly updating the render when I want. I have something like this in my component:

```
componentWillMount () {
	this.forceRecomputeRowHeights = false
}

// When the function data changes I set that to true this.forceRecomputeRowHeights = true
// Then on render

render () {
   let forceRecomputeRowHeights = this.forceRecomputeRowHeights

   if  (forceRecomputeRowHeights)  {
         this.forceRecomputeRowHeights = false
   }

   <VirtualScroll
          ...
	  forceRecomputeRowHeights={forceRecomputeRowHeights}
    />
}
```

What's do you think? Thanks

