### PR TITLE
Adding natural sorting to FlexTable

### DIFF
--- a/source/Table/SortDirection.js
+++ b/source/Table/SortDirection.js
@@ -1,5 +1,11 @@
 const SortDirection = {
   /**
+   * Sort items in natural (original) order.
+   * This means returning data as it was originally sorted.
+   */
+  NAT: 'NAT',
+
+  /**
    * Sort items in ascending order.
    * This means arranging from the lowest value to the highest (e.g. a-z, 0-9).
    */

--- a/source/Table/SortIndicator.js
+++ b/source/Table/SortIndicator.js
@@ -11,6 +11,17 @@ export default function SortIndicator ({ sortDirection }) {
     'ReactVirtualized__Table__sortableHeaderIcon--DESC': sortDirection === SortDirection.DESC
   })
 
+  const renderSortIcon = () => {
+    switch (sortDirection) {
+      case SortDirection.ASC:
+        return <path d='M7 14l5-5 5 5z' />
+      case SortDirection.DESC:
+        return <path d='M7 10l5 5 5-5z' />
+      default:
+        return null
+    }
+  }
+
   return (
     <svg
       className={classNames}
@@ -18,14 +29,11 @@ export default function SortIndicator ({ sortDirection }) {
       height={18}
       viewBox='0 0 24 24'
     >
-      {sortDirection === SortDirection.ASC
-        ? <path d='M7 14l5-5 5 5z' />
-        : <path d='M7 10l5 5 5-5z' />
-      }
+      {renderSortIcon(sortDirection)}
       <path d='M0 0h24v24H0z' fill='none' />
     </svg>
   )
 }
 SortIndicator.propTypes = {
-  sortDirection: PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC])
+  sortDirection: PropTypes.oneOf([SortDirection.NAT, SortDirection.ASC, SortDirection.DESC])
 }

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -175,7 +175,7 @@ export default class Table extends Component {
     sortBy: PropTypes.string,
 
     /** Table data is currently sorted in this direction (if it is sorted at all) */
-    sortDirection: PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC]),
+    sortDirection: PropTypes.oneOf([SortDirection.NAT, SortDirection.ASC, SortDirection.DESC]),
 
     /** Optional inline style */
     style: PropTypes.object,
@@ -390,9 +390,9 @@ export default class Table extends Component {
 
     if (sortEnabled || onHeaderClick) {
       // If this is a sortable header, clicking it should update the table data's sorting.
-      const newSortDirection = sortBy !== dataKey || sortDirection === SortDirection.DESC
+      const newSortDirection = sortBy !== dataKey || sortDirection === SortDirection.NAT
         ? SortDirection.ASC
-        : SortDirection.DESC
+        : (sortDirection === SortDirection.DESC ? SortDirection.NAT : SortDirection.DESC)
 
       const onClick = () => {
         sortEnabled && sort({

--- a/source/Table/Table.test.js
+++ b/source/Table/Table.test.js
@@ -318,7 +318,7 @@ describe('Table', () => {
     })
 
     it('should call sort with the correct arguments when the current sort-by column header is clicked', () => {
-      const sortDirections = [SortDirection.ASC, SortDirection.DESC]
+      const sortDirections = [SortDirection.NAT, SortDirection.ASC, SortDirection.DESC]
       sortDirections.forEach(sortDirection => {
         const sortCalls = []
         const rendered = findDOMNode(render(getMarkup({
@@ -332,7 +332,8 @@ describe('Table', () => {
         expect(sortCalls.length).toEqual(1)
 
         const { sortBy, sortDirection: newSortDirection } = sortCalls[0]
-        const expectedSortDirection = sortDirection === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC
+        const expectedSortDirection = sortDirection === SortDirection.ASC ? SortDirection.DESC
+          : (sortDirection === SortDirection.DESC ? SortDirection.NAT : SortDirection.ASC)
         expect(sortBy).toEqual('name')
         expect(newSortDirection).toEqual(expectedSortDirection)
       })


### PR DESCRIPTION
Now sorting can be reset to its original order (natural), after clicking a sortable column header.

The new order of sorting direction is: 
NAT, ASC, DESC, NAT... 

Previously it was: 
NAT, ASC, DESC, ASC, DESC...