### PR TITLE
Remove the animation event listener while removing the resize listener

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -143,10 +143,15 @@ var addResizeListener = function(element, fn){
       element.addEventListener('scroll', scrollListener, true);
 
       /* Listen for a css animation to detect element display/re-attach */
-      animationstartevent && element.__resizeTriggers__.addEventListener(animationstartevent, function(e) {
-        if(e.animationName == animationName)
-          resetTriggers(element);
-      });
+      if (animationstartevent) {
+        element.__resizeTriggers__.__animationListener__ = function animationListener(e) {
+          if(e.animationName == animationName)
+            resetTriggers(element);
+        };
+        element.__resizeTriggers__.addEventListener(
+          animationstartevent, element.__resizeTriggers__.__animationListener__
+        );
+      }
     }
     element.__resizeListeners__.push(fn);
   }
@@ -158,6 +163,12 @@ var removeResizeListener = function(element, fn){
     element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
     if (!element.__resizeListeners__.length) {
         element.removeEventListener('scroll', scrollListener, true);
+        if (element.__resizeTriggers__.__animationListener__) {
+          element.__resizeTriggers__.removeEventListener(
+            animationstartevent, element.__resizeTriggers__.__animationListener__
+          );
+          element.__resizeTriggers__.__animationListener__ = null;
+        }
         element.__resizeTriggers__ = !element.removeChild(element.__resizeTriggers__);
     }
   }


### PR DESCRIPTION
When mounting and unmounting very quickly a complex component on IE11 and a quite old computer as a child of AutoSizer, the `resetTriggers` function gets called *after* the `removeResizeListener` has been called. Hence `resetTriggers` fails because `element.__resizeTriggers__` is `false`.
Since such a trigger is called by the animation event listener, this pull request tracks and removes such a listener.

PS: The test case highlighting this problem is quite complex and it could be (I believe, at least) time-dependant, but I could spend some time if it is needed.