### PR TITLE
Add CellMeasurer size cache strategy for uniform-yet-unknown row heights (follow-up)

### DIFF
--- a/source/CellMeasurer/uniformSizeCellSizeCache.js
+++ b/source/CellMeasurer/uniformSizeCellSizeCache.js
@@ -3,43 +3,58 @@
  * Permanently caches cell sizes until explicitly cleared.
  */
 export default class UniformSizeCellSizeCache {
+  constructor ({ uniformWidth = true, uniformHeight = true } = {}) {
+    this.uniformWidth = uniformWidth
+    this.uniformHeight = uniformHeight
+    this._cachedColumnWidth = (uniformWidth ? undefined : {})
+    this._cachedRowHeight = (uniformHeight ? undefined : {})
+  }
+
   clearAllColumnWidths () {
-    this._cachedColumnWidth = undefined
+    this._cachedColumnWidth = this.uniformWidth ? undefined : {}
   }
 
   clearAllRowHeights () {
-    this._cachedRowHeight = undefined
+    this._cachedRowHeight = this.uniformHeight ? undefined : {}
   }
 
   clearColumnWidth (index: number) {
-    this._cachedColumnWidth = undefined
+    this.setColumnWidth(index, undefined)
   }
 
   clearRowHeight (index: number) {
-    this._cachedRowHeight = undefined
+    this.setRowHeight(index, undefined)
   }
 
   getColumnWidth (index: number): number {
-    return this._cachedColumnWidth
+    return this.uniformWidth ? this._cachedColumnWidth : this._cachedColumnWidth[index]
   }
 
   getRowHeight (index: number): number {
-    return this._cachedRowHeight
+    return this.uniformHeight ? this._cachedRowHeight : this._cachedRowHeight[index]
   }
 
   hasColumnWidth (index: number): boolean {
-    return !!this._cachedColumnWidth
+    return (this.uniformWidth ? this._cachedColumnWidth : this._cachedColumnWidth[index]) != null
   }
 
   hasRowHeight (index: number): boolean {
-    return !!this._cachedRowHeight
+    return (this.uniformHeight ? this._cachedRowHeight : this._cachedRowHeight[index]) != null
   }
 
   setColumnWidth (index: number, width: number) {
-    this._cachedColumnWidth = width
+    if (this.uniformWidth) {
+      this._cachedColumnWidth = width
+    } else {
+      this._cachedColumnWidth[index] = width
+    }
   }
 
   setRowHeight (index: number, height: number) {
-    this._cachedRowHeight = height
+    if (this.uniformHeight) {
+      this._cachedRowHeight = height
+    } else {
+      this._cachedRowHeight[index] = height
+    }
   }
 }


### PR DESCRIPTION
This is a follow-up on #362. In the merged solution, the size cache imposes that both row height and col width are uniform, which might not be what the user wants. In this PR, the cache can be configured upon construction (defaults being `uniformWidth: true, uniformHeight: true`).