### PR TITLE
Update package.json - add "files" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "type": "git",
     "url": "https://github.com/bvaughn/react-virtualized.git"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "react",
     "reactjs",


### PR DESCRIPTION
Added "files" field to package.json to prevent the playground files from being downloaded when doing npm install.

I'm pretty sure the dist folder is all you need since everything lives in there on build.  package.json, changelog, readme, and license are always included as per https://docs.npmjs.com/files/package.json#files