### PR TITLE
Add resetRowMeasurements() and resetColumnMeasurements() to CellMeasurer

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -29,6 +29,8 @@ The child function is passed the following named parameters:
 | getColumnWidth | Function | Callback to set as the `columnWidth` property of a `Grid` |
 | getRowHeight | Function | Callback to set as the `rowHeight` property of a `Grid` |
 | resetMeasurements | Function | Use this function to clear cached measurements in `CellRenderer`; its size will be remeasured the next time it is requested. |
+| resetRowMeasurements(rowIndex) | Function | Use this function to clear cached measurements for specific row in `CellRenderer`; its size will be remeasured the next time it is requested. |
+| resetColumnMeasurements(columnIndex) | Function | Use this function to clear cached measurements for specific column in `CellRenderer`; its size will be remeasured the next time it is requested. |
 
 ### Examples
 

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -116,6 +116,14 @@ export default class CellMeasurer extends Component {
     this._cachedRowHeights = {}
   }
 
+  resetRowMeasurements (rowIndex) {
+    delete this._cachedRowHeights[rowIndex]
+  }
+
+  resetColumnMeasurements (columnIndex) {
+    delete this._cachedColumnWidths[columnIndex]
+  }
+
   componentDidMount () {
     this._renderAndMount()
   }


### PR DESCRIPTION
We need to reset measurements of specific row/column when the cell is resized.  Resize event occurs in children components and `CellMeasurer` cannot detect it.  So we need to notify `CellMeasurer` should reset measurements for the cell.  These APIs can be used for it.

I didn't know how to add test case because these are related to cache.  Cache is an internal state of component and I didn't know how to access inner state of the component.