### PR TITLE
Fix getComputedStyle can return null

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -105,7 +105,7 @@ export default class AutoSizer extends Component {
     const height = boundingRect.height || 0
     const width = boundingRect.width || 0
 
-    const style = window.getComputedStyle(this._parentNode)
+    const style = window.getComputedStyle(this._parentNode) || {}
     const paddingLeft = parseInt(style.paddingLeft, 10) || 0
     const paddingRight = parseInt(style.paddingRight, 10) || 0
     const paddingTop = parseInt(style.paddingTop, 10) || 0

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -133,7 +133,10 @@ export default function createDetectElementResize () {
     if (attachEvent) element.attachEvent('onresize', fn);
     else {
       if (!element.__resizeTriggers__) {
-        if (_window.getComputedStyle(element).position == 'static') element.style.position = 'relative';
+        var elementStyle = _window.getComputedStyle(element);
+        if (elementStyle && elementStyle.position == 'static') {
+          element.style.position = 'relative';
+        }
         createStyles();
         element.__resizeLast__ = {};
         element.__resizeListeners__ = [];


### PR DESCRIPTION
getComputedStyle can return null if the element is not displayed, it must be considered.