### PR TITLE
Update CellMeasurer.md

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -174,14 +174,15 @@ For example:
 ```jsx
 import { CellMeasurer, List } from 'react-virtualized';
 
-function renderList (listProps) {
+function renderList(listProps, cellMeasurerProps = Object.create(null)) {
   return (
     <CellMeasurer
-      {...listProps}
+      rowCount={listProps.rowCount}
       cellRenderer={
         ({ rowIndex, ...rest }) => listProps.rowRenderer({ index: rowIndex, ...rest })
       }
       columnCount={1}
+      {...cellMeasurerProps}
     >
       {({ getRowHeight }) => (
         <List

--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -174,7 +174,7 @@ For example:
 ```jsx
 import { CellMeasurer, List } from 'react-virtualized';
 
-function renderList(listProps, cellMeasurerProps = Object.create(null)) {
+function renderList(listProps, cellMeasurerProps) {
   return (
     <CellMeasurer
       rowCount={listProps.rowCount}

--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -174,7 +174,7 @@ For example:
 ```jsx
 import { CellMeasurer, List } from 'react-virtualized';
 
-function renderList(listProps, cellMeasurerProps) {
+function renderList(listProps, cellMeasurerProps = Object.create(null)) {
   return (
     <CellMeasurer
       rowCount={listProps.rowCount}


### PR DESCRIPTION
While it may be tempting to share the `List` props with the `CellMeasurer` I think it is best to explicitly call them out rather than spreading the `List` props over the `CellMeasurer` as this could lead to potential conflict by setting a prop you may not have intended to set (e.g. `ref`, `width`, or `height`)

I know this is just an example, but many (most?) people will copy and paste this and it could lead to rather insidious bugs.