### PR TITLE
Reduce unnecessary render() calls by ensuring ref equality with style objects

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -98,6 +98,8 @@ This function accepts the following named parameters:
 ```js
 function cellRangeRenderer ({
   cellCache,                    // Temporary cell cache for use while scrolling
+  styleCache,                   // Cache of style objects sent to cells, to
+                                // ensure referential equality
   cellRenderer,                 // Cell renderer prop supplied to Grid
   columnSizeAndPositionManager, // @see CellSizeAndPositionManager,
   columnStartIndex,             // Index of first column (inclusive) to render

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -208,6 +208,7 @@ export default class Grid extends Component {
   constructor (props, context) {
     super(props, context)
 
+    this._styleCache = {}
     this.state = {
       isScrolling: false,
       scrollDirectionHorizontal: SCROLL_DIRECTION_FORWARD,
@@ -663,6 +664,7 @@ export default class Grid extends Component {
       this._childrenToDisplay = cellRangeRenderer({
         cellCache: this._cellCache,
         cellRenderer,
+        styleCache: this._styleCache,
         columnSizeAndPositionManager: this._columnSizeAndPositionManager,
         columnStartIndex: this._columnStartIndex,
         columnStopIndex: this._columnStopIndex,

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -5,6 +5,7 @@
  */
 export default function defaultCellRangeRenderer ({
   cellCache,
+  styleCache,
   cellRenderer,
   columnSizeAndPositionManager,
   columnStartIndex,
@@ -34,12 +35,22 @@ export default function defaultCellRangeRenderer ({
         rowIndex <= visibleRowIndices.stop
       )
       let key = `${rowIndex}-${columnIndex}`
-      let style = {
-        height: rowDatum.size,
-        left: columnDatum.offset + horizontalOffsetAdjustment,
-        position: 'absolute',
-        top: rowDatum.offset + verticalOffsetAdjustment,
-        width: columnDatum.size
+
+      const height = rowDatum.size
+      const left = columnDatum.offset + horizontalOffsetAdjustment
+      const top = rowDatum.offset + verticalOffsetAdjustment
+      const width = columnDatum.size
+
+      const styleKey = `x${left}-y${top}-w${width}-h${height}`
+      let style
+
+      // avoid creating new style objects at all times to maintain referential
+      // equality, so shallowCompare components don't rerun render() unnecessarily
+      if (styleCache[styleKey]) {
+        style = styleCache[styleKey]
+      } else {
+        style = {height, width, left, top, position: 'absolute'}
+        styleCache[styleKey] = style
       }
 
       let cellRendererParams = {
@@ -88,6 +99,7 @@ export default function defaultCellRangeRenderer ({
 
 type DefaultCellRangeRendererParams = {
   cellCache: Object,
+  styleCache: Object,
   cellRenderer: Function,
   columnSizeAndPositionManager: Object,
   columnStartIndex: number,


### PR DESCRIPTION
Hey there, this a pull request following up what I was talking about on Twitter the other day.

Thankfully because the cellRangeRenderer is an optional property we can still use this behaviour in our project even if you don't think it's suitable to be merged in, however I think there's little downside to using it. Reusing the style objects through a light object cache means that referential equality is preserved, so 'pure' components that use `shallowCompare` will only execute on creation of elements and transition to/from `isScrolling` while scrolling, rather than every scroll tick.

The test that exercises this functionality can be made to fail by changing the defaultCellRangeRenderer to not use the styleCache:

```
      if (false) {
        style = styleCache[styleKey]
      } else {
        style = {height, width, left, top, position: 'absolute'}
        styleCache[styleKey] = style
      }
```

...which reverts to current behaviour where the style object is regenerated every tick.