### PR TITLE
Correct export of IS_SCROLLING_TIMEOUT to be a named export

### DIFF
--- a/source/WindowScroller/index.js
+++ b/source/WindowScroller/index.js
@@ -1,3 +1,3 @@
 export default from './WindowScroller'
 export WindowScroller from './WindowScroller'
-export IS_SCROLLING_TIMEOUT from './utils/onScroll'
+export {IS_SCROLLING_TIMEOUT} from './utils/onScroll'


### PR DESCRIPTION
I ran across this while working to incorporate react-virtualized into a project using rollup. It reported that it was unable to locate a default export in [onScroll.js](https://github.com/bvaughn/react-virtualized/blob/master/source/WindowScroller/utils/onScroll.js);

A little digging showed the problem to be the export located in the PR. It appears that you were attempting to export [this named export of IS_SCROLLING_TIMEOUT](https://github.com/bvaughn/react-virtualized/blob/master/source/WindowScroller/utils/onScroll.js#L9). Without the braces though it appears to be trying to treat that as a default export.

This will likely work for most consumers since due to the way babel seems to be compiling it. Only became obvious within a system that tries to use the es module directly.

On a side note I am not certain of the validity of the `export foo from './foo'` syntax in es2015 Couple references for that concern:
- http://www.2ality.com/2014/09/es6-modules-final.html
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export