### PR TITLE
Update dom-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.3",
-    "dom-helpers": "^2.4.0"
+    "dom-helpers": "^3.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "classnames": "^2.2.3",
-    "dom-helpers": "^3.2.0"
+    "dom-helpers": "^2.4.0 || ^3.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Currently uses the older version, which leads to dom-helpers being included twice, when bundling react-virtualized with webpack and having dom-helpers 2.x and 3.x used.