### PR TITLE
Arrowkeystepper align

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -74,7 +74,7 @@ export default class ArrowKeyStepperExample extends Component {
               onChange={event => event.target.checked && this.setState({ mode: 'align:top-left' })}
               value='align:top-left'
             />
-            align:top-left
+            align:top-left (<code>Grid</code> prop <code>SetToAlignment</code> is set to <code>start</code>)
           </label>
           <label>
             <input
@@ -85,7 +85,7 @@ export default class ArrowKeyStepperExample extends Component {
               onChange={event => event.target.checked && this.setState({ mode: 'align:bottom-right' })}
               value='align:bottom-right'
             />
-            align:bottom-right
+            align:bottom-right (<code>Grid</code> prop <code>SetToAlignment</code> is set to <code>end</code>)
           </label>
 
         </ContentBoxParagraph>

--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -78,14 +78,14 @@ export default class ArrowKeyStepperExample extends Component {
           </label>
           <label>
             <input
-              aria-label='Set mode equal to "align:top-right"'
-              checked={mode === 'align:top-right'}
+              aria-label='Set mode equal to "align:bottom-right"'
+              checked={mode === 'align:bottom-right'}
               className={styles.Radio}
               type='radio'
-              onChange={event => event.target.checked && this.setState({ mode: 'align:top-right' })}
-              value='align:top-right'
+              onChange={event => event.target.checked && this.setState({ mode: 'align:bottom-right' })}
+              value='align:bottom-right'
             />
-            align:top-right
+            align:bottom-right
           </label>
 
         </ContentBoxParagraph>
@@ -112,6 +112,7 @@ export default class ArrowKeyStepperExample extends Component {
                     cellRenderer={({ columnIndex, key, rowIndex, style }) => this._cellRenderer({ columnIndex, key, rowIndex, scrollToColumn, scrollToRow, style })}
                     rowHeight={this._getRowHeight}
                     rowCount={100}
+                    scrollToAlignment={mode === 'align:top-left' ? 'start' : (mode === 'align:bottom-right' ? 'end' : 'auto')}
                     scrollToColumn={scrollToColumn}
                     scrollToRow={scrollToRow}
                     width={width}

--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -65,6 +65,29 @@ export default class ArrowKeyStepperExample extends Component {
             />
             edges (default)
           </label>
+          <label>
+            <input
+              aria-label='Set mode equal to "align:top-left"'
+              checked={mode === 'align:top-left'}
+              className={styles.Radio}
+              type='radio'
+              onChange={event => event.target.checked && this.setState({ mode: 'align:top-left' })}
+              value='align:top-left'
+            />
+            align:top-left
+          </label>
+          <label>
+            <input
+              aria-label='Set mode equal to "align:top-right"'
+              checked={mode === 'align:top-right'}
+              className={styles.Radio}
+              type='radio'
+              onChange={event => event.target.checked && this.setState({ mode: 'align:top-right' })}
+              value='align:top-right'
+            />
+            align:top-right
+          </label>
+
         </ContentBoxParagraph>
 
         <ArrowKeyStepper

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -18,7 +18,7 @@ export default class ArrowKeyStepper extends Component {
     className: PropTypes.string,
     columnCount: PropTypes.number.isRequired,
     disabled: PropTypes.bool.isRequired,
-    mode: PropTypes.oneOf(['cells', 'edges', 'align:top-left', 'align:top-right']),
+    mode: PropTypes.oneOf(['cells', 'edges', 'align:top-left', 'align:bottom-right']),
     rowCount: PropTypes.number.isRequired,
     scrollToColumn: PropTypes.number.isRequired,
     scrollToRow: PropTypes.number.isRequired
@@ -97,8 +97,8 @@ export default class ArrowKeyStepper extends Component {
           scrollToRow = Math.min(scrollToRow + 1, rowCount - 1)
         } else if (mode === 'align:top-left') {
           scrollToRow = Math.min(this._rowStartIndex + 1, rowCount - 1)
-        } else if (mode === 'align:top-right') {
-          scrollToRow = Math.min(this._rowStartIndex + 1, rowCount - 1)
+        } else if (mode === 'align:bottom-right') {
+          scrollToRow = Math.min(this._rowStopIndex + 1, rowCount - 1)
         } else {
           scrollToRow = Math.min(this._rowStopIndex + 1, rowCount - 1)
         }
@@ -108,7 +108,7 @@ export default class ArrowKeyStepper extends Component {
           scrollToColumn = Math.max(scrollToColumn - 1, 0)
         } else if (mode === 'align:top-left') {
           scrollToColumn = Math.max(this._columnStartIndex - 1, 0)
-        } else if (mode === 'align:top-right') {
+        } else if (mode === 'align:bottom-right') {
           scrollToColumn = Math.max(this._columnStopIndex - 1, 0)
         } else {
           scrollToColumn = Math.max(this._columnStartIndex - 1, 0)
@@ -119,7 +119,7 @@ export default class ArrowKeyStepper extends Component {
           scrollToColumn = Math.min(scrollToColumn + 1, columnCount - 1)
         } else if (mode === 'align:top-left') {
           scrollToColumn = Math.min(this._columnStartIndex + 1, columnCount - 1)
-        } else if (mode === 'align:top-right') {
+        } else if (mode === 'align:bottom-right') {
           scrollToColumn = Math.min(this._columnStopIndex + 1, columnCount - 1)
         } else {
           scrollToColumn = Math.min(this._columnStopIndex + 1, columnCount - 1)
@@ -130,8 +130,8 @@ export default class ArrowKeyStepper extends Component {
           scrollToRow = Math.max(scrollToRow - 1, 0)
         } else if (mode === 'align:top-left') {
           scrollToRow = Math.max(this._rowStartIndex - 1, 0)
-        } else if (mode === 'align:top-right') {
-          scrollToRow = Math.max(this._rowStartIndex - 1, 0)
+        } else if (mode === 'align:bottom-right') {
+          scrollToRow = Math.max(this._rowStopIndex - 1, 0)
         } else {
           scrollToRow = Math.max(this._rowStartIndex - 1, 0)
         }

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -18,7 +18,7 @@ export default class ArrowKeyStepper extends Component {
     className: PropTypes.string,
     columnCount: PropTypes.number.isRequired,
     disabled: PropTypes.bool.isRequired,
-    mode: PropTypes.oneOf(['cells', 'edges']),
+    mode: PropTypes.oneOf(['cells', 'edges', 'align:top-left', 'align:top-right']),
     rowCount: PropTypes.number.isRequired,
     scrollToColumn: PropTypes.number.isRequired,
     scrollToRow: PropTypes.number.isRequired
@@ -93,24 +93,48 @@ export default class ArrowKeyStepper extends Component {
     // This is to keep the grid from scrolling after the snap-to update.
     switch (event.key) {
       case 'ArrowDown':
-        scrollToRow = mode === 'cells'
-          ? Math.min(scrollToRow + 1, rowCount - 1)
-          : Math.min(this._rowStopIndex + 1, rowCount - 1)
+        if (mode === 'cells') {
+          scrollToRow = Math.min(scrollToRow + 1, rowCount - 1)
+        } else if (mode === 'align:top-left') {
+          scrollToRow = Math.min(this._rowStartIndex + 1, rowCount - 1)
+        } else if (mode === 'align:top-right') {
+          scrollToRow = Math.min(this._rowStartIndex + 1, rowCount - 1)
+        } else {
+          scrollToRow = Math.min(this._rowStopIndex + 1, rowCount - 1)
+        }
         break
       case 'ArrowLeft':
-        scrollToColumn = mode === 'cells'
-          ? Math.max(scrollToColumn - 1, 0)
-          : Math.max(this._columnStartIndex - 1, 0)
+        if (mode === 'cells') {
+          scrollToColumn = Math.max(scrollToColumn - 1, 0)
+        } else if (mode === 'align:top-left') {
+          scrollToColumn = Math.max(this._columnStartIndex - 1, 0)
+        } else if (mode === 'align:top-right') {
+          scrollToColumn = Math.max(this._columnStopIndex - 1, 0)
+        } else {
+          scrollToColumn = Math.max(this._columnStartIndex - 1, 0)
+        }
         break
       case 'ArrowRight':
-        scrollToColumn = mode === 'cells'
-          ? Math.min(scrollToColumn + 1, columnCount - 1)
-          : Math.min(this._columnStopIndex + 1, columnCount - 1)
+        if (mode === 'cells') {
+          scrollToColumn = Math.min(scrollToColumn + 1, columnCount - 1)
+        } else if (mode === 'align:top-left') {
+          scrollToColumn = Math.min(this._columnStartIndex + 1, columnCount - 1)
+        } else if (mode === 'align:top-right') {
+          scrollToColumn = Math.min(this._columnStopIndex + 1, columnCount - 1)
+        } else {
+          scrollToColumn = Math.min(this._columnStopIndex + 1, columnCount - 1)
+        }
         break
       case 'ArrowUp':
-        scrollToRow = mode === 'cells'
-          ? Math.max(scrollToRow - 1, 0)
-          : Math.max(this._rowStartIndex - 1, 0)
+        if (mode === 'cells') {
+          scrollToRow = Math.max(scrollToRow - 1, 0)
+        } else if (mode === 'align:top-left') {
+          scrollToRow = Math.max(this._rowStartIndex - 1, 0)
+        } else if (mode === 'align:top-right') {
+          scrollToRow = Math.max(this._rowStartIndex - 1, 0)
+        } else {
+          scrollToRow = Math.max(this._rowStartIndex - 1, 0)
+        }
         break
     }
 

--- a/source/ArrowKeyStepper/ArrowKeyStepper.test.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.test.js
@@ -168,6 +168,7 @@ describe('ArrowKeyStepper', () => {
       })
       Simulate.keyDown(node, {key: 'ArrowLeft'})
       assertCurrentScrollTo(node, 1, 1)
+      render.unmount()
     })
   })
 
@@ -200,6 +201,94 @@ describe('ArrowKeyStepper', () => {
       assertCurrentScrollTo(node, 6, 5)
       Simulate.keyDown(node, {key: 'ArrowLeft'})
       assertCurrentScrollTo(node, 5, 5)
+    })
+  })
+
+  describe('mode === "align:top-left"', () => {
+    it('should update :scrollToColumn and :scrollToRow relative to the most recent :onSectionRendered event', () => {
+      const { node, onSectionRendered } = renderHelper({
+        mode: 'align:top-left'
+      })
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 0,
+        columnStopIndex: 4,
+        rowStartIndex: 4,
+        rowStopIndex: 6
+      })
+      Simulate.keyDown(node, {key: 'ArrowDown'})
+      assertCurrentScrollTo(node, 0, 5)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 5,
+        columnStopIndex: 10,
+        rowStartIndex: 2,
+        rowStopIndex: 4
+      })
+      Simulate.keyDown(node, {key: 'ArrowUp'})
+      assertCurrentScrollTo(node, 0, 1)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 4,
+        columnStopIndex: 8,
+        rowStartIndex: 5,
+        rowStopIndex: 10
+      })
+      Simulate.keyDown(node, {key: 'ArrowRight'})
+      assertCurrentScrollTo(node, 5, 1)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 2,
+        columnStopIndex: 4,
+        rowStartIndex: 2,
+        rowStopIndex: 4
+      })
+      Simulate.keyDown(node, {key: 'ArrowLeft'})
+      assertCurrentScrollTo(node, 1, 1)
+    })
+  })
+
+  describe('mode === "align:top-right"', () => {
+    it('should update :scrollToColumn and :scrollToRow relative to the most recent :onSectionRendered event', () => {
+      const { node, onSectionRendered } = renderHelper({
+        mode: 'align:top-right'
+      })
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 0,
+        columnStopIndex: 4,
+        rowStartIndex: 4,
+        rowStopIndex: 6
+      })
+      Simulate.keyDown(node, {key: 'ArrowDown'})
+      assertCurrentScrollTo(node, 0, 5)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 5,
+        columnStopIndex: 10,
+        rowStartIndex: 2,
+        rowStopIndex: 4
+      })
+      Simulate.keyDown(node, {key: 'ArrowUp'})
+      assertCurrentScrollTo(node, 0, 1)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 4,
+        columnStopIndex: 8,
+        rowStartIndex: 5,
+        rowStopIndex: 10
+      })
+      Simulate.keyDown(node, {key: 'ArrowRight'})
+      assertCurrentScrollTo(node, 9, 1)
+
+      onSectionRendered({ // Simulate a scroll
+        columnStartIndex: 2,
+        columnStopIndex: 4,
+        rowStartIndex: 2,
+        rowStopIndex: 4
+      })
+      Simulate.keyDown(node, {key: 'ArrowLeft'})
+      assertCurrentScrollTo(node, 3, 1)
     })
   })
 })

--- a/source/ArrowKeyStepper/ArrowKeyStepper.test.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.test.js
@@ -248,10 +248,10 @@ describe('ArrowKeyStepper', () => {
     })
   })
 
-  describe('mode === "align:top-right"', () => {
+  describe('mode === "align:bottom-right"', () => {
     it('should update :scrollToColumn and :scrollToRow relative to the most recent :onSectionRendered event', () => {
       const { node, onSectionRendered } = renderHelper({
-        mode: 'align:top-right'
+        mode: 'align:bottom-right'
       })
 
       onSectionRendered({ // Simulate a scroll
@@ -261,7 +261,7 @@ describe('ArrowKeyStepper', () => {
         rowStopIndex: 6
       })
       Simulate.keyDown(node, {key: 'ArrowDown'})
-      assertCurrentScrollTo(node, 0, 5)
+      assertCurrentScrollTo(node, 0, 7)
 
       onSectionRendered({ // Simulate a scroll
         columnStartIndex: 5,
@@ -270,7 +270,7 @@ describe('ArrowKeyStepper', () => {
         rowStopIndex: 4
       })
       Simulate.keyDown(node, {key: 'ArrowUp'})
-      assertCurrentScrollTo(node, 0, 1)
+      assertCurrentScrollTo(node, 0, 3)
 
       onSectionRendered({ // Simulate a scroll
         columnStartIndex: 4,
@@ -279,7 +279,7 @@ describe('ArrowKeyStepper', () => {
         rowStopIndex: 10
       })
       Simulate.keyDown(node, {key: 'ArrowRight'})
-      assertCurrentScrollTo(node, 9, 1)
+      assertCurrentScrollTo(node, 9, 3)
 
       onSectionRendered({ // Simulate a scroll
         columnStartIndex: 2,
@@ -288,7 +288,7 @@ describe('ArrowKeyStepper', () => {
         rowStopIndex: 4
       })
       Simulate.keyDown(node, {key: 'ArrowLeft'})
-      assertCurrentScrollTo(node, 3, 1)
+      assertCurrentScrollTo(node, 3, 3)
     })
   })
 })

--- a/source/demo/index.js
+++ b/source/demo/index.js
@@ -2,7 +2,7 @@
 import 'babel-polyfill'
 
 // Import react-virtualized styles as part of bootstrap process
-import '../styles.css'
+import '../../styles.css'
 
 import React from 'react'
 import { render } from 'react-dom'

--- a/source/demo/index.js
+++ b/source/demo/index.js
@@ -2,7 +2,7 @@
 import 'babel-polyfill'
 
 // Import react-virtualized styles as part of bootstrap process
-import '../../styles.css'
+import '../styles.css'
 
 import React from 'react'
 import { render } from 'react-dom'


### PR DESCRIPTION
Hey,

First thanks for building and maintaining this great library.

I have recently begun using ArrowKeyStepper to add keyboard navigation to a pivot grid component I am developing using react-virtualized.
However, I did not found a combination of `ArrowKeyStepper` `mode` and `Grid` `scrollToAlignement` that gives the behaviour I want.

### Behaviour
- on key press, the grid moves to the next column/row in the direction
- the borders of the top left cell are aligned with the borders of the grid

### Existing
- `mode:  cells` and `scrollToAlignment: start`
Works almost as wished but `ArrowKeyStepper` does not follow the scroll.
- `mode:  edges` and `scrollToAlignment: start`
The grid jumps to the next cell not yet visible.
- `mode:  edges` and `scrollToAlignment: auto`
Follows the scroll but the align the borders of the bottom right cell instead. This causes problems when the cells are of unequal sizes.

### Proposition
I have been able to get the desired behaviour by setting `scrollToAlignment` to `start` and creating a new `mode` in `ArrowKeyStepper` called `align:top-left`. For completion, (and to help support right-to-left setups) I also added a `align:top-right` `mode` (to be used with `scrollToAlignment` `end`. You can see the commits for the changes but it's pretty straight-forward replacing some `columnStartIndex` with `columStopIndex` and vice-versa.

I will be happy to help if you have any questions/remarks.
Thanks



