### PR TITLE
Run tests using jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -59,9 +59,6 @@
     },
     "test": {
       "comments": false,
-      "plugins": [
-        "__coverage__"
-      ],
       "presets": [
         "es2015",
         "react",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,17 @@
       "jasmine"
     ]
   },
+  "jest": {
+    "setupFiles": [
+      "source/jest-setup.js"
+    ]
+  },
   "devDependencies": {
     "autoprefixer": "^6.2.3",
     "babel-cli": "6.8.0",
     "babel-core": "^6.5.1",
     "babel-eslint": "^6.0.4",
+    "babel-jest": "^15.0.0",
     "babel-loader": "^6.2.3",
     "babel-plugin-__coverage__": "^0.111111.11",
     "babel-plugin-react-transform": "^2.0.0",
@@ -108,6 +114,7 @@
     "immutable": "^3.7.5",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",
+    "jest": "^15.1.1",
     "karma": "^0.13.22",
     "karma-coverage": "^1.0.0",
     "karma-jasmine": "^1.0.2",

--- a/source/FlexTable/FlexTable.test.js
+++ b/source/FlexTable/FlexTable.test.js
@@ -278,7 +278,7 @@ describe('FlexTable', () => {
       const rendered = findDOMNode(render(getMarkup()))
       const nameColumn = rendered.querySelectorAll('.FlexTable__headerColumn:first-of-type')
 
-      expect(nameColumn.className).not.toContain('FlexTable__sortableHeaderColumn')
+      expect(nameColumn.className || '').not.toContain('FlexTable__sortableHeaderColumn')
     })
 
     it('should not render sort indicators for non-sortable columns', () => {
@@ -288,7 +288,7 @@ describe('FlexTable', () => {
       })))
       const nameColumn = rendered.querySelectorAll('.FlexTable__headerColumn:first-of-type')
 
-      expect(nameColumn.className).not.toContain('FlexTable__sortableHeaderColumn')
+      expect(nameColumn.className || '').not.toContain('FlexTable__sortableHeaderColumn')
       expect(rendered.querySelectorAll('.FlexTable__sortableHeaderColumn').length).toEqual(1) // Email only
     })
 

--- a/source/jest-setup.js
+++ b/source/jest-setup.js
@@ -1,0 +1,5 @@
+jest.mock('dom-helpers/util/scrollbarSize', () => {
+  return function getScrollbarSize() {
+    return 20;
+  };
+});


### PR DESCRIPTION
AutoSizer, CellMeasurer, and WindowScroller fail because jsdom doesn't do measurement stuff properly and you need a real browser. The other tests work with `./node_modules/.bin/jest` though.