### PR TITLE
Add loose-envify transform to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,8 +144,7 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.3",
-    "dom-helpers": "^2.4.0",
-    "loose-envify": "^1.1.0"
+    "dom-helpers": "^2.4.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -144,11 +144,17 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.3",
-    "dom-helpers": "^2.4.0"
+    "dom-helpers": "^2.4.0",
+    "loose-envify": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }


### PR DESCRIPTION
We are building our application using Browserify. When including react-virtualized through Browserify, the `process.env.NODE_ENV` checks are not processed, causing Browserify to include a `process` shim in the bundle. This bloats the bundle size and reduces opportunity for minification since `"development" !== "production"` checks are no longer removable.

This PR tells Browserify to apply the `loose-envify` transform when react-virtualized is included in a Browserify bundle. After applying this change, `process.env.NODE_ENV` is correctly replaced during our build process.

Other libraries, such as Redux, use this method to provide `process.env` replacement too -- see [here](https://github.com/reactjs/redux/commit/a9d7c0ef09b1d7970e774ab09a55aff44048cdb5) for the relevant commit on Redux.