### PR TITLE
Remove pointer-events: auto while not scrolling

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -555,7 +555,7 @@ export default class Grid extends Component {
               height: totalRowsHeight,
               maxWidth: totalColumnsWidth,
               maxHeight: totalRowsHeight,
-              pointerEvents: isScrolling ? 'none' : 'auto'
+              pointerEvents: isScrolling ? 'none' : ''
             }}
           >
             {childrenToDisplay}


### PR DESCRIPTION
I am embedding a VirtualScroll into a parent with `pointer-events: none` in CSS. The `pointer-events` property in CSS has behavior that I wouldn't have guessed: if a parent sets `pointer-events: none` and a child sets `pointer-events: auto` or `pointer-events: all`, then the child interacts with mouse events even though its parent does not. [This line](https://github.com/bvaughn/react-virtualized/blob/f00e1aed09c63cf78504a694b1647cebee1cd68d/source/Grid/Grid.js#L558) in Grid.js sets `pointer-events: none` while scrolling, then back to `auto` when the scroll stops. I would like to propose that when scrolling stops, set `pointer-events: ''` instead so that if a Grid is inside a parent with `pointer-events: none`, the grid does not intercept mouse events when it is not scrolling.

If you are curious, the parent component in my case is a proprietary tab control that renders all its tabs at once, but uses `pointer-events: none` to ensure that only the selected tab is usable. When the Grid sets `pointer-events: auto`, it intercepts mouse events even though it sits in a `pointer-events: none` parent.