### PR TITLE
Pass correct datastructure to getColumnWidth

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -175,7 +175,7 @@ export default class MultiGrid extends Component {
     const { fixedColumnCount, columnWidth } = this.props
 
     return columnWidth instanceof Function
-      ? columnWidth(index + fixedColumnCount)
+      ? columnWidth({index: index.index + fixedColumnCount})
       : columnWidth
   }
 
@@ -195,7 +195,7 @@ export default class MultiGrid extends Component {
         let leftGridWidth = 0
 
         for (let index = 0; index < fixedColumnCount; index++) {
-          leftGridWidth += columnWidth(index)
+          leftGridWidth += columnWidth({index: index})
         }
 
         this._leftGridWidth = leftGridWidth


### PR DESCRIPTION
This makes it so `MultiGrid` doesn't error out and renders appropriately when using a `CellMeasurer`.

I still see this error:

```
Warning: _renderNewRootComponent(): Render methods should be a pure function of props and state; triggering nested component updates from render is not allowed. If necessary, trigger nested updates in componentDidUpdate. Check the render method of MultiGrid.
```

but I'm not sure whats causing that.  It only happens when using CellMeasurer though.