### PR TITLE
Update docs for List

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -16,7 +16,7 @@ Elements can have fixed or varying heights.
 | overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
 | rowCount | Number | ✓ | Number of rows in list. |
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
-| rowRenderer | Function | ✓ | Responsible for rendering a row given an index. Signature should look like `({ index: number, isScrolling: boolean }): React.PropTypes.node` |
+| rowRenderer | Function | ✓ | Responsible for rendering a row given an index. Signature should look like `({ index: number, key: string, style: Object, isScrolling: boolean }): React.PropTypes.node` |
 | scrollToAlignment | String |  | Controls the alignment scrolled-to-rows. The default ("_auto_") scrolls the least amount possible to ensure that the specified row is fully visible. Use "_start_" to always align rows to the top of the list and "_end_" to align them bottom. Use "_center_" to align them in the middle of container. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |
 | scrollTop | Number |  | Forced vertical scroll offset; can be used to synchronize scrolling between components |
@@ -76,13 +76,13 @@ const list = [
   // And so on...
 ];
 
-function rowRenderer ({ key, rowIndex, style}) {
+function rowRenderer ({ key, index, style}) {
   return (
     <div
       key={key}
       style={style}
     >
-      {list[rowIndex]}
+      {list[index]}
     </div>
   )
 }


### PR DESCRIPTION
Changing `index` to `rowIndex` was decided against, so this reverts that change in the example.

This also adds `key` and `style` to the `rowRenderer` function signature.

Fixes: #402