### PR TITLE
Avoid duplicated style declarations for detectElementResize

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -21,7 +21,6 @@ export default function createDetectElementResize () {
   }
 
   var attachEvent = typeof document !== 'undefined' && document.attachEvent;
-  var stylesCreated = false;
 
   if (!attachEvent) {
     var requestFrame = (function(){
@@ -109,7 +108,7 @@ export default function createDetectElementResize () {
   }
 
   var createStyles = function() {
-    if (!stylesCreated) {
+    if (!document.getElementById('detectElementResize')) {
       //opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
       var css = (animationKeyframes ? animationKeyframes : '') +
           '.resize-triggers { ' + (animationStyle ? animationStyle : '') + 'visibility: hidden; opacity: 0; } ' +
@@ -117,6 +116,7 @@ export default function createDetectElementResize () {
         head = document.head || document.getElementsByTagName('head')[0],
         style = document.createElement('style');
 
+      style.id = 'detectElementResize';
       style.type = 'text/css';
       if (style.styleSheet) {
         style.styleSheet.cssText = css;
@@ -125,7 +125,6 @@ export default function createDetectElementResize () {
       }
 
       head.appendChild(style);
-      stylesCreated = true;
     }
   }
 


### PR DESCRIPTION
## Issue
When using multiple instances of AutoSizer (or mounting and unmounting multiple times) a new style tag is being added to the document head. This is due to `detectElementResize` vendor library that forces creation  every time it's called.

## Approaches

### Solution 1
Move `stylesCreated` variable outside of function scope. This way this variable would be set just once independently of how many times function is called.

### Solution 2
Identify style tag with an `id` attribute so we don't duplicate it if it already exists.

### Solution 3
Extract style declaration to RV `styles.css` file.

## Current approach
I've opted for using an id as it ensures style tag is created even if it has been previously removed somehow.

## Screenshot
Here you can see it in action:

![detectElementResize](https://cloud.githubusercontent.com/assets/62171/21146201/1fd49648-c151-11e6-957e-7ea81884691d.gif)
