### PR TITLE
scrollToAlignment should be pull from props and not from state

### DIFF
--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -205,8 +205,8 @@ export default class CollectionView extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    const { height, scrollToCell, width } = this.props
-    const { scrollLeft, scrollPositionChangeReason, scrollToAlignment, scrollTop } = this.state
+    const { height, scrollToAlignment, scrollToCell, width } = this.props
+    const { scrollLeft, scrollPositionChangeReason, scrollTop } = this.state
 
     // Make sure requested changes to :scrollLeft or :scrollTop get applied.
     // Assigning to scrollLeft/scrollTop tells the browser to interrupt any running scroll animations,


### PR DESCRIPTION
ISSUE:  if you set a value to scrollToCell in a Collection component, when you scroll up or down the previous/next cells are not being rendered. This is happening in the Collection example (https://bvaughn.github.io/react-virtualized/#/components/Collection) as well.

ORIGIN: on `componentDidUpdate()` from CollectionView.js you were trying to pull scrollToAlignment value from `this.state` instead from `this.props` so it was always `undefined` making `scrollToAlignment !== prevProps.scrollToAlignment` being always true and `this._updateScrollPositionForScrollToCell()` always triggered.