### PR TITLE
Fix FlexTable table formatting

### DIFF
--- a/docs/FlexTable.md
+++ b/docs/FlexTable.md
@@ -113,7 +113,6 @@ If you require greater customization, you may want to fork the [`defaultFlexTabl
 
 This function accepts the following named parameters:
 
-```js
 | Property | Description |
 |:---|:---|
 | className | Row-level class name |
@@ -126,8 +125,6 @@ This function accepts the following named parameters:
 | onRowMouseOut | Optional row `onMouseOut` handler |
 | rowData | Row data |
 | style | Row-level style object |
-})
-```
 
 ### Examples
 


### PR DESCRIPTION
Minor, but the table formatting for one of the tables in `FlexTable.md` was off.

Before / After:

![image](https://cloud.githubusercontent.com/assets/4006642/17273381/9d9f74a6-5678-11e6-9a08-90d32b5b0580.png)

Thanks!