### PR TITLE
Reduce reflows, don't block scroll events in AutoSizer

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -39,7 +39,6 @@ export default class AutoSizer extends Component {
     }
 
     this._onResize = this._onResize.bind(this)
-    this._onScroll = this._onScroll.bind(this)
     this._setRef = this._setRef.bind(this)
   }
 
@@ -83,7 +82,6 @@ export default class AutoSizer extends Component {
     return (
       <div
         ref={this._setRef}
-        onScroll={this._onScroll}
         style={outerStyle}
       >
         {children({ height, width })}
@@ -118,11 +116,6 @@ export default class AutoSizer extends Component {
     })
 
     onResize({ height, width })
-  }
-
-  _onScroll (event) {
-    // Prevent detectElementResize library from being triggered by this scroll event.
-    event.stopPropagation()
   }
 
   _setRef (autoSizer) {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -852,14 +852,6 @@ export default class Grid extends Component {
       this.state.scrollLeft !== scrollLeft ||
       this.state.scrollTop !== scrollTop
     ) {
-      // Browsers with cancelable scroll events (eg. Firefox) interrupt scrolling animations if scrollTop/scrollLeft is set.
-      // Other browsers (eg. Safari) don't scroll as well without the help under certain conditions (DOM or style changes during scrolling).
-      // All things considered, this seems to be the best current work around that I'm aware of.
-      // For more information see https://github.com/bvaughn/react-virtualized/pull/124
-      const scrollPositionChangeReason = event.cancelable
-        ? SCROLL_POSITION_CHANGE_REASONS.OBSERVED
-        : SCROLL_POSITION_CHANGE_REASONS.REQUESTED
-
       // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
       const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
       const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
@@ -869,7 +861,7 @@ export default class Grid extends Component {
         scrollDirectionHorizontal,
         scrollDirectionVertical,
         scrollLeft,
-        scrollPositionChangeReason,
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED,
         scrollTop
       })
     }

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -53,6 +53,14 @@ if (!attachEvent) {
   }
 
   var scrollListener = function(e){
+    // Don't measure (which forces) reflow for scrolls that happen inside of children!
+    if (
+      !e.target.className.includes('contract-trigger') &&
+      !e.target.className.includes('expand-trigger')
+    ) {
+      return
+    }
+
     var element = this;
     resetTriggers(this);
     if (this.__resizeRAF__) cancelFrame(this.__resizeRAF__);


### PR DESCRIPTION
Tweaked some AutoSize/Grid related things in an effort to reduce reflows