### PR TITLE
Remove proptypes in production

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -6,13 +6,6 @@ import shallowCompare from 'react-addons-shallow-compare'
  * This HOC decorates a virtualized component and responds to arrow-key events by scrolling one row or column at a time.
  */
 export default class ArrowKeyStepper extends Component {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    className: PropTypes.string,
-    columnCount: PropTypes.number.isRequired,
-    rowCount: PropTypes.number.isRequired
-  }
-
   constructor (props, context) {
     super(props, context)
 
@@ -90,5 +83,14 @@ export default class ArrowKeyStepper extends Component {
     this._columnStopIndex = columnStopIndex
     this._rowStartIndex = rowStartIndex
     this._rowStopIndex = rowStopIndex
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  ArrowKeyStepper.propTypes = {
+    children: PropTypes.func.isRequired,
+    className: PropTypes.string,
+    columnCount: PropTypes.number.isRequired,
+    rowCount: PropTypes.number.isRequired
   }
 }

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -9,24 +9,6 @@ import createDetectElementResize from '../vendor/detectElementResize'
  * All other properties will be passed through to the child component.
  */
 export default class AutoSizer extends Component {
-  static propTypes = {
-    /**
-     * Function responsible for rendering children.
-     * This function should implement the following signature:
-     * ({ height, width }) => PropTypes.element
-     */
-    children: PropTypes.func.isRequired,
-
-    /** Disable dynamic :height property */
-    disableHeight: PropTypes.bool,
-
-    /** Disable dynamic :width property */
-    disableWidth: PropTypes.bool,
-
-    /** Callback to be invoked on-resize: ({ height, width }) */
-    onResize: PropTypes.func.isRequired
-  }
-
   static defaultProps = {
     onResize: () => {}
   }
@@ -121,5 +103,25 @@ export default class AutoSizer extends Component {
 
   _setRef (autoSizer) {
     this._autoSizer = autoSizer
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  AutoSizer.propTypes = {
+    /**
+    * Function responsible for rendering children.
+    * This function should implement the following signature:
+    * ({ height, width }) => PropTypes.element
+    */
+    children: PropTypes.func.isRequired,
+
+    /** Disable dynamic :height property */
+    disableHeight: PropTypes.bool,
+
+    /** Disable dynamic :width property */
+    disableWidth: PropTypes.bool,
+
+    /** Callback to be invoked on-resize: ({ height, width }) */
+    onResize: PropTypes.func.isRequired
   }
 }

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -9,55 +9,6 @@ import CellSizeCache from './defaultCellSizeCache'
  * Either a fixed width or height may be provided if it is desirable to measure only in one direction.
  */
 export default class CellMeasurer extends Component {
-  static propTypes = {
-    /**
-     * Renders a cell given its indices.
-     * Should implement the following interface: ({ columnIndex: number, rowIndex: number }): PropTypes.node
-     */
-    cellRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Optional, custom caching strategy for cell sizes.
-     */
-    cellSizeCache: PropTypes.object,
-
-    /**
-     * Function responsible for rendering a virtualized component.
-     * This function should implement the following signature:
-     * ({ getColumnWidth, getRowHeight, resetMeasurements }) => PropTypes.element
-     */
-    children: PropTypes.func.isRequired,
-
-    /**
-     * Number of columns in grid.
-     */
-    columnCount: PropTypes.number.isRequired,
-
-    /**
-     * A Node, Component instance, or function that returns either.
-     * If this property is not specified the document body will be used.
-     */
-    container: React.PropTypes.oneOfType([
-      React.PropTypes.func,
-      React.PropTypes.node
-    ]),
-
-    /**
-     * Assign a fixed :height in order to measure dynamic text :width only.
-     */
-    height: PropTypes.number,
-
-    /**
-     * Number of rows in grid.
-     */
-    rowCount: PropTypes.number.isRequired,
-
-    /**
-     * Assign a fixed :width in order to measure dynamic text :height only.
-     */
-    width: PropTypes.number
-  };
-
   constructor (props, state) {
     super(props, state)
 
@@ -252,5 +203,56 @@ export default class CellMeasurer extends Component {
       this._divWidth = width
       this._div.style.width = `${width}px`
     }
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  CellMeasurer.propTypes = {
+    /**
+     * Renders a cell given its indices.
+     * Should implement the following interface: ({ columnIndex: number, rowIndex: number }): PropTypes.node
+     */
+    cellRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Optional, custom caching strategy for cell sizes.
+     */
+    cellSizeCache: PropTypes.object,
+
+    /**
+     * Function responsible for rendering a virtualized component.
+     * This function should implement the following signature:
+     * ({ getColumnWidth, getRowHeight, resetMeasurements }) => PropTypes.element
+     */
+    children: PropTypes.func.isRequired,
+
+    /**
+     * Number of columns in grid.
+     */
+    columnCount: PropTypes.number.isRequired,
+
+    /**
+     * A Node, Component instance, or function that returns either.
+     * If this property is not specified the document body will be used.
+     */
+    container: React.PropTypes.oneOfType([
+      React.PropTypes.func,
+      React.PropTypes.node
+    ]),
+
+    /**
+     * Assign a fixed :height in order to measure dynamic text :width only.
+     */
+    height: PropTypes.number,
+
+    /**
+     * Number of rows in grid.
+     */
+    rowCount: PropTypes.number.isRequired,
+
+    /**
+     * Assign a fixed :width in order to measure dynamic text :height only.
+     */
+    width: PropTypes.number
   }
 }

--- a/source/Collection/Collection.js
+++ b/source/Collection/Collection.js
@@ -10,43 +10,6 @@ import type { ScrollPosition, SizeInfo } from './types'
  * Unlike Grid, which renders checkerboard data, Collection can render arbitrarily positioned- even overlapping- data.
  */
 export default class Collection extends Component {
-
-  static propTypes = {
-    'aria-label': PropTypes.string,
-
-    /**
-     * Number of cells in Collection.
-     */
-    cellCount: PropTypes.number.isRequired,
-
-    /**
-     * Responsible for rendering a group of cells given their indices.
-     * Should implement the following interface: ({
-     *   cellSizeAndPositionGetter:Function,
-     *   indices: Array<number>,
-     *   cellRenderer: Function
-     * }): Array<PropTypes.node>
-     */
-    cellGroupRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Responsible for rendering a cell given an row and column index.
-     * Should implement the following interface: ({ index: number, key: string, style: object }): PropTypes.element
-     */
-    cellRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Callback responsible for returning size and offset/position information for a given cell (index).
-     * ({ index: number }): { height: number, width: number, x: number, y: number }
-     */
-    cellSizeAndPositionGetter: PropTypes.func.isRequired,
-
-    /**
-     * Optionally override the size of the sections a Collection's cells are split into.
-     */
-    sectionSize: PropTypes.number
-  };
-
   static defaultProps = {
     'aria-label': 'grid',
     cellGroupRenderer: defaultCellGroupRenderer
@@ -238,4 +201,42 @@ function defaultCellGroupRenderer ({
       }
     })
     .filter((renderedCell) => !!renderedCell)
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  Collection.propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Number of cells in Collection.
+     */
+    cellCount: PropTypes.number.isRequired,
+
+    /**
+     * Responsible for rendering a group of cells given their indices.
+     * Should implement the following interface: ({
+     *   cellSizeAndPositionGetter:Function,
+     *   indices: Array<number>,
+     *   cellRenderer: Function
+     * }): Array<PropTypes.node>
+     */
+    cellGroupRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Responsible for rendering a cell given an row and column index.
+     * Should implement the following interface: ({ index: number, key: string, style: object }): PropTypes.element
+     */
+    cellRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Callback responsible for returning size and offset/position information for a given cell (index).
+     * ({ index: number }): { height: number, width: number, x: number, y: number }
+     */
+    cellSizeAndPositionGetter: PropTypes.func.isRequired,
+
+    /**
+     * Optionally override the size of the sections a Collection's cells are split into.
+     */
+    sectionSize: PropTypes.number
+  }
 }

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -27,100 +27,6 @@ const SCROLL_POSITION_CHANGE_REASONS = {
  * This component does not render any visible content itself; it defers to the specified :cellLayoutManager.
  */
 export default class CollectionView extends Component {
-  static propTypes = {
-    'aria-label': PropTypes.string,
-
-    /**
-     * Removes fixed height from the scrollingContainer so that the total height
-     * of rows can stretch the window. Intended for use with WindowScroller
-     */
-    autoHeight: PropTypes.bool,
-
-    /**
-     * Number of cells in collection.
-     */
-    cellCount: PropTypes.number.isRequired,
-
-    /**
-     * Calculates cell sizes and positions and manages rendering the appropriate cells given a specified window.
-     */
-    cellLayoutManager: PropTypes.object.isRequired,
-
-    /**
-     * Optional custom CSS class name to attach to root Collection element.
-     */
-    className: PropTypes.string,
-
-    /**
-     * Height of Collection; this property determines the number of visible (vs virtualized) rows.
-     */
-    height: PropTypes.number.isRequired,
-
-    /**
-     * Enables the `Collection` to horiontally "overscan" its content similar to how `Grid` does.
-     * This can reduce flicker around the edges when a user scrolls quickly.
-     */
-    horizontalOverscanSize: PropTypes.number.isRequired,
-
-    isScrollingChange: PropTypes.func,
-
-    /**
-     * Optional renderer to be used in place of rows when either :rowCount or :cellCount is 0.
-     */
-    noContentRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
-     * This callback can be used to sync scrolling between lists, tables, or grids.
-     * ({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth }): void
-     */
-    onScroll: PropTypes.func.isRequired,
-
-    /**
-     * Callback invoked with information about the section of the Collection that was just rendered.
-     * This callback is passed a named :indices parameter which is an Array of the most recently rendered section indices.
-     */
-    onSectionRendered: PropTypes.func.isRequired,
-
-    /**
-     * Horizontal offset.
-     */
-    scrollLeft: PropTypes.number,
-
-    /**
-     * Controls scroll-to-cell behavior of the Grid.
-     * The default ("auto") scrolls the least amount possible to ensure that the specified cell is fully visible.
-     * Use "start" to align cells to the top/left of the Grid and "end" to align bottom/right.
-     */
-    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
-
-    /**
-     * Cell index to ensure visible (by forcefully scrolling if necessary).
-     */
-    scrollToCell: PropTypes.number,
-
-    /**
-     * Vertical offset.
-     */
-    scrollTop: PropTypes.number,
-
-    /**
-     * Optional custom inline style to attach to root Collection element.
-     */
-    style: PropTypes.object,
-
-    /**
-     * Enables the `Collection` to vertically "overscan" its content similar to how `Grid` does.
-     * This can reduce flicker around the edges when a user scrolls quickly.
-     */
-    verticalOverscanSize: PropTypes.number.isRequired,
-
-    /**
-     * Width of Collection; this property determines the number of visible (vs virtualized) columns.
-     */
-    width: PropTypes.number.isRequired
-  };
-
   static defaultProps = {
     'aria-label': 'grid',
     horizontalOverscanSize: 0,
@@ -573,5 +479,101 @@ export default class CollectionView extends Component {
       totalWidth,
       totalHeight
     })
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  CollectionView.propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Removes fixed height from the scrollingContainer so that the total height
+     * of rows can stretch the window. Intended for use with WindowScroller
+     */
+    autoHeight: PropTypes.bool,
+
+    /**
+     * Number of cells in collection.
+     */
+    cellCount: PropTypes.number.isRequired,
+
+    /**
+     * Calculates cell sizes and positions and manages rendering the appropriate cells given a specified window.
+     */
+    cellLayoutManager: PropTypes.object.isRequired,
+
+    /**
+     * Optional custom CSS class name to attach to root Collection element.
+     */
+    className: PropTypes.string,
+
+    /**
+     * Height of Collection; this property determines the number of visible (vs virtualized) rows.
+     */
+    height: PropTypes.number.isRequired,
+
+    /**
+     * Enables the `Collection` to horiontally "overscan" its content similar to how `Grid` does.
+     * This can reduce flicker around the edges when a user scrolls quickly.
+     */
+    horizontalOverscanSize: PropTypes.number.isRequired,
+
+    isScrollingChange: PropTypes.func,
+
+    /**
+     * Optional renderer to be used in place of rows when either :rowCount or :cellCount is 0.
+     */
+    noContentRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
+     * This callback can be used to sync scrolling between lists, tables, or grids.
+     * ({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth }): void
+     */
+    onScroll: PropTypes.func.isRequired,
+
+    /**
+     * Callback invoked with information about the section of the Collection that was just rendered.
+     * This callback is passed a named :indices parameter which is an Array of the most recently rendered section indices.
+     */
+    onSectionRendered: PropTypes.func.isRequired,
+
+    /**
+     * Horizontal offset.
+     */
+    scrollLeft: PropTypes.number,
+
+    /**
+     * Controls scroll-to-cell behavior of the Grid.
+     * The default ("auto") scrolls the least amount possible to ensure that the specified cell is fully visible.
+     * Use "start" to align cells to the top/left of the Grid and "end" to align bottom/right.
+     */
+    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
+
+    /**
+     * Cell index to ensure visible (by forcefully scrolling if necessary).
+     */
+    scrollToCell: PropTypes.number,
+
+    /**
+     * Vertical offset.
+     */
+    scrollTop: PropTypes.number,
+
+    /**
+     * Optional custom inline style to attach to root Collection element.
+     */
+    style: PropTypes.object,
+
+    /**
+     * Enables the `Collection` to vertically "overscan" its content similar to how `Grid` does.
+     * This can reduce flicker around the edges when a user scrolls quickly.
+     */
+    verticalOverscanSize: PropTypes.number.isRequired,
+
+    /**
+     * Width of Collection; this property determines the number of visible (vs virtualized) columns.
+     */
+    width: PropTypes.number.isRequired
   }
 }

--- a/source/ColumnSizer/ColumnSizer.js
+++ b/source/ColumnSizer/ColumnSizer.js
@@ -7,31 +7,6 @@ import Grid from '../Grid'
  * High-order component that auto-calculates column-widths for `Grid` cells.
  */
 export default class ColumnSizer extends Component {
-  static propTypes = {
-    /**
-     * Function responsible for rendering a virtualized Grid.
-     * This function should implement the following signature:
-     * ({ adjustedWidth, getColumnWidth, registerChild }) => PropTypes.element
-     *
-     * The specified :getColumnWidth function should be passed to the Grid's :columnWidth property.
-     * The :registerChild should be passed to the Grid's :ref property.
-     * The :adjustedWidth property is optional; it reflects the lesser of the overall width or the width of all columns.
-     */
-    children: PropTypes.func.isRequired,
-
-    /** Optional maximum allowed column width */
-    columnMaxWidth: PropTypes.number,
-
-    /** Optional minimum allowed column width */
-    columnMinWidth: PropTypes.number,
-
-    /** Number of columns in Grid or Table child */
-    columnCount: PropTypes.number.isRequired,
-
-    /** Width of Grid or Table child */
-    width: PropTypes.number.isRequired
-  }
-
   constructor (props, context) {
     super(props, context)
 
@@ -101,5 +76,32 @@ export default class ColumnSizer extends Component {
     if (this._registeredChild) {
       this._registeredChild.recomputeGridSize()
     }
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  ColumnSizer.propTypes = {
+    /**
+     * Function responsible for rendering a virtualized Grid.
+     * This function should implement the following signature:
+     * ({ adjustedWidth, getColumnWidth, registerChild }) => PropTypes.element
+     *
+     * The specified :getColumnWidth function should be passed to the Grid's :columnWidth property.
+     * The :registerChild should be passed to the Grid's :ref property.
+     * The :adjustedWidth property is optional; it reflects the lesser of the overall width or the width of all columns.
+     */
+    children: PropTypes.func.isRequired,
+
+    /** Optional maximum allowed column width */
+    columnMaxWidth: PropTypes.number,
+
+    /** Optional minimum allowed column width */
+    columnMinWidth: PropTypes.number,
+
+    /** Number of columns in Grid or Table child */
+    columnCount: PropTypes.number.isRequired,
+
+    /** Width of Grid or Table child */
+    width: PropTypes.number.isRequired
   }
 }

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -30,160 +30,6 @@ const SCROLL_POSITION_CHANGE_REASONS = {
  * Row heights and column widths must be known ahead of time and specified as properties.
  */
 export default class Grid extends Component {
-  static propTypes = {
-    'aria-label': PropTypes.string,
-
-    /**
-     * Set the width of the inner scrollable container to 'auto'.
-     * This is useful for single-column Grids to ensure that the column doesn't extend below a vertical scrollbar.
-     */
-    autoContainerWidth: PropTypes.bool,
-
-    /**
-     * Removes fixed height from the scrollingContainer so that the total height
-     * of rows can stretch the window. Intended for use with WindowScroller
-     */
-    autoHeight: PropTypes.bool,
-
-    /**
-     * Responsible for rendering a cell given an row and column index.
-     * Should implement the following interface: ({ columnIndex: number, rowIndex: number }): PropTypes.node
-     */
-    cellRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Responsible for rendering a group of cells given their index ranges.
-     * Should implement the following interface: ({
-     *   cellCache: Map,
-     *   cellRenderer: Function,
-     *   columnSizeAndPositionManager: CellSizeAndPositionManager,
-     *   columnStartIndex: number,
-     *   columnStopIndex: number,
-     *   isScrolling: boolean,
-     *   rowSizeAndPositionManager: CellSizeAndPositionManager,
-     *   rowStartIndex: number,
-     *   rowStopIndex: number,
-     *   scrollLeft: number,
-     *   scrollTop: number
-     * }): Array<PropTypes.node>
-     */
-    cellRangeRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Optional custom CSS class name to attach to root Grid element.
-     */
-    className: PropTypes.string,
-
-    /**
-     * Number of columns in grid.
-     */
-    columnCount: PropTypes.number.isRequired,
-
-    /**
-     * Either a fixed column width (number) or a function that returns the width of a column given its index.
-     * Should implement the following interface: (index: number): number
-     */
-    columnWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
-
-    /** Optional inline style applied to inner cell-container */
-    containerStyle: PropTypes.object,
-
-    /**
-     * Used to estimate the total width of a Grid before all of its columns have actually been measured.
-     * The estimated total width is adjusted as columns are rendered.
-     */
-    estimatedColumnSize: PropTypes.number.isRequired,
-
-    /**
-     * Used to estimate the total height of a Grid before all of its rows have actually been measured.
-     * The estimated total height is adjusted as rows are rendered.
-     */
-    estimatedRowSize: PropTypes.number.isRequired,
-
-    /**
-     * Height of Grid; this property determines the number of visible (vs virtualized) rows.
-     */
-    height: PropTypes.number.isRequired,
-
-    /**
-     * Optional renderer to be used in place of rows when either :rowCount or :columnCount is 0.
-     */
-    noContentRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
-     * This callback can be used to sync scrolling between lists, tables, or grids.
-     * ({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth }): void
-     */
-    onScroll: PropTypes.func.isRequired,
-
-    /**
-     * Callback invoked with information about the section of the Grid that was just rendered.
-     * ({ columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex }): void
-     */
-    onSectionRendered: PropTypes.func.isRequired,
-
-    /**
-     * Number of columns to render before/after the visible section of the grid.
-     * These columns can help for smoother scrolling on touch devices or browsers that send scroll events infrequently.
-     */
-    overscanColumnCount: PropTypes.number.isRequired,
-
-    /**
-     * Number of rows to render above/below the visible section of the grid.
-     * These rows can help for smoother scrolling on touch devices or browsers that send scroll events infrequently.
-     */
-    overscanRowCount: PropTypes.number.isRequired,
-
-    /**
-     * Either a fixed row height (number) or a function that returns the height of a row given its index.
-     * Should implement the following interface: ({ index: number }): number
-     */
-    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
-
-    /**
-     * Number of rows in grid.
-     */
-    rowCount: PropTypes.number.isRequired,
-
-    /** Wait this amount of time after the last scroll event before resetting Grid `pointer-events`. */
-    scrollingResetTimeInterval: PropTypes.number,
-
-    /** Horizontal offset. */
-    scrollLeft: PropTypes.number,
-
-    /**
-     * Controls scroll-to-cell behavior of the Grid.
-     * The default ("auto") scrolls the least amount possible to ensure that the specified cell is fully visible.
-     * Use "start" to align cells to the top/left of the Grid and "end" to align bottom/right.
-     */
-    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
-
-    /**
-     * Column index to ensure visible (by forcefully scrolling if necessary)
-     */
-    scrollToColumn: PropTypes.number,
-
-    /** Vertical offset. */
-    scrollTop: PropTypes.number,
-
-    /**
-     * Row index to ensure visible (by forcefully scrolling if necessary)
-     */
-    scrollToRow: PropTypes.number,
-
-    /** Optional inline style */
-    style: PropTypes.object,
-
-    /** Tab index for focus */
-    tabIndex: PropTypes.number,
-
-    /**
-     * Width of Grid; this property determines the number of visible (vs virtualized) columns.
-     */
-    width: PropTypes.number.isRequired
-  };
-
   static defaultProps = {
     'aria-label': 'grid',
     cellRangeRenderer: defaultCellRangeRenderer,
@@ -872,5 +718,161 @@ export default class Grid extends Component {
     }
 
     this._invokeOnScrollMemoizer({ scrollLeft, scrollTop, totalColumnsWidth, totalRowsHeight })
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  Grid.propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Set the width of the inner scrollable container to 'auto'.
+     * This is useful for single-column Grids to ensure that the column doesn't extend below a vertical scrollbar.
+     */
+    autoContainerWidth: PropTypes.bool,
+
+    /**
+     * Removes fixed height from the scrollingContainer so that the total height
+     * of rows can stretch the window. Intended for use with WindowScroller
+     */
+    autoHeight: PropTypes.bool,
+
+    /**
+     * Responsible for rendering a cell given an row and column index.
+     * Should implement the following interface: ({ columnIndex: number, rowIndex: number }): PropTypes.node
+     */
+    cellRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Responsible for rendering a group of cells given their index ranges.
+     * Should implement the following interface: ({
+     *   cellCache: Map,
+     *   cellRenderer: Function,
+     *   columnSizeAndPositionManager: CellSizeAndPositionManager,
+     *   columnStartIndex: number,
+     *   columnStopIndex: number,
+     *   isScrolling: boolean,
+     *   rowSizeAndPositionManager: CellSizeAndPositionManager,
+     *   rowStartIndex: number,
+     *   rowStopIndex: number,
+     *   scrollLeft: number,
+     *   scrollTop: number
+     * }): Array<PropTypes.node>
+     */
+    cellRangeRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Optional custom CSS class name to attach to root Grid element.
+     */
+    className: PropTypes.string,
+
+    /**
+     * Number of columns in grid.
+     */
+    columnCount: PropTypes.number.isRequired,
+
+    /**
+     * Either a fixed column width (number) or a function that returns the width of a column given its index.
+     * Should implement the following interface: (index: number): number
+     */
+    columnWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
+
+    /** Optional inline style applied to inner cell-container */
+    containerStyle: PropTypes.object,
+
+    /**
+     * Used to estimate the total width of a Grid before all of its columns have actually been measured.
+     * The estimated total width is adjusted as columns are rendered.
+     */
+    estimatedColumnSize: PropTypes.number.isRequired,
+
+    /**
+     * Used to estimate the total height of a Grid before all of its rows have actually been measured.
+     * The estimated total height is adjusted as rows are rendered.
+     */
+    estimatedRowSize: PropTypes.number.isRequired,
+
+    /**
+     * Height of Grid; this property determines the number of visible (vs virtualized) rows.
+     */
+    height: PropTypes.number.isRequired,
+
+    /**
+     * Optional renderer to be used in place of rows when either :rowCount or :columnCount is 0.
+     */
+    noContentRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
+     * This callback can be used to sync scrolling between lists, tables, or grids.
+     * ({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth }): void
+     */
+    onScroll: PropTypes.func.isRequired,
+
+    /**
+     * Callback invoked with information about the section of the Grid that was just rendered.
+     * ({ columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex }): void
+     */
+    onSectionRendered: PropTypes.func.isRequired,
+
+    /**
+     * Number of columns to render before/after the visible section of the grid.
+     * These columns can help for smoother scrolling on touch devices or browsers that send scroll events infrequently.
+     */
+    overscanColumnCount: PropTypes.number.isRequired,
+
+    /**
+     * Number of rows to render above/below the visible section of the grid.
+     * These rows can help for smoother scrolling on touch devices or browsers that send scroll events infrequently.
+     */
+    overscanRowCount: PropTypes.number.isRequired,
+
+    /**
+     * Either a fixed row height (number) or a function that returns the height of a row given its index.
+     * Should implement the following interface: ({ index: number }): number
+     */
+    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
+
+    /**
+     * Number of rows in grid.
+     */
+    rowCount: PropTypes.number.isRequired,
+
+    /** Wait this amount of time after the last scroll event before resetting Grid `pointer-events`. */
+    scrollingResetTimeInterval: PropTypes.number,
+
+    /** Horizontal offset. */
+    scrollLeft: PropTypes.number,
+
+    /**
+     * Controls scroll-to-cell behavior of the Grid.
+     * The default ("auto") scrolls the least amount possible to ensure that the specified cell is fully visible.
+     * Use "start" to align cells to the top/left of the Grid and "end" to align bottom/right.
+     */
+    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
+
+    /**
+     * Column index to ensure visible (by forcefully scrolling if necessary)
+     */
+    scrollToColumn: PropTypes.number,
+
+    /** Vertical offset. */
+    scrollTop: PropTypes.number,
+
+    /**
+     * Row index to ensure visible (by forcefully scrolling if necessary)
+     */
+    scrollToRow: PropTypes.number,
+
+    /** Optional inline style */
+    style: PropTypes.object,
+
+    /** Tab index for focus */
+    tabIndex: PropTypes.number,
+
+    /**
+     * Width of Grid; this property determines the number of visible (vs virtualized) columns.
+     */
+    width: PropTypes.number.isRequired
   }
 }

--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -9,51 +9,6 @@ import createCallbackMemoizer from '../utils/createCallbackMemoizer'
  * It is intended as a convenience component; fork it if you'd like finer-grained control over data-loading.
  */
 export default class InfiniteLoader extends Component {
-  static propTypes = {
-    /**
-     * Function responsible for rendering a virtualized component.
-     * This function should implement the following signature:
-     * ({ onRowsRendered, registerChild }) => PropTypes.element
-     *
-     * The specified :onRowsRendered function should be passed through to the child's :onRowsRendered property.
-     * The :registerChild callback should be set as the virtualized component's :ref.
-     */
-    children: PropTypes.func.isRequired,
-
-    /**
-     * Function responsible for tracking the loaded state of each row.
-     * It should implement the following signature: ({ index: number }): boolean
-     */
-    isRowLoaded: PropTypes.func.isRequired,
-
-    /**
-     * Callback to be invoked when more rows must be loaded.
-     * It should implement the following signature: ({ startIndex, stopIndex }): Promise
-     * The returned Promise should be resolved once row data has finished loading.
-     * It will be used to determine when to refresh the list with the newly-loaded data.
-     * This callback may be called multiple times in reaction to a single scroll event.
-     */
-    loadMoreRows: PropTypes.func.isRequired,
-
-    /**
-     * Minimum number of rows to be loaded at a time.
-     * This property can be used to batch requests to reduce HTTP requests.
-     */
-    minimumBatchSize: PropTypes.number.isRequired,
-
-    /**
-     * Number of rows in list; can be arbitrary high number if actual number is unknown.
-     */
-    rowCount: PropTypes.number.isRequired,
-
-    /**
-     * Threshold at which to pre-fetch data.
-     * A threshold X means that data will start loading when a user scrolls within X rows.
-     * This value defaults to 15.
-     */
-    threshold: PropTypes.number.isRequired
-  }
-
   static defaultProps = {
     minimumBatchSize: 10,
     rowCount: 0,
@@ -244,4 +199,51 @@ export function forceUpdateReactVirtualizedComponent (component) {
   typeof component.forceUpdateGrid === 'function'
     ? component.forceUpdateGrid()
     : component.forceUpdate()
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  InfiniteLoader.propTypes = {
+    /**
+     * Function responsible for rendering a virtualized component.
+     * This function should implement the following signature:
+     * ({ onRowsRendered, registerChild }) => PropTypes.element
+     *
+     * The specified :onRowsRendered function should be passed through to the child's :onRowsRendered property.
+     * The :registerChild callback should be set as the virtualized component's :ref.
+     */
+    children: PropTypes.func.isRequired,
+
+    /**
+     * Function responsible for tracking the loaded state of each row.
+     * It should implement the following signature: ({ index: number }): boolean
+     */
+    isRowLoaded: PropTypes.func.isRequired,
+
+    /**
+     * Callback to be invoked when more rows must be loaded.
+     * It should implement the following signature: ({ startIndex, stopIndex }): Promise
+     * The returned Promise should be resolved once row data has finished loading.
+     * It will be used to determine when to refresh the list with the newly-loaded data.
+     * This callback may be called multiple times in reaction to a single scroll event.
+     */
+    loadMoreRows: PropTypes.func.isRequired,
+
+    /**
+     * Minimum number of rows to be loaded at a time.
+     * This property can be used to batch requests to reduce HTTP requests.
+     */
+    minimumBatchSize: PropTypes.number.isRequired,
+
+    /**
+     * Number of rows in list; can be arbitrary high number if actual number is unknown.
+     */
+    rowCount: PropTypes.number.isRequired,
+
+    /**
+     * Threshold at which to pre-fetch data.
+     * A threshold X means that data will start loading when a user scrolls within X rows.
+     * This value defaults to 15.
+     */
+    threshold: PropTypes.number.isRequired
+  }
 }

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -13,80 +13,6 @@ import shallowCompare from 'react-addons-shallow-compare'
  * This component renders a virtualized list of elements with either fixed or dynamic heights.
  */
 export default class List extends Component {
-  static propTypes = {
-    'aria-label': PropTypes.string,
-
-    /**
-     * Removes fixed height from the scrollingContainer so that the total height
-     * of rows can stretch the window. Intended for use with WindowScroller
-     */
-    autoHeight: PropTypes.bool,
-
-    /** Optional CSS class name */
-    className: PropTypes.string,
-
-    /**
-     * Used to estimate the total height of a List before all of its rows have actually been measured.
-     * The estimated total height is adjusted as rows are rendered.
-     */
-    estimatedRowSize: PropTypes.number.isRequired,
-
-    /** Height constraint for list (determines how many actual rows are rendered) */
-    height: PropTypes.number.isRequired,
-
-    /** Optional renderer to be used in place of rows when rowCount is 0 */
-    noRowsRenderer: PropTypes.func.isRequired,
-
-    /**
-     * Callback invoked with information about the slice of rows that were just rendered.
-     * ({ startIndex, stopIndex }): void
-     */
-    onRowsRendered: PropTypes.func.isRequired,
-
-    /**
-     * Number of rows to render above/below the visible bounds of the list.
-     * These rows can help for smoother scrolling on touch devices.
-     */
-    overscanRowCount: PropTypes.number.isRequired,
-
-    /**
-     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
-     * This callback can be used to sync scrolling between lists, tables, or grids.
-     * ({ clientHeight, scrollHeight, scrollTop }): void
-     */
-    onScroll: PropTypes.func.isRequired,
-
-    /**
-     * Either a fixed row height (number) or a function that returns the height of a row given its index.
-     * ({ index: number }): number
-     */
-    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
-
-    /** Responsible for rendering a row given an index; ({ index: number }): node */
-    rowRenderer: PropTypes.func.isRequired,
-
-    /** Number of rows in list. */
-    rowCount: PropTypes.number.isRequired,
-
-    /** See Grid#scrollToAlignment */
-    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
-
-    /** Row index to ensure visible (by forcefully scrolling if necessary) */
-    scrollToIndex: PropTypes.number,
-
-    /** Vertical offset. */
-    scrollTop: PropTypes.number,
-
-    /** Optional inline style */
-    style: PropTypes.object,
-
-    /** Tab index for focus */
-    tabIndex: PropTypes.number,
-
-    /** Width of list */
-    width: PropTypes.number.isRequired
-  }
-
   static defaultProps = {
     estimatedRowSize: 30,
     noRowsRenderer: () => null,
@@ -185,5 +111,81 @@ export default class List extends Component {
       startIndex: rowStartIndex,
       stopIndex: rowStopIndex
     })
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  List.propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Removes fixed height from the scrollingContainer so that the total height
+     * of rows can stretch the window. Intended for use with WindowScroller
+     */
+    autoHeight: PropTypes.bool,
+
+    /** Optional CSS class name */
+    className: PropTypes.string,
+
+    /**
+     * Used to estimate the total height of a List before all of its rows have actually been measured.
+     * The estimated total height is adjusted as rows are rendered.
+     */
+    estimatedRowSize: PropTypes.number.isRequired,
+
+    /** Height constraint for list (determines how many actual rows are rendered) */
+    height: PropTypes.number.isRequired,
+
+    /** Optional renderer to be used in place of rows when rowCount is 0 */
+    noRowsRenderer: PropTypes.func.isRequired,
+
+    /**
+     * Callback invoked with information about the slice of rows that were just rendered.
+     * ({ startIndex, stopIndex }): void
+     */
+    onRowsRendered: PropTypes.func.isRequired,
+
+    /**
+     * Number of rows to render above/below the visible bounds of the list.
+     * These rows can help for smoother scrolling on touch devices.
+     */
+    overscanRowCount: PropTypes.number.isRequired,
+
+    /**
+     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
+     * This callback can be used to sync scrolling between lists, tables, or grids.
+     * ({ clientHeight, scrollHeight, scrollTop }): void
+     */
+    onScroll: PropTypes.func.isRequired,
+
+    /**
+     * Either a fixed row height (number) or a function that returns the height of a row given its index.
+     * ({ index: number }): number
+     */
+    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]).isRequired,
+
+    /** Responsible for rendering a row given an index; ({ index: number }): node */
+    rowRenderer: PropTypes.func.isRequired,
+
+    /** Number of rows in list. */
+    rowCount: PropTypes.number.isRequired,
+
+    /** See Grid#scrollToAlignment */
+    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
+
+    /** Row index to ensure visible (by forcefully scrolling if necessary) */
+    scrollToIndex: PropTypes.number,
+
+    /** Vertical offset. */
+    scrollTop: PropTypes.number,
+
+    /** Optional inline style */
+    style: PropTypes.object,
+
+    /** Tab index for focus */
+    tabIndex: PropTypes.number,
+
+    /** Width of list */
+    width: PropTypes.number.isRequired
   }
 }

--- a/source/ScrollSync/ScrollSync.js
+++ b/source/ScrollSync/ScrollSync.js
@@ -5,15 +5,6 @@ import shallowCompare from 'react-addons-shallow-compare'
  * HOC that simplifies the process of synchronizing scrolling between two or more virtualized components.
  */
 export default class ScrollSync extends Component {
-  static propTypes = {
-    /**
-     * Function responsible for rendering 2 or more virtualized components.
-     * This function should implement the following signature:
-     * ({ onScroll, scrollLeft, scrollTop }) => PropTypes.element
-     */
-    children: PropTypes.func.isRequired
-  }
-
   constructor (props, context) {
     super(props, context)
 
@@ -50,5 +41,16 @@ export default class ScrollSync extends Component {
 
   _onScroll ({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth }) {
     this.setState({ clientHeight, clientWidth, scrollHeight, scrollLeft, scrollTop, scrollWidth })
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  ScrollSync.propTypes = {
+    /**
+     * Function responsible for rendering 2 or more virtualized components.
+     * This function should implement the following signature:
+     * ({ onScroll, scrollLeft, scrollTop }) => PropTypes.element
+     */
+    children: PropTypes.func.isRequired
   }
 }

--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -8,16 +8,6 @@ import defaultCellDataGetter from './defaultCellDataGetter'
  * Describes the header and cell contents of a table column.
  */
 export default class Column extends Component {
-
-  static defaultProps = {
-    cellDataGetter: defaultCellDataGetter,
-    cellRenderer: defaultCellRenderer,
-    flexGrow: 0,
-    flexShrink: 1,
-    headerRenderer: defaultHeaderRenderer,
-    style: {}
-  }
-
   static propTypes = {
     /** Optional aria-label value to set on the column header */
     'aria-label': PropTypes.string,
@@ -75,5 +65,16 @@ export default class Column extends Component {
 
     /** Flex basis (width) for this column; This value can grow or shrink based on :flexGrow and :flexShrink properties. */
     width: PropTypes.number.isRequired
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  Column.defaultProps = {
+    cellDataGetter: defaultCellDataGetter,
+    cellRenderer: defaultCellRenderer,
+    flexGrow: 0,
+    flexShrink: 1,
+    headerRenderer: defaultHeaderRenderer,
+    style: {}
   }
 }

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -5,22 +5,6 @@ import shallowCompare from 'react-addons-shallow-compare'
 import { registerScrollListener, unregisterScrollListener } from './utils/onScroll'
 
 export default class WindowScroller extends Component {
-
-  static propTypes = {
-    /**
-     * Function responsible for rendering children.
-     * This function should implement the following signature:
-     * ({ height, scrollTop }) => PropTypes.element
-     */
-    children: PropTypes.func.isRequired,
-
-    /** Callback to be invoked on-resize: ({ height }) */
-    onResize: PropTypes.func.isRequired,
-
-    /** Callback to be invoked on-scroll: ({ scrollTop }) */
-    onScroll: PropTypes.func.isRequired
-  }
-
   static defaultProps = {
     onResize: () => {},
     onScroll: () => {}
@@ -120,5 +104,22 @@ export default class WindowScroller extends Component {
     })
 
     onScroll({ scrollTop })
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  WindowScroller.propTypes = {
+    /**
+     * Function responsible for rendering children.
+     * This function should implement the following signature:
+     * ({ height, scrollTop }) => PropTypes.element
+     */
+    children: PropTypes.func.isRequired,
+
+    /** Callback to be invoked on-resize: ({ height }) */
+    onResize: PropTypes.func.isRequired,
+
+    /** Callback to be invoked on-scroll: ({ scrollTop }) */
+    onScroll: PropTypes.func.isRequired
   }
 }


### PR DESCRIPTION
As react doesn't check proptypes in production, there is no point in keeping them in the build. Removing them make the build size ever so slightly smaller.

~~While I didn't see tests passing locally, they don't seem to be passing on master, either.~~ If CI says its good, then its good!

