### PR TITLE
[WindowScroller] correct initial _positionFromTop if page scrolled

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -46,7 +46,8 @@ export default class WindowScroller extends Component {
   }
 
   componentDidMount () {
-    this._positionFromTop = ReactDOM.findDOMNode(this).getBoundingClientRect().top
+    this._positionFromTop = ReactDOM.findDOMNode(this).getBoundingClientRect().top -
+        document.documentElement.getBoundingClientRect().top
 
     this.setState({ height: window.innerHeight })
 


### PR DESCRIPTION
In the case when page already have a scrolling on component mount, _positionFromTop should take this into consideration when using getBoundingClientRect for calculations. The most common use-case is when navigating back in history page is rendered directly with scroll.

Because PhantomJS seems to ignore window scrolling and return same getBoundingClientRect for elements, all tests are passing without any changes and I coundn't find any way to improve them to test the fix. Maybe setting a negative top or translateY for documentElement would work to reproduce this use-case in unit-tests, but that's a bit weird solution.