### PR TITLE
Changed predictive overscan cell shifting to improve perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ------------
 
+##### 8.5.3
+Changed overscan rows/cols behavior as described [here](https://github.com/bvaughn/react-virtualized/pull/478).
+This change targets performance improvements only and should have no other noticeable impact.
+
 ##### 8.5.2
 Added guard against potential `null` return value from `getComputedStyle` for hidden elements (see PR #465).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.5.3",
+  "version": "8.5.3-beta",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.5.3-beta",
+  "version": "8.5.3",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import calculateSizeAndPositionDataAndUpdateScrollOffset from './utils/calculateSizeAndPositionDataAndUpdateScrollOffset'
 import ScalingCellSizeAndPositionManager from './utils/ScalingCellSizeAndPositionManager'
 import createCallbackMemoizer from '../utils/createCallbackMemoizer'
-import getOverscanIndices, { SCROLL_DIRECTION_BACKWARD, SCROLL_DIRECTION_FIXED, SCROLL_DIRECTION_FORWARD } from './utils/getOverscanIndices'
+import getOverscanIndices, { SCROLL_DIRECTION_BACKWARD, SCROLL_DIRECTION_FORWARD } from './utils/getOverscanIndices'
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize'
 import shallowCompare from 'react-addons-shallow-compare'
 import updateScrollIndexHelper from './utils/updateScrollIndexHelper'
@@ -210,8 +210,8 @@ export default class Grid extends Component {
 
     this.state = {
       isScrolling: false,
-      scrollDirectionHorizontal: SCROLL_DIRECTION_FIXED,
-      scrollDirectionVertical: SCROLL_DIRECTION_FIXED,
+      scrollDirectionHorizontal: SCROLL_DIRECTION_FORWARD,
+      scrollDirectionVertical: SCROLL_DIRECTION_FORWARD,
       scrollLeft: 0,
       scrollTop: 0
     }
@@ -705,9 +705,7 @@ export default class Grid extends Component {
     this._cellCache = {}
 
     this.setState({
-      isScrolling: false,
-      scrollDirectionHorizontal: SCROLL_DIRECTION_FIXED,
-      scrollDirectionVertical: SCROLL_DIRECTION_FIXED
+      isScrolling: false
     })
   }
 

--- a/source/Grid/utils/getOverscanIndices.js
+++ b/source/Grid/utils/getOverscanIndices.js
@@ -1,5 +1,4 @@
 export const SCROLL_DIRECTION_BACKWARD = -1
-export const SCROLL_DIRECTION_FIXED = 0
 export const SCROLL_DIRECTION_FORWARD = 1
 
 /**
@@ -16,15 +15,15 @@ export default function getOverscanIndices ({ cellCount, overscanCellsCount, scr
   let overscanStartIndex
   let overscanStopIndex
 
-  if (scrollDirection === SCROLL_DIRECTION_FORWARD) {
-    overscanStartIndex = startIndex
-    overscanStopIndex = stopIndex + overscanCellsCount * 2
-  } else if (scrollDirection === SCROLL_DIRECTION_BACKWARD) {
-    overscanStartIndex = startIndex - overscanCellsCount * 2
-    overscanStopIndex = stopIndex
-  } else {
-    overscanStartIndex = startIndex - overscanCellsCount
-    overscanStopIndex = stopIndex + overscanCellsCount
+  switch (scrollDirection) {
+    case SCROLL_DIRECTION_FORWARD:
+      overscanStartIndex = startIndex
+      overscanStopIndex = stopIndex + overscanCellsCount
+      break
+    case SCROLL_DIRECTION_BACKWARD:
+      overscanStartIndex = startIndex - overscanCellsCount
+      overscanStopIndex = stopIndex
+      break
   }
 
   return {

--- a/source/Grid/utils/getOverscanIndices.test.js
+++ b/source/Grid/utils/getOverscanIndices.test.js
@@ -1,11 +1,16 @@
 import getOverscanIndices, {
   SCROLL_DIRECTION_BACKWARD,
-  SCROLL_DIRECTION_FIXED,
   SCROLL_DIRECTION_FORWARD
 } from './getOverscanIndices'
 
 describe('getOverscanIndices', () => {
-  function testHelper (cellCount, startIndex, stopIndex, overscanCellsCount, scrollDirection = SCROLL_DIRECTION_FIXED) {
+  function testHelper ({
+    cellCount,
+    startIndex,
+    stopIndex,
+    overscanCellsCount,
+    scrollDirection
+  }) {
     return getOverscanIndices({
       cellCount,
       overscanCellsCount,
@@ -16,41 +21,89 @@ describe('getOverscanIndices', () => {
   }
 
   it('should not overscan if :overscanCellsCount is 0', () => {
-    expect(testHelper(100, 10, 20, 0)).toEqual({
+    expect(
+      testHelper({
+        cellCount: 100,
+        startIndex: 10,
+        stopIndex: 20,
+        overscanCellsCount: 0,
+        scrollDirection: SCROLL_DIRECTION_BACKWARD
+      })
+    ).toEqual({
+      overscanStartIndex: 10,
+      overscanStopIndex: 20
+    })
+
+    expect(
+      testHelper({
+        cellCount: 100,
+        startIndex: 10,
+        stopIndex: 20,
+        overscanCellsCount: 0,
+        scrollDirection: SCROLL_DIRECTION_FORWARD
+      })
+    ).toEqual({
       overscanStartIndex: 10,
       overscanStopIndex: 20
     })
   })
 
-  it('should overscan by the specified :overscanCellsCount', () => {
-    expect(testHelper(100, 10, 20, 10)).toEqual({
-      overscanStartIndex: 0,
-      overscanStopIndex: 30
+  it('should overscan forward', () => {
+    expect(
+      testHelper({
+        cellCount: 100,
+        startIndex: 20,
+        stopIndex: 30,
+        overscanCellsCount: 10,
+        scrollDirection: SCROLL_DIRECTION_FORWARD
+      })
+    ).toEqual({
+      overscanStartIndex: 20,
+      overscanStopIndex: 40
     })
   })
 
-  it('should double the overscan in the direction being scrolled', () => {
-    expect(testHelper(100, 20, 30, 10, SCROLL_DIRECTION_FORWARD)).toEqual({
-      overscanStartIndex: 20,
-      overscanStopIndex: 50
-    })
-
-    expect(testHelper(100, 20, 30, 10, SCROLL_DIRECTION_BACKWARD)).toEqual({
-      overscanStartIndex: 0,
+  it('should overscan backward', () => {
+    expect(
+      testHelper({
+        cellCount: 100,
+        startIndex: 20,
+        stopIndex: 30,
+        overscanCellsCount: 10,
+        scrollDirection: SCROLL_DIRECTION_BACKWARD
+      })
+    ).toEqual({
+      overscanStartIndex: 10,
       overscanStopIndex: 30
     })
   })
 
   it('should not overscan beyond the start of the list', () => {
-    expect(testHelper(100, 5, 15, 10)).toEqual({
+    expect(
+      testHelper({
+        cellCount: 100,
+        startIndex: 5,
+        stopIndex: 15,
+        overscanCellsCount: 10,
+        scrollDirection: SCROLL_DIRECTION_BACKWARD
+      })
+    ).toEqual({
       overscanStartIndex: 0,
-      overscanStopIndex: 25
+      overscanStopIndex: 15
     })
   })
 
   it('should not overscan beyond the end of the list', () => {
-    expect(testHelper(25, 10, 20, 10)).toEqual({
-      overscanStartIndex: 0,
+    expect(
+      testHelper({
+        cellCount: 25,
+        startIndex: 10,
+        stopIndex: 20,
+        overscanCellsCount: 10,
+        scrollDirection: SCROLL_DIRECTION_FORWARD
+      })
+    ).toEqual({
+      overscanStartIndex: 10,
       overscanStopIndex: 24
     })
   })

--- a/source/List/List.test.js
+++ b/source/List/List.test.js
@@ -296,7 +296,7 @@ describe('List', () => {
         overscanRowCount: 10,
         scrollToIndex: 30
       }))
-      expect(overscanStartIndex).toEqual(11)
+      expect(overscanStartIndex).toEqual(21)
       expect(startIndex).toEqual(21)
       expect(stopIndex).toEqual(30)
       expect(overscanStopIndex).toEqual(40)

--- a/source/Table/Table.test.js
+++ b/source/Table/Table.test.js
@@ -778,7 +778,7 @@ describe('Table', () => {
         overscanRowCount: 10,
         scrollToIndex: 30
       }))
-      expect(overscanStartIndex).toEqual(13)
+      expect(overscanStartIndex).toEqual(23)
       expect(startIndex).toEqual(23)
       expect(stopIndex).toEqual(30)
       expect(overscanStopIndex).toEqual(40)


### PR DESCRIPTION
## How does overscan work now?

Background information: [This](https://bvaughn.github.io/connect-tech-2016/#/22/9) is how react-virtualized overscanning works.

For simplicity I'll mention rows only. Columns work the same though. It works like this:

1) Overscanned rows are initially rendered above and below your visible rows (eg overscan of 5 means 5 rows above, 5 rows below)
2) When you start scrolling, overscanned rows are stacked in the direction you're scrolling, to help cut down on visible lag (eg overscan of 5 means 0 rows above, 10 rows below)
3) Once you stop scrolling, react-virtualized returns to its default behavior (eg overscan of 5 means 5 rows above, 5 rows below)

## How is overscan changing?

This PR changes that behavior so that:

1) Overscanned rows are initially rendered below your visible rows (eg overscan of 5 means 5 rows below)
2) If you scroll down, nothing changes. If you scroll up, overscanned rows are shifted (eg 5 above, 0 below).
3) When you stop scrolling, nothing changes- until/unless you change scroll direction.

## Why the change?

React reinstantiates components that have been unmounted and remounted. If components are expensive this leads to a perforamnce hit. RV changing overscan on scroll-stop caused half of the overscanned rows to be reinstantiated due to this (since half of the cells were previously unmounted- _even if their elements_ were cached).

This changeset modifies the shifting behavior. Predictive shifting will remain until/unless scroll direction is reversed, in which case it will be reversed as well. Hopefully this should not have any noticeable impact on UX regarding 'scroll lag' around the edges of the list being scrolled.

It may further help performance as RV was previously doubling down on the number of rows/cols being rendered in the direction being scrolled. (I think this was the wrong initial implementation, but...live and learn.) Now it will render only the exact number specified by the overscan props.

## Test the build

I'd love for you to give this change a test before I release it. You can install the beta release:

```
npm install react-virtualized@8.5.3-beta
```