### PR TITLE
[Grid] render inner scroll container based on rowCount

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -482,7 +482,9 @@ export default class Grid extends Component {
       noContentRenderer,
       style,
       tabIndex,
-      width
+      width,
+      rowCount,
+      columnCount
     } = this.props
 
     const { isScrolling } = this.state
@@ -516,7 +518,7 @@ export default class Grid extends Component {
     const childrenToDisplay = this._childrenToDisplay
 
     const showNoContentRenderer = (
-      childrenToDisplay.length === 0 &&
+      (rowCount === 0 || columnCount === 0) &&
       height > 0 &&
       width > 0
     )
@@ -536,7 +538,7 @@ export default class Grid extends Component {
         }}
         tabIndex={tabIndex}
       >
-        {childrenToDisplay.length > 0 &&
+        {(rowCount > 0 && columnCount > 0) &&
           <div
             className='Grid__innerScrollContainer'
             style={{


### PR DESCRIPTION
Rendering inner scroll container based on rowCount and columnCount rather than based on childrenToDisplay should keep current behavior in most use-cases, but it fixed one particular use-case, that was important for my app:

When going back to a page that renders a Grid wrapped with WindowScroller it should come back to the same scroll position in grid. 
Instead, when the previous scroll was big enough (in my case > 10000px) it failed to return to that scroll. This happen basically because Grid didn't render the scroll inner container fast enough and browser saw there is not enough height in the document and just didn't scroll. I'm not sure if this would be easy to reproduce on a simple example, but it was 100% reproducible in my project. Again, I'm not sure if it's a specific browser buggy behavior or a kind of a race condition my app has hit, but this change fixed the issue for me and hopefully will help others too.

I didn't add any unit-tests because it would probably be really really hard to reproduce the bug in a testing environment.

Beside that, the change basically is more aligned to the docs:

```
| noContentRenderer | Function |  | Optional renderer to be rendered inside the grid when either `rowCount` or `columnCount` is empty: `(): PropTypes.node` |
```