### PR TITLE
Add CellMeasurer size cache strategy for uniform-yet-unknown row heights

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -52,11 +52,11 @@ class CellSizeCache {
 }
 ```
 
-The [default caching strategy](https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/defaultCellSizeCache.js) is exported as `defaultCellMeasurerCellSizeCache` should you wish to decorate it.
+The [default caching strategy](https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/defaultCellSizeCache.js) is exported as `defaultCellMeasurerCellSizeCache` should you wish to decorate it. You can also use [an alternative caching strategy for lists with a uniform (yet unknown) row height](https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/CellSizeCacheUniformHeight.js), exported as `CellMeasurerCellSizeCacheUniformHeight`.
 
 ### Examples
 
-This example shows a `Grid` with fixed column widths and dynamic row heights.
+This example shows a `Grid` with fixed row heights and dynamic column widths.
 For more examples check out the component [demo page](https://bvaughn.github.io/react-virtualized/?component=CellMeasurer).
 
 ```javascript
@@ -69,7 +69,7 @@ ReactDOM.render(
   <CellMeasurer
     cellRenderer={cellRenderer}
     columnCount={columnCount}
-    height={height}
+    height={fixedRowHeight}
     rowCount={rowCount}
   >
     {({ getColumnWidth }) => (
@@ -88,6 +88,36 @@ ReactDOM.render(
 );
 ```
 
+If you want to use a custom cell size cache (in this case, columns are fixed-width and rows have a fixed but unknown height):
+
+```js
+// ...
+import { CellMeasurer, Grid, CellMeasurerCellSizeCacheUniformHeight } from 'react-virtualized';
+
+ReactDOM.render(
+  <CellMeasurer
+    cellRenderer={cellRenderer}
+    cellSizeCache={new CellMeasurerCellSizeCacheUniformHeight()}
+    width={fixedColumnWidth}
+    columnCount={columnCount}
+    rowCount={rowCount}
+  >
+    {({ getRowHeight }) => (
+      <Grid
+        columnCount={columnCount}
+        columnWidth={fixedColumnWidth}
+        height={height}
+        cellRenderer={cellRenderer}
+        rowCount={rowCount}
+        rowHeight={getRowHeight}
+        width={width}
+      />
+    )}
+  </CellMeasurer>,
+  document.getElementById('example')
+);
+```
+
 ### Limitations and Performance Considerations
 
 ###### Styling
@@ -97,13 +127,13 @@ This means that they will not inherit the parent styles while being measured.
 Take care not rely on inherited styles for things that will affect measurement (eg `font-size`).
 (See [issue 352](https://github.com/bvaughn/react-virtualized/issues/352) for more background information.)
 
-Certain box-sizing settings (eg `box-sizing: border-box`) may cause slight discrepencies if borders are applied to a `Grid` whose cells are being measured.
+Certain box-sizing settings (eg `box-sizing: border-box`) may cause slight discrepancies if borders are applied to a `Grid` whose cells are being measured.
 For this reason, it is recommended that you avoid placing borders on a `Grid` that uses a `CellMeasurer` and instead style its parent container.
 (See [issue 338](https://github.com/bvaughn/react-virtualized/issues/338) for more background information.)
 
 ###### Performance
 
-Measuring a column's width requires measuring all rows in order to determine the widest occurance of that column.
+Measuring a column's width requires measuring all rows in order to determine the widest occurrence of that column.
 The same is true in reverse for measuring a row's height.
 For this reason it may not be a good idea to use this HOC for `Grid`s containing a large number of both columns _and_ cells.
 

--- a/source/CellMeasurer/CellMeasurer.test.js
+++ b/source/CellMeasurer/CellMeasurer.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '../TestUtils'
 import CellMeasurer from './CellMeasurer'
 import CellSizeCache from './defaultCellSizeCache'
+import CellSizeCacheUniformHeight from './CellSizeCacheUniformHeight'
 
 const HEIGHTS = [75, 50, 125, 100, 150]
 const WIDTHS = [125, 50, 200, 175, 100]
@@ -319,5 +320,32 @@ describe('CellMeasurer', () => {
     expect(customCellSizeCacheB.hasColumnWidth(0)).toEqual(false)
     expect(getColumnWidthC({ index: 0 })).toEqual(50)
     expect(customCellSizeCacheB.hasColumnWidth(0)).toEqual(true)
+  })
+
+  it('should calculate row height just once when using the alternative uniform-height cell size cache', () => {
+    const cellSizeCacheUniformHeight = new CellSizeCacheUniformHeight()
+    const {
+      cellRenderer,
+      cellRendererParams
+    } = createCellRenderer()
+    const {
+      getRowHeight
+    } = renderHelper({
+      cellRenderer,
+      cellSizeCache: cellSizeCacheUniformHeight,
+      rowCount: 5
+    })
+
+    expect(cellRendererParams).toEqual([])
+    const height1 = getRowHeight({ index: 0 })
+    const height2 = getRowHeight({ index: 1 })
+    const height3 = getRowHeight({ index: 0 })
+    expect(cellRendererParams).toEqual([
+      { columnIndex: 0, rowIndex: 0 }
+    ])
+
+    expect(height1).toEqual(75)
+    expect(height2).toEqual(75)
+    expect(height3).toEqual(75)
   })
 })

--- a/source/CellMeasurer/CellSizeCacheUniformHeight.js
+++ b/source/CellMeasurer/CellSizeCacheUniformHeight.js
@@ -1,0 +1,52 @@
+/**
+ * Alternative CellMeasurer `cellSizeCache` implementation
+ * for lists with unknown **but uniform** row heights.
+ * Permanently caches column widths (identified by column index) and
+ * a single row height unless explicitly cleared.
+ */
+export default class CellSizeCacheUniformHeight {
+  constructor () {
+    this._cachedColumnWidths = {}
+    this._cachedRowHeight = undefined
+  }
+
+  clearAllColumnWidths () {
+    this._cachedColumnWidths = {}
+  }
+
+  clearAllRowHeights () {
+    this._cachedRowHeight = undefined
+  }
+
+  clearColumnWidth (index: number) {
+    this._cachedColumnWidths[index] = undefined
+  }
+
+  clearRowHeight (index: number) {
+    this._cachedRowHeight = undefined
+  }
+
+  getColumnWidth (index: number): number {
+    return this._cachedColumnWidths[index]
+  }
+
+  getRowHeight (index: number): number {
+    return this._cachedRowHeight
+  }
+
+  hasColumnWidth (index: number): boolean {
+    return this._cachedColumnWidths[index] >= 0
+  }
+
+  hasRowHeight (index: number): boolean {
+    return this._cachedRowHeight >= 0
+  }
+
+  setColumnWidth (index: number, width: number) {
+    this._cachedColumnWidths[index] = width
+  }
+
+  setRowHeight (index: number, height: number) {
+    this._cachedRowHeight = height
+  }
+}

--- a/source/CellMeasurer/index.js
+++ b/source/CellMeasurer/index.js
@@ -1,3 +1,4 @@
 export default from './CellMeasurer'
 export CellMeasurer from './CellMeasurer'
 export defaultCellSizeCache from './defaultCellSizeCache'
+export CellSizeCacheUniformHeight from './CellSizeCacheUniformHeight'

--- a/source/index.js
+++ b/source/index.js
@@ -3,7 +3,8 @@ export { ArrowKeyStepper } from './ArrowKeyStepper'
 export { AutoSizer } from './AutoSizer'
 export {
   CellMeasurer,
-  defaultCellSizeCache as defaultCellMeasurerCellSizeCache
+  defaultCellSizeCache as defaultCellMeasurerCellSizeCache,
+  CellSizeCacheUniformHeight as CellMeasurerCellSizeCacheUniformHeight
 } from './CellMeasurer'
 export { Collection } from './Collection'
 export { ColumnSizer } from './ColumnSizer'


### PR DESCRIPTION
As discussed in 9839c52d96b6cec72a58cbf550bc78c57728a97b, I have added a new size cache strategy for the case in which we know that all rows have the same height, even though this height is unknown. This use case can be quite common (e.g. custom drop-down menus). The new class is exported as `CellMeasurerCellSizeCacheUniformHeight`.

I have updated the related documentation and included a unit test.