### PR TITLE
Fix an issue with testing in Enzyme

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -104,7 +104,7 @@ export default class AutoSizer extends Component {
     const height = boundingRect.height || 0
     const width = boundingRect.width || 0
 
-    const style = getComputedStyle(this._parentNode)
+    const style = window.getComputedStyle(this._parentNode)
     const paddingLeft = parseInt(style.paddingLeft, 10) || 0
     const paddingRight = parseInt(style.paddingRight, 10) || 0
     const paddingTop = parseInt(style.paddingTop, 10) || 0

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -131,7 +131,7 @@ var addResizeListener = function(element, fn){
   if (attachEvent) element.attachEvent('onresize', fn);
   else {
     if (!element.__resizeTriggers__) {
-      if (getComputedStyle(element).position == 'static') element.style.position = 'relative';
+      if (_window.getComputedStyle(element).position == 'static') element.style.position = 'relative';
       createStyles();
       element.__resizeLast__ = {};
       element.__resizeListeners__ = [];


### PR DESCRIPTION
Enzyme, or upstream of Enzyme, aliases window methods (like getComputedStyle) to their own methods. When these are called like `getComputedStyle()` rather than `window.getComputedStyle()` they are interpreted as `global.getComputedStyle()` which does not exist.

We were fixing this by adding this to our Enzyme setup file.
```js
global.getComputedStyle = window.getComputedStyle;
```

Tests and linting passed locally. I also played around with the playground to make sure everything still worked there.