### PR TITLE
Added parameter alias in CellMeasurer to ease List integration

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -12,7 +12,7 @@ This is an advanced component and has some limitations and performance considera
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
-| cellRenderer | Function | ✓ | Renders a cell given its indices. `({ columnIndex: number, rowIndex: number }): PropTypes.node` |
+| cellRenderer | Function | ✓ | Renders a cell given its indices. `({ columnIndex: number, rowIndex: number, index: number }): PropTypes.node`.<br/>**NOTE**: `index` is just an alias to `rowIndex` |
 | cellSizeCache | Object |  | Optional, custom caching strategy for cell sizes. Learn more [here](#cellsizecache). |
 | children | Function | ✓ | Function responsible for rendering a virtualized component; `({ getColumnWidth: Function, getRowHeight: Function, resetMeasurements: Function }) => PropTypes.element` |
 | columnCount | number | ✓ | Number of columns in the `Grid`; in order to measure a row's height, all of that row's columns must be rendered. |
@@ -178,11 +178,9 @@ function renderList(listProps, cellMeasurerProps = Object.create(null)) {
   return (
     <CellMeasurer
       {...cellMeasurerProps}
-      cellRenderer={
-        ({ rowIndex, ...rest }) => listProps.rowRenderer({ index: rowIndex, ...rest })
-      }
       columnCount={1}
       rowCount={listProps.rowCount}
+      cellRenderer={listProps.rowRenderer}
     >
       {({ getRowHeight }) => (
         <List

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -190,7 +190,7 @@ export default class CellMeasurer extends Component {
     const rendered = cellRenderer({
       columnIndex,
       rowIndex,
-      index: rowIndex, // List component `rowRenderer` compatibility
+      index: rowIndex // List component `rowRenderer` compatibility
     })
 
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -189,7 +189,8 @@ export default class CellMeasurer extends Component {
 
     const rendered = cellRenderer({
       columnIndex,
-      rowIndex
+      rowIndex,
+      index: rowIndex, // List component `rowRenderer` compatibility
     })
 
     // Handle edge case where this method is called before the CellMeasurer has completed its initial render (and mounted).


### PR DESCRIPTION
This allows to use CellMeasurer with Lists without mocking rowRenderer.