### PR TITLE
[WindowScroller] initializing height from window.innerHeight

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -36,7 +36,7 @@ export default class WindowScroller extends Component {
 
     this.state = {
       isScrolling: false,
-      height: 0,
+      height: window ? window.innerHeight : 0,
       scrollTop: 0
     }
 


### PR DESCRIPTION
Starting directly with height equal to window.innerHeight instead of zero, will avoid re-rendring on componentDidMount if window.innerHeight is unchanged. 

First render with zero height can have unexpected consequences. I had this specific but important use-case:

When going back to a page that renders a Grid wrapped with WindowScroller it should come back to the same scroll position in grid. 
Instead, when the previous scroll was big enough (in my case > 10000px) it failed to return to that scroll. This happen basically because Grid first rendered with no content (because WindowScroller rendered with zero height) and browser saw there is not enough height in the document and just didn't scroll.

At first, I tried to solve this in [another way](https://github.com/bvaughn/react-virtualized/pull/348), but this was basically the root cause.
