### PR TITLE
match InfiniteLoader onRowsRendered callback with Grids onSectionRendered signature

### DIFF
--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -108,18 +108,18 @@ export default class InfiniteLoader extends Component {
     })
   }
 
-  _onRowsRendered ({ startIndex, stopIndex }) {
+  _onRowsRendered ({ startIndex, stopIndex, rowStartIndex, rowStopIndex }) {
     const { isRowLoaded, minimumBatchSize, rowCount, threshold } = this.props
 
-    this._lastRenderedStartIndex = startIndex
-    this._lastRenderedStopIndex = stopIndex
+    this._lastRenderedStartIndex = (startIndex != null) ? startIndex : rowStartIndex
+    this._lastRenderedStopIndex = (stopIndex != null) ? stopIndex : rowStopIndex
 
     const unloadedRanges = scanForUnloadedRanges({
       isRowLoaded,
       minimumBatchSize,
       rowCount,
-      startIndex: Math.max(0, startIndex - threshold),
-      stopIndex: Math.min(rowCount - 1, stopIndex + threshold)
+      startIndex: Math.max(0, this._lastRenderedStartIndex - threshold),
+      stopIndex: Math.min(rowCount - 1, this._lastRenderedStopIndex + threshold)
     })
 
     // For memoize comparison


### PR DESCRIPTION
Currently, if you want to use Grid with InfiniteLoader, you can map `onRowsRendered` to `onSectionRendered` like so:

```
<InfiniteLoader>
  {({ onRowsRendered }) => (
    <Grid onSectionRendered={(x) => onRowsRendered({startIndex: x.rowStartIndex, stopIndex: x.rowStopIndex})} />
  )}
</InfiniteLoader>
```

This just adapts the signature for `InfiniteLoader`s callback to read `startIndex` first, and then `rowStartIndex` second if that was null or undefined.

```
<InfiniteLoader>
  {({ onRowsRendered }) => (
    <Grid onSectionRendered={onRowsRendered})} />
  )}
</InfiniteLoader>
```

I'd be happy to write a test for this, but please let me know first if this is a welcome change. 

(sidenote: I am really enjoying using this library, it's one of the best I've had a pleasure to use, but the differences between Tables and Grids seems to be a bit of a pain point, in my view).
