### PR TITLE
Fix blocked safari scrollbar

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -111,7 +111,7 @@ var createStyles = function() {
     //opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
     var css = (animationKeyframes ? animationKeyframes : '') +
         '.resize-triggers { ' + (animationStyle ? animationStyle : '') + 'visibility: hidden; opacity: 0; } ' +
-        '.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
+        '.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; z-index: -1; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
       head = document.head || document.getElementsByTagName('head')[0],
       style = document.createElement('style');
 


### PR DESCRIPTION
The `detectElementResize.js` library has a bug in Safari in which an invisible element covers the scrollbar and prevents clicks from going through to the control.
![before](https://cloud.githubusercontent.com/assets/4413963/18779850/b2cd74dc-81b5-11e6-881d-d88dc617673d.gif)

This is documented in [this issue](https://github.com/sdecima/javascript-detect-element-resize/issues/31) and I got the idea for the fix from [this commit](https://github.com/poscar/javascript-detect-element-resize/commit/0a80f3ec58ab6de6e5491898bcfe263b04032ae6).

The result:
![after](https://cloud.githubusercontent.com/assets/4413963/18779885/e45e46fc-81b5-11e6-85bd-32943cdd9a94.gif)


