### PR TITLE
[WindowScroller] restore pointerEvents on body on unmount

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -8,7 +8,7 @@ import raf from 'raf'
  * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.
  * This improves performance and makes scrolling smoother.
  */
-const IS_SCROLLING_TIMEOUT = 150
+export const IS_SCROLLING_TIMEOUT = 150
 
 export default class WindowScroller extends Component {
   static propTypes = {
@@ -57,6 +57,10 @@ export default class WindowScroller extends Component {
   componentWillUnmount () {
     window.removeEventListener('scroll', this._onScrollWindow, false)
     window.removeEventListener('resize', this._onResizeWindow, false)
+    if (this._disablePointerEventsTimeoutId) {
+      clearTimeout(this._disablePointerEventsTimeoutId)
+      this._enablePointerEvents()
+    }
   }
 
   /**
@@ -105,12 +109,16 @@ export default class WindowScroller extends Component {
     )
   }
 
-  _enablePointerEventsAfterDelayCallback () {
+  _enablePointerEvents () {
     this._disablePointerEventsTimeoutId = null
 
     document.body.style.pointerEvents = this._originalBodyPointerEvents
 
     this._originalBodyPointerEvents = null
+  }
+
+  _enablePointerEventsAfterDelayCallback () {
+    this._enablePointerEvents()
 
     this.setState({
       isScrolling: false

--- a/source/WindowScroller/WindowScroller.test.js
+++ b/source/WindowScroller/WindowScroller.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { findDOMNode } from 'react-dom'
 import { render } from '../TestUtils'
-import WindowScroller from './WindowScroller'
+import WindowScroller, { IS_SCROLLING_TIMEOUT } from './WindowScroller'
 
 function ChildComponent ({ scrollTop, isScrolling, height }) {
   return (
@@ -57,6 +57,36 @@ describe('WindowScroller', () => {
     expect(component.state.height).toEqual(window.innerHeight)
     expect(component.state.height).toEqual(500)
     expect(rendered.textContent).toContain('height:500')
+  })
+
+  it('should restore pointerEvents on body after IS_SCROLLING_TIMEOUT', async (done) => {
+    render(getMarkup())
+    document.body.style.pointerEvents = 'all'
+    simulateWindowScroll({ scrollY: 5000 })
+    expect(document.body.style.pointerEvents).toEqual('none')
+
+    await new Promise(resolve => setTimeout(resolve, IS_SCROLLING_TIMEOUT))
+
+    expect(document.body.style.pointerEvents).toEqual('all')
+
+    done()
+  })
+
+  it('should restore pointerEvents on body after unmount', async (done) => {
+    render(getMarkup())
+    document.body.style.pointerEvents = 'all'
+    simulateWindowScroll({ scrollY: 5000 })
+    expect(document.body.style.pointerEvents).toEqual('none')
+    console.log = jasmine.createSpy('log')
+    render.unmount()
+    expect(document.body.style.pointerEvents).toEqual('all')
+
+    await new Promise(resolve => setTimeout(resolve, IS_SCROLLING_TIMEOUT))
+
+    // Testing that no React warning about setState after unmount occured
+    expect(console.log).not.toHaveBeenCalled()
+
+    done()
   })
 
   describe('onScroll', () => {


### PR DESCRIPTION
Restoring pointerEvents on body right away on unmount, without a timeout, will also prevent react warning about setState on not mounted component. Basically, that warning was the trigger for this PR.

Added 2 tests about pointerEvents on scrolling and on unmounting.

BTW, @bvaughn I had a hard time writing these unit-tests partially because little experience with all the tooling, but also because running the tests took me a lot of time. I would love to see something like [karma-webpack-with-fast-source-maps](https://www.npmjs.com/package/karma-webpack-with-fast-source-maps) used here. This would help future contributions on this great project. What do you think? Can you do this?