### PR TITLE
Utilize babel-plugin-transform-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -41,6 +41,9 @@
       ]
     },
     "es": {
+      "plugins": [
+				"transform-runtime"
+      ],
       "presets": [
         "es2015-rollup",
         "react",
@@ -50,6 +53,7 @@
     "production": {
       "comments": false,
       "plugins": [
+				"transform-runtime"
       ],
       "presets": [
         "es2015",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-plugin-__coverage__": "^0.111111.11",
     "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-plugin-typecheck": "^3.9.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
@@ -134,6 +135,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "classnames": "^2.2.3",
     "dom-helpers": "^2.4.0",
     "raf": "^3.1.0"


### PR DESCRIPTION
Allow `react-virtualized` to be usable without requiring `babel-external-helpers` to be included in the application code.