### PR TITLE
Add support for id prop to components

### DIFF
--- a/docs/Collection.md
+++ b/docs/Collection.md
@@ -10,13 +10,14 @@ Unlike `Grid`, which renders checkerboard data, `Collection` can render arbitrar
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
 | autoHeight | Boolean |  | Outer `height` of `Collection` is set to "auto". This property should only be used in conjunction with the `WindowScroller` HOC. |
-| className | String |  | Optional custom CSS class name to attach to root Collection element. |
+| className | String |  | Optional custom CSS class name to attach to root `Collection` element. |
 | cellCount | Number | ✓ | Number of cells in collection. |
 | cellGroupRenderer | Function |  | Responsible for rendering a group of cells given their indices.: `({ cellSizeAndPositionGetter:Function, indices: Array<number>, cellRenderer: Function }): Array<PropTypes.node>` |
 | cellRenderer | Function | ✓ | Responsible for rendering a cell given an row and column index: `({ index: number, isScrolling: boolean, key: string, style: object }): PropTypes.element` |
 | cellSizeAndPositionGetter | Function | ✓ | Callback responsible for returning size and offset/position information for a given cell (index): `({ index: number }): { height: number, width: number, x: number, y: number }` |
 | height | Number | ✓ | Height of Collection; this property determines the number of visible (vs virtualized) rows. |
 | horizontalOverscanSize | Number |  | Enables the `Collection` to horiontally "overscan" its content similar to how `Grid` does. This can reduce flicker around the edges when a user scrolls quickly. This property defaults to `0`; |
+| id | String |  | Optional custom CSS id to attach to root `Collection` element. |
 | noContentRenderer | Function |  | Optional renderer to be rendered inside the grid when `cellCount` is 0: `(): PropTypes.node` |
 | onSectionRendered | Function |  | Callback invoked with information about the section of the Collection that was just rendered: `({ indices: Array<number> }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, clientWidth: number, scrollHeight: number, scrollLeft: number, scrollTop: number, scrollWidth: number }): void` |

--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -17,6 +17,7 @@ A windowed grid of elements. `Grid` only renders cells necessary to fill itself 
 | estimatedColumnSize | Number |  | Used to estimate the total width of a `Grid` before all of its columns have actually been measured. The estimated total width is adjusted as columns are rendered. |
 | estimatedRowSize | Number |  | Used to estimate the total height of a `Grid` before all of its rows have actually been measured. The estimated total height is adjusted as rows are rendered. |
 | height | Number | ✓ | Height of Grid; this property determines the number of visible (vs virtualized) rows. |
+| id | String |  | Optional custom CSS id to attach to root `Grid` element. |
 | noContentRenderer | Function |  | Optional renderer to be rendered inside the grid when either `rowCount` or `columnCount` is empty: `(): PropTypes.node` |
 | onSectionRendered | Function |  | Callback invoked with information about the section of the Grid that was just rendered. This callback is only invoked when visible rows have changed: `({ columnOverscanStartIndex: number, columnOverscanStopIndex: number, columnStartIndex: number, columnStopIndex: number, rowOverscanStartIndex: number, rowOverscanStopIndex: number, rowStartIndex: number, rowStopIndex: number }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, clientWidth: number, scrollHeight: number, scrollLeft: number, scrollTop: number, scrollWidth: number }): void` |
@@ -146,7 +147,7 @@ Responsible for rendering a single cell, given its row and column index.
 This function accepts the following named parameters:
 
 ```jsx
-function cellRenderer ({ 
+function cellRenderer ({
   columnIndex, // Horizontal (column) index of cell
   isScrolling, // The Grid is currently being scrolled
   key,         // Unique key within array of cells

--- a/docs/List.md
+++ b/docs/List.md
@@ -11,6 +11,7 @@ Elements can have fixed or varying heights.
 | className | String |  | Optional custom CSS class name to attach to root `List` element. |
 | estimatedRowSize | Number |  | Used to estimate the total height of a `List` before all of its rows have actually been measured. The estimated total height is adjusted as rows are rendered. |
 | height | Number | ✓ | Height constraint for list (determines how many actual rows are rendered) |
+| id | String |  | Optional custom CSS id to attach to root `List` element. |
 | noRowsRenderer | Function |  | Callback used to render placeholder content when `rowCount` is 0 |
 | onRowsRendered | Function |  | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number, scrollTop: number }): void` |

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -19,6 +19,7 @@ This component expects explicit `width` and `height` parameters.
 | headerHeight | Number | ✓ | Fixed height of header row |
 | headerStyle | Object |  | Optional custom inline style to attach to table header columns. |
 | height | Number | ✓ | Fixed/available height for out DOM element |
+| id | String |  | Optional custom CSS id to attach to root `Table` element. |
 | noRowsRenderer | Function |  | Callback used to render placeholder content when :rowCount is 0 |
 | onHeaderClick | Function |  | Callback invoked when a user clicks on a table header. `(dataKey: string, columnData: any): void` |
 | onRowClick | Function |  | Callback invoked when a user clicks on a table row. `({ index: number }): void` |

--- a/source/Collection/Collection.test.js
+++ b/source/Collection/Collection.test.js
@@ -421,7 +421,7 @@ describe('Collection', () => {
     })
   })
 
-  describe('styles and classeNames', () => {
+  describe('styles, classNames, and ids', () => {
     it('should use the expected global CSS classNames', () => {
       const rendered = findDOMNode(render(getMarkup()))
       expect(rendered.className).toEqual('ReactVirtualized__Collection')
@@ -430,6 +430,11 @@ describe('Collection', () => {
     it('should use a custom :className if specified', () => {
       const rendered = findDOMNode(render(getMarkup({ className: 'foo' })))
       expect(rendered.className).toContain('foo')
+    })
+
+    it('should use a custom :id if specified', () => {
+      const rendered = findDOMNode(render(getMarkup({ id: 'bar' })))
+      expect(rendered.id).toContain('bar')
     })
 
     it('should use a custom :style if specified', () => {

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -57,6 +57,11 @@ export default class CollectionView extends Component {
     height: PropTypes.number.isRequired,
 
     /**
+     * Optional custom CSS id to attach to root Collection element.
+     */
+    id: PropTypes.string,
+
+    /**
      * Enables the `Collection` to horiontally "overscan" its content similar to how `Grid` does.
      * This can reduce flicker around the edges when a user scrolls quickly.
      */
@@ -313,6 +318,7 @@ export default class CollectionView extends Component {
       className,
       height,
       horizontalOverscanSize,
+      id,
       noContentRenderer,
       style,
       verticalOverscanSize,
@@ -374,6 +380,7 @@ export default class CollectionView extends Component {
         }}
         aria-label={this.props['aria-label']}
         className={cn('ReactVirtualized__Collection', className)}
+        id={id}
         onScroll={this._onScroll}
         role='grid'
         style={{

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -106,6 +106,11 @@ export default class Grid extends Component {
     height: PropTypes.number.isRequired,
 
     /**
+     * Optional custom CSS id to attach to root Grid element.
+     */
+    id: PropTypes.string,
+
+    /**
      * Optional renderer to be used in place of rows when either :rowCount or :columnCount is 0.
      */
     noContentRenderer: PropTypes.func.isRequired,
@@ -492,6 +497,7 @@ export default class Grid extends Component {
       className,
       containerStyle,
       height,
+      id,
       noContentRenderer,
       style,
       tabIndex,
@@ -545,6 +551,7 @@ export default class Grid extends Component {
         }}
         aria-label={this.props['aria-label']}
         className={cn('ReactVirtualized__Grid', className)}
+        id={id}
         onScroll={this._onScroll}
         role='grid'
         style={{

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -591,7 +591,7 @@ describe('Grid', () => {
     })
   })
 
-  describe('styles and classNames', () => {
+  describe('styles, classNames, and ids', () => {
     it('should use the expected global CSS classNames', () => {
       const rendered = findDOMNode(render(getMarkup()))
       expect(rendered.className).toEqual('ReactVirtualized__Grid')
@@ -600,6 +600,11 @@ describe('Grid', () => {
     it('should use a custom :className if specified', () => {
       const rendered = findDOMNode(render(getMarkup({ className: 'foo' })))
       expect(rendered.className).toContain('foo')
+    })
+
+    it('should use a custom :id if specified', () => {
+      const rendered = findDOMNode(render(getMarkup({ id: 'bar' })))
+      expect(rendered.id).toContain('bar')
     })
 
     it('should use a custom :style if specified', () => {

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -34,6 +34,9 @@ export default class List extends Component {
     /** Height constraint for list (determines how many actual rows are rendered) */
     height: PropTypes.number.isRequired,
 
+    /** Optional CSS class id */
+    id: PropTypes.string,
+
     /** Optional renderer to be used in place of rows when rowCount is 0 */
     noRowsRenderer: PropTypes.func.isRequired,
 

--- a/source/List/List.test.js
+++ b/source/List/List.test.js
@@ -250,7 +250,7 @@ describe('List', () => {
     })
   })
 
-  describe('styles and classNames', () => {
+  describe('styles, classNames, and ids', () => {
     it('should use the expected global CSS classNames', () => {
       const node = findDOMNode(render(getMarkup()))
       expect(node.className).toContain('ReactVirtualized__List')
@@ -259,6 +259,11 @@ describe('List', () => {
     it('should use a custom :className if specified', () => {
       const node = findDOMNode(render(getMarkup({ className: 'foo' })))
       expect(node.className).toContain('foo')
+    })
+
+    it('should use a custom :id if specified', () => {
+      const node = findDOMNode(render(getMarkup({ id: 'bar' })))
+      expect(node.id).toContain('bar')
     })
 
     it('should use a custom :style if specified', () => {

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -59,6 +59,9 @@ export default class Table extends Component {
     /** Fixed/available height for out DOM element */
     height: PropTypes.number.isRequired,
 
+    /** Optional CSS id */
+    id: PropTypes.string,
+
     /** Optional renderer to be used in place of table body rows when rowCount is 0 */
     noRowsRenderer: PropTypes.func,
 
@@ -249,6 +252,7 @@ export default class Table extends Component {
       gridStyle,
       headerHeight,
       height,
+      id,
       noRowsRenderer,
       rowClassName,
       rowStyle,
@@ -280,6 +284,7 @@ export default class Table extends Component {
     return (
       <div
         className={cn('ReactVirtualized__Table', className)}
+        id={id}
         style={style}
       >
         {!disableHeader && (

--- a/source/Table/Table.test.js
+++ b/source/Table/Table.test.js
@@ -654,7 +654,7 @@ describe('Table', () => {
     })
   })
 
-  describe('styles and classeNames', () => {
+  describe('styles, classNames, and ids', () => {
     it('should use the expected global CSS classNames', () => {
       const node = findDOMNode(render(getMarkup({
         sort: () => {},
@@ -679,6 +679,13 @@ describe('Table', () => {
       expect(node.className).toContain('foo')
       expect(node.querySelectorAll('.bar').length).toEqual(2)
       expect(node.querySelectorAll('.baz').length).toEqual(9)
+    })
+
+    it('should use a custom :id if specified', () => {
+      const node = findDOMNode(render(getMarkup({
+        id: 'bar'
+      })))
+      expect(node.id).toContain('bar')
     })
 
     it('should use custom :styles if specified', () => {


### PR DESCRIPTION
Closes https://github.com/bvaughn/react-virtualized/issues/441

This PR adds a new optional prop, `id`, to `List`, `Grid`, `Table`, and `Collection`, which lets users pass a CSS `id` down to the root nodes of those components for styling purposes. `className`s definitely preferred, but sometimes you have to use the nuclear option and pass an `id` for styling purposes. 😝 
