### PR TITLE
Add basename to fix demo links

### DIFF
--- a/source/demo/Application.js
+++ b/source/demo/Application.js
@@ -53,7 +53,7 @@ export default class Application extends Component {
 
   render () {
     return (
-      <HashRouter>
+      <HashRouter basename=''>
         <div className={styles.demo}>
           <div className={styles.headerRow}>
             <div className={styles.logoRow}>


### PR DESCRIPTION
react-router links in the demo are broken when you try opening em in a new tab with cmd+click, middle-mouse button, or right-click. You can reproduce it by opening the demo and trying to open the wizard in a separate tab.

I'm not 100% sure this change fixes it, but it seems to work locally.

To test it out I copied the html entry point (`build/index.html` => `build/react-virtualized/index.html`) and updated the script tag's source (`static/demo.js` => `../static/demo.js`).  Opening links in a new tab seems to work for both of the following urls:

* `http://localhost:3001/#/wizard`
* `http://localhost:3001/react-virtualized/#/wizard`
