### PR TITLE
Add `autoHeight` to `Table` and `List` documentation

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -7,6 +7,7 @@ Elements can have fixed or varying heights.
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
+| autoHeight | Boolean |  | Outer `height` of `List` is set to "auto". This property should only be used in conjunction with the `WindowScroller` HOC. |
 | className | String |  | Optional custom CSS class name to attach to root `List` element. |
 | estimatedRowSize | Number |  | Used to estimate the total height of a `List` before all of its rows have actually been measured. The estimated total height is adjusted as rows are rendered. |
 | height | Number | ✓ | Height constraint for list (determines how many actual rows are rendered) |

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -8,6 +8,7 @@ This component expects explicit `width` and `height` parameters.
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
+| autoHeight | Boolean |  | Outer `height` of `Table` is set to "auto". This property should only be used in conjunction with the `WindowScroller` HOC. |
 | children | [Column](Column.md) | ✓ | One or more Columns describing the data displayed in this table |
 | className | String |  | Optional custom CSS class name to attach to root `Table` element. |
 | disableHeader | Boolean |  | Do not render the table header (only the rows) |


### PR DESCRIPTION
Just updating a bit of documentation that I found lacking while setting up `WindowScroller`. Thanks!