### PR TITLE
Add custom element option to WindowScroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 8.7.1
+Reverted part of the change introduced in version 8.6.0 that changed the behavior regarding controlled/uncontrolled `scrollTop` and `scrollLeft` props and `Grid` in a way that was not backwards compatible. (See issue #490 for more.)
+
 ##### 8.7.0
 Added `updatePosition` to `WindowScroller` to handle case when header items change or resize. `WindowScroller` also better handles window resize events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ------------
 
-##### 8.6.0 (pending)
+##### 8.6.0
 `CellMeasurer` passes `index` param (duplicate of `rowIndex`) in order to more easily integrate with `List` by default.
 
 `Grid` now better handles a mix of controlled and uncontrolled scroll offsets. Previously changes to one offset would wipe out the other causing cells to disappear (see PR #482). This is an edge-case bug and only impacted an uncommon usecase for `Grid`. As such this change is expected to only impact only a small percetange of users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 8.6.0 (pending)
+`CellMeasurer` passes `index` param (duplicate of `rowIndex`) in order to more easily integrate with `List` by default.
+
 ##### 8.5.3
 Changed overscan rows/cols behavior as described [here](https://github.com/bvaughn/react-virtualized/pull/478).
 This change targets performance improvements only and should have no other noticeable impact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 8.6.1
+Updated `CellSizeCache` interface for the better perfomance by removing `has` methods, reducing a double hashtable lookup to a single lookup. Special thanks to @arusakov for this contribution!
+
 ##### 8.6.0
 `CellMeasurer` passes `index` param (duplicate of `rowIndex`) in order to more easily integrate with `List` by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ------------
 
+##### 8.7.0
+Added `updatePosition` to `WindowScroller` to handle case when header items change or resize. `WindowScroller` also better handles window resize events.
+
 ##### 8.6.1
 Updated `CellSizeCache` interface for the better perfomance by removing `has` methods, reducing a double hashtable lookup to a single lookup. Special thanks to @arusakov for this contribution!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 ##### 8.6.0 (pending)
 `CellMeasurer` passes `index` param (duplicate of `rowIndex`) in order to more easily integrate with `List` by default.
 
+`Grid` now better handles a mix of controlled and uncontrolled scroll offsets. Previously changes to one offset would wipe out the other causing cells to disappear (see PR #482). This is an edge-case bug and only impacted an uncommon usecase for `Grid`. As such this change is expected to only impact only a small percetange of users.
+
 ##### 8.5.3
 Changed overscan rows/cols behavior as described [here](https://github.com/bvaughn/react-virtualized/pull/478).
 This change targets performance improvements only and should have no other noticeable impact.

--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -43,10 +43,8 @@ class CellSizeCache {
   clearAllRowHeights (): void;
   clearColumnWidth (index: number): void;
   clearRowHeight (index: number): void;
-  getColumnWidth (index: number): number;
-  getRowHeight (index: number): number;
-  hasColumnWidth (index: number): boolean;
-  hasRowHeight (index: number): boolean;
+  getColumnWidth (index: number): number | undefined | null;
+  getRowHeight (index: number): number | undefined | null;
   setColumnWidth (index: number, width: number): void;
   setRowHeight (index: number, height: number): void;
 }

--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -162,33 +162,3 @@ For this reason it may not be a good idea to use this HOC for `Grid`s containing
 
 Since this component measures one cell at a time to determine it's width/height, it will likely be slow if a user skips many rows (or columns) at once by scrolling with a scrollbar or via a scroll-to-cell prop.
 There is (unfortunately) no workaround for this performance limitation at the moment.
-
-### Using `CellMeasurer` with `List`
-
-This HOC is intended for use with a `Grid`.
-That means it passes `cellRenderer` the same named index parameter used by `Grid` (`rowIndex`).
-However the `rowRenderer` used by `List` expects a slightly different named index parameter (`index`).
-To use `CellMeasurerer` with `List` then you need to provide an adapter method that converts the param names.
-For example:
-
-```jsx
-import { CellMeasurer, List } from 'react-virtualized';
-
-function renderList(listProps, cellMeasurerProps = Object.create(null)) {
-  return (
-    <CellMeasurer
-      {...cellMeasurerProps}
-      columnCount={1}
-      rowCount={listProps.rowCount}
-      cellRenderer={listProps.rowRenderer}
-    >
-      {({ getRowHeight }) => (
-        <List
-          {...listProps}
-          rowHeight={getRowHeight}
-        />
-      )}
-    </CellMeasurer>
-  )
-}
-```

--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -12,7 +12,7 @@ This is an advanced component and has some limitations and performance considera
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
-| cellRenderer | Function | ✓ | Renders a cell given its indices. `({ columnIndex: number, rowIndex: number }): PropTypes.node` |
+| cellRenderer | Function | ✓ | Renders a cell given its indices. `({ columnIndex: number, rowIndex: number, index: number }): PropTypes.node`.<br/>**NOTE**: `index` is just an alias to `rowIndex` |
 | cellSizeCache | Object |  | Optional, custom caching strategy for cell sizes. Learn more [here](#cellsizecache). |
 | children | Function | ✓ | Function responsible for rendering a virtualized component; `({ getColumnWidth: Function, getRowHeight: Function, resetMeasurements: Function }) => PropTypes.element` |
 | columnCount | number | ✓ | Number of columns in the `Grid`; in order to measure a row's height, all of that row's columns must be rendered. |
@@ -178,11 +178,9 @@ function renderList(listProps, cellMeasurerProps = Object.create(null)) {
   return (
     <CellMeasurer
       {...cellMeasurerProps}
-      cellRenderer={
-        ({ rowIndex, ...rest }) => listProps.rowRenderer({ index: rowIndex, ...rest })
-      }
       columnCount={1}
       rowCount={listProps.rowCount}
+      cellRenderer={listProps.rowRenderer}
     >
       {({ getRowHeight }) => (
         <List

--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -14,6 +14,14 @@ This may change with a future release but for the time being this HOC is should 
 | onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number })`. | 
 | onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number })`. | 
 
+### Public Methods
+
+##### updatePosition
+
+Recalculates scroll position from the top of page.
+
+This methoed is automatically triggered when the component mounts as well as when the browser resizes. It should be manually called if the page header (eg any items in the DOM "above" the `WindowScroller`) resizes or changes.
+
 ### Examples
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.5.3",
+  "version": "8.6.0",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.6.1",
+  "version": "8.7.0",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -189,8 +189,8 @@ export default class CellMeasurer extends Component {
 
     const rendered = cellRenderer({
       columnIndex,
-      rowIndex,
-      index: rowIndex // List component `rowRenderer` compatibility
+      index: rowIndex, // Simplify List :rowRenderer use case
+      rowIndex
     })
 
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -190,7 +190,7 @@ export default class CellMeasurer extends Component {
     const rendered = cellRenderer({
       columnIndex,
       rowIndex,
-      index: rowIndex, // List component `rowRenderer` compatibility
+      index: rowIndex // List component `rowRenderer` compatibility
     })
 
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -71,8 +71,9 @@ export default class CellMeasurer extends Component {
   }
 
   getColumnWidth ({ index }) {
-    if (this._cellSizeCache.hasColumnWidth(index)) {
-      return this._cellSizeCache.getColumnWidth(index)
+    const columnWidth = this._cellSizeCache.getColumnWidth(index)
+    if (columnWidth != null) {
+      return columnWidth
     }
 
     const { rowCount } = this.props
@@ -95,8 +96,9 @@ export default class CellMeasurer extends Component {
   }
 
   getRowHeight ({ index }) {
-    if (this._cellSizeCache.hasRowHeight(index)) {
-      return this._cellSizeCache.getRowHeight(index)
+    const rowHeight = this._cellSizeCache.getRowHeight(index)
+    if (rowHeight != null) {
+      return rowHeight
     }
 
     const { columnCount } = this.props

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -189,7 +189,8 @@ export default class CellMeasurer extends Component {
 
     const rendered = cellRenderer({
       columnIndex,
-      rowIndex
+      rowIndex,
+      index: rowIndex, // List component `rowRenderer` compatibility
     })
 
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).

--- a/source/CellMeasurer/CellMeasurer.test.js
+++ b/source/CellMeasurer/CellMeasurer.test.js
@@ -284,19 +284,17 @@ describe('CellMeasurer', () => {
       rowHeight: 50
     })
 
-    expect(customCellSizeCache.hasColumnWidth(0)).toEqual(false)
+    expect(customCellSizeCache.getColumnWidth(0)).toEqual(undefined)
     expect(cellRendererParams.length).toEqual(0)
     expect(getColumnWidth({ index: 0 })).toEqual(200)
-    expect(customCellSizeCache.hasColumnWidth(0)).toEqual(true)
     expect(customCellSizeCache.getColumnWidth(0)).toEqual(200)
     expect(cellRendererParams.length).toEqual(2)
     expect(getColumnWidth({ index: 0 })).toEqual(200)
     expect(cellRendererParams.length).toEqual(2)
 
-    expect(customCellSizeCache.hasRowHeight(0)).toEqual(false)
+    expect(customCellSizeCache.getRowHeight(0)).toEqual(undefined)
     expect(cellRendererParams.length).toEqual(2)
     expect(getRowHeight({ index: 0 })).toEqual(50)
-    expect(customCellSizeCache.hasRowHeight(0)).toEqual(true)
     expect(customCellSizeCache.getRowHeight(0)).toEqual(50)
     expect(cellRendererParams.length).toEqual(7)
     expect(getRowHeight({ index: 0 })).toEqual(50)
@@ -313,9 +311,9 @@ describe('CellMeasurer', () => {
       columnCount: 5,
       columnWidth: 200
     })
-    expect(customCellSizeCacheA.hasColumnWidth(0)).toEqual(false)
+    expect(customCellSizeCacheA.getColumnWidth(0)).toEqual(undefined)
     expect(getColumnWidthA({ index: 0 })).toEqual(200)
-    expect(customCellSizeCacheA.hasColumnWidth(0)).toEqual(true)
+    expect(customCellSizeCacheA.getColumnWidth(0)).toEqual(200)
 
     const { getColumnWidth: getColumnWidthB } = renderHelper({
       cellRenderer,
@@ -323,9 +321,9 @@ describe('CellMeasurer', () => {
       columnCount: 5,
       columnWidth: 100
     })
-    expect(customCellSizeCacheA.hasColumnWidth(0)).toEqual(true)
+    expect(customCellSizeCacheA.getColumnWidth(0)).toEqual(200)
     expect(getColumnWidthB({ index: 0 })).toEqual(200)
-    expect(customCellSizeCacheA.hasColumnWidth(0)).toEqual(true)
+    expect(customCellSizeCacheA.getColumnWidth(0)).toEqual(200)
 
     const { getColumnWidth: getColumnWidthC } = renderHelper({
       cellRenderer,
@@ -333,9 +331,9 @@ describe('CellMeasurer', () => {
       columnCount: 5,
       columnWidth: 50
     })
-    expect(customCellSizeCacheB.hasColumnWidth(0)).toEqual(false)
+    expect(customCellSizeCacheB.getColumnWidth(0)).toEqual(undefined)
     expect(getColumnWidthC({ index: 0 })).toEqual(50)
-    expect(customCellSizeCacheB.hasColumnWidth(0)).toEqual(true)
+    expect(customCellSizeCacheB.getColumnWidth(0)).toEqual(50)
   })
 
   it('should calculate row height just once when using the alternative uniform-size cell size cache', () => {

--- a/source/CellMeasurer/CellMeasurer.test.js
+++ b/source/CellMeasurer/CellMeasurer.test.js
@@ -72,7 +72,7 @@ describe('CellMeasurer', () => {
     })
     expect(cellRendererParams).toEqual([])
     expect(getRowHeight({ index: 0 })).toEqual(75)
-    expect(cellRendererParams).toEqual([{ columnIndex: 0, rowIndex: 0 }])
+    expect(cellRendererParams).toEqual([{ columnIndex: 0, index: 0, rowIndex: 0 }])
     expect(getColumnWidth({ index: 0 })).toEqual(100)
 
     // For some reason this explicit unmount is necessary.
@@ -94,7 +94,7 @@ describe('CellMeasurer', () => {
     })
     expect(cellRendererParams).toEqual([])
     expect(getColumnWidth({ index: 0 })).toEqual(125)
-    expect(cellRendererParams).toEqual([{ columnIndex: 0, rowIndex: 0 }])
+    expect(cellRendererParams).toEqual([{ columnIndex: 0, index: 0, rowIndex: 0 }])
     expect(getRowHeight({ index: 0 })).toEqual(50)
   })
 
@@ -136,6 +136,23 @@ describe('CellMeasurer', () => {
     expect(getRowHeight({ index: 0 })).toEqual(50)
   })
 
+  it('should support :rowRenderer via :index param for easier List integration', () => {
+    const {
+      cellRenderer,
+      cellRendererParams
+    } = createCellRenderer()
+    const { getColumnWidth } = renderHelper({
+      cellRenderer,
+      rowCount: 5,
+      rowHeight: 50
+    })
+    getColumnWidth({ index: 0 })
+    expect(cellRendererParams.length).toEqual(5)
+    for (let i = 0; i < 5; i++) {
+      expect(cellRendererParams[i].index).toEqual(i)
+    }
+  })
+
   it('should cache cell measurements once a cell has been rendered', () => {
     const {
       cellRenderer,
@@ -149,15 +166,15 @@ describe('CellMeasurer', () => {
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 }
     ])
 
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 }
     ])
   })
 
@@ -175,8 +192,8 @@ describe('CellMeasurer', () => {
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 }
     ])
 
     resetMeasurements()
@@ -184,10 +201,10 @@ describe('CellMeasurer', () => {
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 },
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 },
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 }
     ])
   })
 
@@ -205,8 +222,8 @@ describe('CellMeasurer', () => {
     getColumnWidth({ index: 0 })
     getColumnWidth({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 1, rowIndex: 0 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 1, index: 0, rowIndex: 0 }
     ])
 
     resetMeasurementForColumn(0)
@@ -214,9 +231,9 @@ describe('CellMeasurer', () => {
     getColumnWidth({ index: 0 })
     getColumnWidth({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 1, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 0 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 1, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 0, rowIndex: 0 }
     ])
   })
 
@@ -234,8 +251,8 @@ describe('CellMeasurer', () => {
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 }
     ])
 
     resetMeasurementForRow(0)
@@ -243,9 +260,9 @@ describe('CellMeasurer', () => {
     getRowHeight({ index: 0 })
     getRowHeight({ index: 1 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 },
-      { columnIndex: 0, rowIndex: 1 },
-      { columnIndex: 0, rowIndex: 0 }
+      { columnIndex: 0, index: 0, rowIndex: 0 },
+      { columnIndex: 0, index: 1, rowIndex: 1 },
+      { columnIndex: 0, index: 0, rowIndex: 0 }
     ])
   })
 
@@ -342,7 +359,7 @@ describe('CellMeasurer', () => {
     const height2 = getRowHeight({ index: 1 })
     const height3 = getRowHeight({ index: 0 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 }
+      { columnIndex: 0, index: 0, rowIndex: 0 }
     ])
 
     const expectedHeight = HEIGHTS[0]
@@ -373,7 +390,7 @@ describe('CellMeasurer', () => {
     const width2 = getColumnWidth({ index: 1 })
     const width3 = getColumnWidth({ index: 0 })
     expect(cellRendererParams).toEqual([
-      { columnIndex: 0, rowIndex: 0 }
+      { columnIndex: 0, index: 0, rowIndex: 0 }
     ])
 
     const expectedWidth = WIDTHS[0]

--- a/source/CellMeasurer/defaultCellSizeCache.js
+++ b/source/CellMeasurer/defaultCellSizeCache.js
@@ -11,6 +11,9 @@ export default class CellSizeCache {
     this._uniformRowHeight = uniformRowHeight
     this._uniformColumnWidth = uniformColumnWidth
 
+    this._cachedColumnWidth = undefined
+    this._cachedRowHeight = undefined
+
     this._cachedColumnWidths = {}
     this._cachedRowHeights = {}
   }
@@ -37,28 +40,16 @@ export default class CellSizeCache {
     delete this._cachedRowHeights[index]
   }
 
-  getColumnWidth (index: number): number {
+  getColumnWidth (index: number): ?number {
     return this._uniformColumnWidth
       ? this._cachedColumnWidth
       : this._cachedColumnWidths[index]
   }
 
-  getRowHeight (index: number): number {
+  getRowHeight (index: number): ?number {
     return this._uniformRowHeight
       ? this._cachedRowHeight
       : this._cachedRowHeights[index]
-  }
-
-  hasColumnWidth (index: number): boolean {
-    return this._uniformColumnWidth
-      ? !!this._cachedColumnWidth
-      : !!this._cachedColumnWidths[index]
-  }
-
-  hasRowHeight (index: number): boolean {
-    return this._uniformRowHeight
-      ? !!this._cachedRowHeight
-      : !!this._cachedRowHeights[index]
   }
 
   setColumnWidth (index: number, width: number) {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -871,27 +871,18 @@ export default class Grid extends Component {
       this.state.scrollLeft !== scrollLeft ||
       this.state.scrollTop !== scrollTop
     ) {
-      const newState = {
+      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
+      const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+      const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+
+      this.setState({
         isScrolling: true,
-        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED
-      }
-
-      // For each axis, only update the internal scroll state if it is not already being controlled by the parent component.
-      // In each case, also track the scrolling direction as it is used for overscanning.
-      if (this.props.scrollLeft === undefined) {
-        newState.scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft
-          ? SCROLL_DIRECTION_FORWARD
-          : SCROLL_DIRECTION_BACKWARD
-        newState.scrollLeft = scrollLeft
-      }
-      if (this.props.scrollTop === undefined) {
-        newState.scrollDirectionVertical = scrollTop > this.state.scrollTop
-          ? SCROLL_DIRECTION_FORWARD
-          : SCROLL_DIRECTION_BACKWARD
-        newState.scrollTop = scrollTop
-      }
-
-      this.setState(newState)
+        scrollDirectionHorizontal,
+        scrollDirectionVertical,
+        scrollLeft,
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED,
+        scrollTop
+      })
     }
 
     this._invokeOnScrollMemoizer({ scrollLeft, scrollTop, totalColumnsWidth, totalRowsHeight })

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -766,10 +766,16 @@ export default class Grid extends Component {
     }
 
     if (scrollLeft >= 0) {
+      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
+      const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+      newState.scrollDirectionHorizontal = scrollDirectionHorizontal
       newState.scrollLeft = scrollLeft
     }
 
     if (scrollTop >= 0) {
+      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
+      const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+      newState.scrollDirectionVertical = scrollDirectionVertical
       newState.scrollTop = scrollTop
     }
 
@@ -865,18 +871,30 @@ export default class Grid extends Component {
       this.state.scrollLeft !== scrollLeft ||
       this.state.scrollTop !== scrollTop
     ) {
-      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
-      const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-      const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-
-      this.setState({
+      const newState = {
         isScrolling: true,
-        scrollDirectionHorizontal,
-        scrollDirectionVertical,
-        scrollLeft,
-        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED,
-        scrollTop
-      })
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED
+      }
+
+      // For each axis, only update the internal scroll state if it is not already being controlled
+      // by the parent component.
+
+      // In each case, also track the scrolling direction so we can more efficiently overscan rows
+      // to reduce empty space around the edges while scrolling.
+
+      if (this.props.scrollLeft === undefined) {
+        const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+        newState.scrollDirectionHorizontal = scrollDirectionHorizontal
+        newState.scrollLeft = scrollLeft
+      }
+
+      if (this.props.scrollTop === undefined) {
+        const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
+        newState.scrollDirectionVertical = scrollDirectionVertical
+        newState.scrollTop = scrollTop
+      }
+
+      this.setState(newState)
     }
 
     this._invokeOnScrollMemoizer({ scrollLeft, scrollTop, totalColumnsWidth, totalRowsHeight })

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -766,16 +766,16 @@ export default class Grid extends Component {
     }
 
     if (scrollLeft >= 0) {
-      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
-      const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-      newState.scrollDirectionHorizontal = scrollDirectionHorizontal
+      newState.scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft
+        ? SCROLL_DIRECTION_FORWARD
+        : SCROLL_DIRECTION_BACKWARD
       newState.scrollLeft = scrollLeft
     }
 
     if (scrollTop >= 0) {
-      // Track scrolling direction so we can more efficiently overscan rows to reduce empty space around the edges while scrolling.
-      const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-      newState.scrollDirectionVertical = scrollDirectionVertical
+      newState.scrollDirectionVertical = scrollTop > this.state.scrollTop
+        ? SCROLL_DIRECTION_FORWARD
+        : SCROLL_DIRECTION_BACKWARD
       newState.scrollTop = scrollTop
     }
 
@@ -876,21 +876,18 @@ export default class Grid extends Component {
         scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED
       }
 
-      // For each axis, only update the internal scroll state if it is not already being controlled
-      // by the parent component.
-
-      // In each case, also track the scrolling direction so we can more efficiently overscan rows
-      // to reduce empty space around the edges while scrolling.
-
+      // For each axis, only update the internal scroll state if it is not already being controlled by the parent component.
+      // In each case, also track the scrolling direction as it is used for overscanning.
       if (this.props.scrollLeft === undefined) {
-        const scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-        newState.scrollDirectionHorizontal = scrollDirectionHorizontal
+        newState.scrollDirectionHorizontal = scrollLeft > this.state.scrollLeft
+          ? SCROLL_DIRECTION_FORWARD
+          : SCROLL_DIRECTION_BACKWARD
         newState.scrollLeft = scrollLeft
       }
-
       if (this.props.scrollTop === undefined) {
-        const scrollDirectionVertical = scrollTop > this.state.scrollTop ? SCROLL_DIRECTION_FORWARD : SCROLL_DIRECTION_BACKWARD
-        newState.scrollDirectionVertical = scrollDirectionVertical
+        newState.scrollDirectionVertical = scrollTop > this.state.scrollTop
+          ? SCROLL_DIRECTION_FORWARD
+          : SCROLL_DIRECTION_BACKWARD
         newState.scrollTop = scrollTop
       }
 

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -889,41 +889,6 @@ describe('Grid', () => {
       expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
     })
 
-    it('should not change the scroll position or direction if the axis is controlled by the parent component', () => {
-      // Setting the scrollTop prop here implies it is controlled by the parent component
-      // (e.g. WindowScroller), while scrollLeft is controlled internally by the Grid
-      const grid = render(getMarkup({
-        scrollTop: 50
-      }))
-
-      expect(grid.state.scrollLeft).toEqual(0)
-      expect(grid.state.scrollTop).toEqual(50)
-      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
-      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
-
-      simulateScroll({
-        grid,
-        scrollLeft: 100,
-        scrollTop: 100
-      })
-
-      expect(grid.state.scrollLeft).toEqual(100)
-      expect(grid.state.scrollTop).toEqual(50)
-      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
-      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
-
-      simulateScroll({
-        grid,
-        scrollLeft: 0,
-        scrollTop: 0
-      })
-
-      expect(grid.state.scrollLeft).toEqual(0)
-      expect(grid.state.scrollTop).toEqual(50)
-      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_BACKWARD)
-      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
-    })
-
     it('should overscan in the direction being scrolled', async (done) => {
       const helper = createHelper()
 

--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -830,10 +830,16 @@ describe('Grid', () => {
     })
 
     it('should set the correct scroll direction', () => {
-      const grid = render(getMarkup({
+      // Do not pass in the initial state as props, otherwise the internal state is forbidden from
+      // updating itself
+      const grid = render(getMarkup())
+
+      // Simulate a scroll to set the initial internal state
+      simulateScroll({
+        grid,
         scrollLeft: 50,
         scrollTop: 50
-      }))
+      })
 
       expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
       expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
@@ -854,6 +860,67 @@ describe('Grid', () => {
       })
 
       expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
+    })
+
+    it('should set the correct scroll direction when scroll position is updated from props', () => {
+      let grid = render(getMarkup({
+        scrollLeft: 50,
+        scrollTop: 50
+      }))
+
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
+
+      grid = render(getMarkup({
+        scrollLeft: 0,
+        scrollTop: 0
+      }))
+
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_BACKWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_BACKWARD)
+
+      grid = render(getMarkup({
+        scrollLeft: 100,
+        scrollTop: 100
+      }))
+
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
+    })
+
+    it('should not change the scroll position or direction if the axis is controlled by the parent component', () => {
+      // Setting the scrollTop prop here implies it is controlled by the parent component
+      // (e.g. WindowScroller), while scrollLeft is controlled internally by the Grid
+      const grid = render(getMarkup({
+        scrollTop: 50
+      }))
+
+      expect(grid.state.scrollLeft).toEqual(0)
+      expect(grid.state.scrollTop).toEqual(50)
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
+
+      simulateScroll({
+        grid,
+        scrollLeft: 100,
+        scrollTop: 100
+      })
+
+      expect(grid.state.scrollLeft).toEqual(100)
+      expect(grid.state.scrollTop).toEqual(50)
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_FORWARD)
+      expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
+
+      simulateScroll({
+        grid,
+        scrollLeft: 0,
+        scrollTop: 0
+      })
+
+      expect(grid.state.scrollLeft).toEqual(0)
+      expect(grid.state.scrollTop).toEqual(50)
+      expect(grid.state.scrollDirectionHorizontal).toEqual(SCROLL_DIRECTION_BACKWARD)
       expect(grid.state.scrollDirectionVertical).toEqual(SCROLL_DIRECTION_FORWARD)
     })
 

--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -17,11 +17,17 @@ export default class AutoSizerExample extends Component {
   constructor (props) {
     super(props)
 
+    this.state = {
+      showHeaderText: true
+    }
+
+    this._hideHeader = this._hideHeader.bind(this)
     this._rowRenderer = this._rowRenderer.bind(this)
   }
 
   render () {
     const { list } = this.context
+    const { showHeaderText } = this.state
 
     return (
       <ContentBox>
@@ -31,13 +37,27 @@ export default class AutoSizerExample extends Component {
           docsLink='https://github.com/bvaughn/react-virtualized/blob/master/docs/WindowScroller.md'
         />
 
-        <ContentBoxParagraph>
-          This component decorates <code>List</code>, <code>Table</code>, or any other component
-          and manages the window scroll to scroll through the list
-        </ContentBoxParagraph>
+        {showHeaderText && (
+          <ContentBoxParagraph>
+            This component decorates <code>List</code>, <code>Table</code>, or any other component
+            and manages the window scroll to scroll through the list
+          </ContentBoxParagraph>
+        )}
+
+        {showHeaderText && (
+          <ContentBoxParagraph>
+            <button onClick={this._hideHeader}>
+              Hide header text
+            </button>
+          </ContentBoxParagraph>
+        )}
 
         <div className={styles.WindowScrollerWrapper}>
-          <WindowScroller>
+          <WindowScroller
+            ref={(ref) => {
+              this._windowScroller = ref
+            }}
+          >
             {({ height, isScrolling, scrollTop }) => (
               <AutoSizer disableHeight>
                 {({ width }) => (
@@ -45,9 +65,10 @@ export default class AutoSizerExample extends Component {
                     autoHeight
                     className={styles.List}
                     height={height}
+                    overscanRowCount={2}
                     rowCount={list.size}
                     rowHeight={30}
-                    rowRenderer={({ index, key, style }) => this._rowRenderer({ index, isScrolling, key, style })}
+                    rowRenderer={({ index, isVisible, key, style }) => this._rowRenderer({ index, isScrolling, isVisible, key, style })}
                     scrollTop={scrollTop}
                     width={width}
                   />
@@ -64,11 +85,22 @@ export default class AutoSizerExample extends Component {
     return shallowCompare(this, nextProps, nextState)
   }
 
-  _rowRenderer ({ index, isScrolling, key, style }) {
+  _hideHeader () {
+    const { showHeaderText } = this.state
+
+    this.setState({
+      showHeaderText: !showHeaderText
+    }, () => {
+      this._windowScroller.updatePosition()
+    })
+  }
+
+  _rowRenderer ({ index, isScrolling, isVisible, key, style }) {
     const { list } = this.context
     const row = list.get(index)
     const className = cn(styles.row, {
-      [styles.rowScrolling]: isScrolling
+      [styles.rowScrolling]: isScrolling,
+      isVisible: isVisible
     })
 
     return (

--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -9,9 +9,12 @@ import AutoSizer from '../AutoSizer'
 import shallowCompare from 'react-addons-shallow-compare'
 import styles from './WindowScroller.example.css'
 
-export default class AutoSizerExample extends Component {
+export default class WindowScrollerExample extends Component {
   static contextTypes = {
-    list: PropTypes.instanceOf(Immutable.List).isRequired
+    list: PropTypes.instanceOf(Immutable.List).isRequired,
+    customElement: PropTypes.any,
+    isScrollingCustomElement: PropTypes.bool.isRequired,
+    setScrollingCustomElement: PropTypes.func
   }
 
   constructor (props) {
@@ -23,10 +26,15 @@ export default class AutoSizerExample extends Component {
 
     this._hideHeader = this._hideHeader.bind(this)
     this._rowRenderer = this._rowRenderer.bind(this)
+    this.onChangeCustomElementCheckbox = this.onChangeCustomElementCheckbox.bind(this)
+  }
+
+  onChangeCustomElementCheckbox (event) {
+    this.context.setScrollingCustomElement(event.target.checked)
   }
 
   render () {
-    const { list } = this.context
+    const { list, isScrollingCustomElement, customElement } = this.context
     const { showHeaderText } = this.state
 
     return (
@@ -52,11 +60,25 @@ export default class AutoSizerExample extends Component {
           </ContentBoxParagraph>
         )}
 
+        <ContentBoxParagraph>
+          <label className={styles.checkboxLabel}>
+            <input
+              aria-label='Use custom element for scrolling'
+              className={styles.checkbox}
+              type='checkbox'
+              checked={isScrollingCustomElement}
+              onChange={this.onChangeCustomElementCheckbox}
+            />
+            Use custom element for scrolling
+          </label>
+        </ContentBoxParagraph>
+
         <div className={styles.WindowScrollerWrapper}>
           <WindowScroller
             ref={(ref) => {
               this._windowScroller = ref
             }}
+            scrollElement={isScrollingCustomElement ? customElement : null}
           >
             {({ height, isScrolling, scrollTop }) => (
               <AutoSizer disableHeight>

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -43,14 +43,18 @@ export default class WindowScroller extends Component {
     this._enablePointerEventsAfterDelayCallback = this._enablePointerEventsAfterDelayCallback.bind(this)
   }
 
-  componentDidMount () {
-    const { height } = this.state
-
+  updatePosition () {
     // Subtract documentElement top to handle edge-case where a user is navigating back (history) from an already-scrolled bage.
     // In this case the body's top position will be a negative number and this element's top will be increased (by that amount).
     this._positionFromTop =
       ReactDOM.findDOMNode(this).getBoundingClientRect().top -
       document.documentElement.getBoundingClientRect().top
+  }
+
+  componentDidMount () {
+    const { height } = this.state
+
+    this.updatePosition()
 
     if (height !== window.innerHeight) {
       this.setState({
@@ -59,6 +63,7 @@ export default class WindowScroller extends Component {
     }
 
     registerScrollListener(this)
+
     window.addEventListener('resize', this._onResizeWindow, false)
   }
 
@@ -91,6 +96,8 @@ export default class WindowScroller extends Component {
 
   _onResizeWindow (event) {
     const { onResize } = this.props
+
+    this.updatePosition()
 
     const height = window.innerHeight || 0
 

--- a/source/WindowScroller/utils/dimensions.js
+++ b/source/WindowScroller/utils/dimensions.js
@@ -1,0 +1,30 @@
+/**
+ * Gets the vertical scroll amount of the element, accounting for IE compatibility
+ * and API differences between `window` and other DOM elements.
+ */
+export function getVerticalScroll (element) {
+  return element === window
+    ? (('scrollY' in window) ? window.scrollY : document.documentElement.scrollTop)
+    : element.scrollTop
+}
+
+/**
+ * Gets the height of the element, accounting for API differences between
+ * `window` and other DOM elements.
+ */
+export function getHeight (element) {
+  return element === window
+    ? window.innerHeight
+    : element.getBoundingClientRect().height
+}
+
+/**
+ * Gets the vertical position of an element within its scroll container.
+ * Elements that have been “scrolled past” return negative values.
+ * Handles edge-case where a user is navigating back (history) from an already-scrolled page.
+ * In this case the body’s top position will be a negative number and this element’s top will be increased (by that amount).
+ */
+export function getPositionFromTop (element, container) {
+  const containerElement = container === window ? document.documentElement : container
+  return element.getBoundingClientRect().top - containerElement.getBoundingClientRect().top
+}

--- a/source/WindowScroller/utils/dimensions.js
+++ b/source/WindowScroller/utils/dimensions.js
@@ -26,5 +26,5 @@ export function getHeight (element) {
  */
 export function getPositionFromTop (element, container) {
   const containerElement = container === window ? document.documentElement : container
-  return element.getBoundingClientRect().top - containerElement.getBoundingClientRect().top
+  return element.getBoundingClientRect().top + getVerticalScroll(container) - containerElement.getBoundingClientRect().top
 }

--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -41,7 +41,11 @@ function onScrollWindow (event) {
     document.body.style.pointerEvents = 'none'
   }
   enablePointerEventsAfterDelay()
-  mountedInstances.forEach(component => component._onScrollWindow(event))
+  mountedInstances.forEach(component => {
+    if (component.scrollElement === event.currentTarget) {
+      component._onScrollWindow(event)
+    }
+  })
 }
 
 export function registerScrollListener (component, element = window) {

--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -45,7 +45,7 @@ function onScrollWindow (event) {
 }
 
 export function registerScrollListener (component, element = window) {
-  if (!mountedInstances.length) {
+  if (!mountedInstances.some(c => c.scrollElement === element)) {
     element.addEventListener('scroll', onScrollWindow)
   }
   mountedInstances.push(component)

--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -35,27 +35,26 @@ function enablePointerEventsAfterDelay () {
 }
 
 function onScrollWindow (event) {
-  if (originalBodyPointerEvents == null) {
+  if (event.currentTarget === window && originalBodyPointerEvents == null) {
     originalBodyPointerEvents = document.body.style.pointerEvents
 
     document.body.style.pointerEvents = 'none'
-
-    enablePointerEventsAfterDelay()
   }
+  enablePointerEventsAfterDelay()
   mountedInstances.forEach(component => component._onScrollWindow(event))
 }
 
-export function registerScrollListener (component) {
+export function registerScrollListener (component, element = window) {
   if (!mountedInstances.length) {
-    window.addEventListener('scroll', onScrollWindow)
+    element.addEventListener('scroll', onScrollWindow)
   }
   mountedInstances.push(component)
 }
 
-export function unregisterScrollListener (component) {
+export function unregisterScrollListener (component, element = window) {
   mountedInstances = mountedInstances.filter(c => (c !== component))
   if (!mountedInstances.length) {
-    window.removeEventListener('scroll', onScrollWindow)
+    element.removeEventListener('scroll', onScrollWindow)
     if (disablePointerEventsTimeoutId) {
       clearTimeout(disablePointerEventsTimeoutId)
       enablePointerEventsIfDisabled()

--- a/source/demo/Application.css
+++ b/source/demo/Application.css
@@ -105,6 +105,11 @@ a {
   flex-wrap: wrap;
   justify-content: center;
 }
+.ScrollingBody {
+  composes: Body;
+  overflow: auto;
+  flex: 1 1 auto;
+}
 .column {
   display: flex;
   flex-direction: column;

--- a/source/demo/Application.js
+++ b/source/demo/Application.js
@@ -42,16 +42,38 @@ const list = Immutable.List(generateRandomList())
 
 export default class Application extends Component {
   static childContextTypes = {
-    list: PropTypes.instanceOf(Immutable.List).isRequired
+    list: PropTypes.instanceOf(Immutable.List).isRequired,
+    customElement: PropTypes.any,
+    isScrollingCustomElement: PropTypes.bool.isRequired,
+    setScrollingCustomElement: PropTypes.func
   };
 
+  state = {
+    isScrollingCustomElement: false
+  }
+
+  constructor (props) {
+    super(props)
+    this.setScrollingCustomElement = this.setScrollingCustomElement.bind(this)
+  }
+
+  setScrollingCustomElement (custom) {
+    this.setState({ isScrollingCustomElement: custom })
+  }
+
   getChildContext () {
+    const { customElement, isScrollingCustomElement } = this.state
     return {
-      list
+      list,
+      customElement,
+      isScrollingCustomElement,
+      setScrollingCustomElement: this.setScrollingCustomElement
     }
   }
 
   render () {
+    const { isScrollingCustomElement } = this.state
+    const bodyStyle = isScrollingCustomElement ? styles.ScrollingBody : styles.Body
     return (
       <HashRouter>
         <div className={styles.demo}>
@@ -98,7 +120,7 @@ export default class Application extends Component {
             </div>
           </div>
 
-          <div className={styles.Body}>
+          <div className={bodyStyle} ref={e => this.setState({ customElement: e })}>
             <div className={styles.column}>
               <Match pattern='/wizard' component={Wizard} />
               {Object.keys(COMPONENT_EXAMPLES_MAP).map((route) => (

--- a/source/demo/ContentBox.css
+++ b/source/demo/ContentBox.css
@@ -1,5 +1,5 @@
 .ContentBox {
-  flex: 1;
+  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
   background-color: #FFF;


### PR DESCRIPTION
In reference to #474 

Adds an optional prop `scrollElement` to WindowScroller which, if provided, attaches scroll handlers to the given element instead of to `window`.

@bvaughn I “tested” this via adding an option to the demo (although maybe you’d like to change the way I did it—added a couple things to Application’s `context`—I’m not familiar with HashRouter, but maybe it can be done through props instead?) and it seems to work nicely. I’m happy to help add tests and docs, but wanted to let you take a look at it as soon as possible, and also get your feedback on the best way to add some tests for this. It almost seems like a big group of the tests could just be run twice, once for `window` and once for some custom element.

There are a couple things I wasn’t sure about, so I’ll start adding a few inline comments to ask about specific things.