### PR TITLE
Reset grid rendered memoizer when underlying data changes

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -414,6 +414,11 @@ export default class Grid extends Component {
    * 3) Cells-count or cells-size has changed, making previous scroll offsets invalid
    */
   componentWillUpdate (nextProps, nextState) {
+    if (nextProps.backingData !== this.props.backingData) {
+      // reset memoization so that load status will be queried again
+      this._onGridRenderedMemoizer = createCallbackMemoizer()
+      this._onScrollMemoizer = createCallbackMemoizer(false)
+    }
     if (
       nextProps.columnCount === 0 &&
       nextState.scrollLeft !== 0 ||

--- a/source/VirtualScroll/VirtualScroll.test.js
+++ b/source/VirtualScroll/VirtualScroll.test.js
@@ -168,6 +168,31 @@ describe('VirtualScroll', () => {
       expect(stopIndex).toEqual(9)
     })
 
+    it('should call :onRowsRendered even if start or stop indices have not changed when props.backingData changes', () => {
+      let numCalls = 0
+      const onRowsRendered = params => {
+        numCalls++
+      }
+      findDOMNode(render(getMarkup({ onRowsRendered, backingData: {} })))
+      expect(numCalls).toEqual(1)
+
+      findDOMNode(render(getMarkup({ onRowsRendered, backingData: {} })))
+      expect(numCalls).toEqual(2)
+    })
+
+    it('should not call :onRowsRendered even if start or stop indices when props.backingData does not change', () => {
+      const backingData = {}
+      let numCalls = 0
+      const onRowsRendered = params => {
+        numCalls++
+      }
+      findDOMNode(render(getMarkup({ onRowsRendered, backingData: backingData })))
+      expect(numCalls).toEqual(1)
+
+      findDOMNode(render(getMarkup({ onRowsRendered, backingData: backingData })))
+      expect(numCalls).toEqual(1)
+    })
+
     it('should not call :onRowsRendered unless the start or stop indices have changed', () => {
       let numCalls = 0
       let startIndex


### PR DESCRIPTION
I have a virtual scrolling table that displays an array of data. The array contains regular row data and possibly multiple loading indicators. When a loading indicator becomes visible (ie. I get onRowsRendered callback) I make a fetch and replace the single loading indicator row with the resulting data rows. This works surprisingly well.

However as Grid memoizes the `_onSectionRendered` calls I do not always get the the callback to `onRowsRendered` when I insert a new loading indicator row in the visible range.

This pull request provides a `backingData` prop that the Grid can look at to determine whether the memoization should be forgot and generally indicate that the data backing the indexes has changed.