### PR TITLE
Fix a few more docs examples

### DIFF
--- a/docs/AutoSizer.md
+++ b/docs/AutoSizer.md
@@ -34,13 +34,13 @@ const list = [
   // And so on...
 ];
 
-function rowRenderer ({ key, rowIndex, style}) {
+function rowRenderer ({ key, index, style}) {
   return (
     <div
       key={key}
       style={style}
     >
-      {list[rowIndex]}
+      {list[index]}
     </div>
   )
 }

--- a/docs/InfiniteLoader.md
+++ b/docs/InfiniteLoader.md
@@ -53,13 +53,13 @@ function loadMoreRows ({ startIndex, stopIndex }) {
     })
 }
 
-function rowRenderer ({ key, rowIndex, style}) {
+function rowRenderer ({ key, index, style}) {
   return (
     <div
       key={key}
       style={style}
     >
-      {list[rowIndex]}
+      {list[index]}
     </div>
   )
 }

--- a/docs/reverseList.md
+++ b/docs/reverseList.md
@@ -54,7 +54,7 @@ export default class Example extends Component {
     this.refs.List.scrollToRow(0)
   }
 
-  _rowRenderer ({ key, rowIndex }) {
+  _rowRenderer ({ key, index }) {
     return (
       <div
         key={key}


### PR DESCRIPTION
#403 got merged a bit [too quick](https://github.com/bvaughn/react-virtualized/pull/403#issuecomment-248195711) ;).  Here are a few more places in the docs which needed to be changed back to `index` as well.