### PR TITLE
Fix bad styles being cached in massive lists

### DIFF
--- a/source/Grid/Grid.test.js
+++ b/source/Grid/Grid.test.js
@@ -6,6 +6,7 @@ import { render } from '../TestUtils'
 import shallowCompare from 'react-addons-shallow-compare'
 import Grid, { DEFAULT_SCROLLING_RESET_TIME_INTERVAL } from './Grid'
 import { SCROLL_DIRECTION_BACKWARD, SCROLL_DIRECTION_FORWARD } from './utils/getOverscanIndices'
+import { DEFAULT_MAX_SCROLL_SIZE } from './utils/ScalingCellSizeAndPositionManager'
 
 const DEFAULT_COLUMN_WIDTH = 50
 const DEFAULT_HEIGHT = 100
@@ -1506,5 +1507,34 @@ describe('Grid', () => {
       expect(cellRendererCalls.length).toEqual(2)
       expect(cellRendererCalls[1].style.width).toEqual(50)
     })
+  })
+
+  it('should not pull from the style cache while scrolling if there is an offset adjustment', () => {
+    let cellRendererCalls = []
+    function cellRenderer (props) {
+      cellRendererCalls.push(props)
+    }
+
+    const grid = render(getMarkup({
+      cellRenderer,
+      width: 100,
+      height: 100,
+      rowHeight: 100,
+      columnWidth: 100,
+      rowCount: DEFAULT_MAX_SCROLL_SIZE * 2 / 100, // lots of offset
+      scrollTop: DEFAULT_MAX_SCROLL_SIZE
+    }))
+
+    simulateScroll({
+      grid,
+      scrollTop: DEFAULT_MAX_SCROLL_SIZE + 100
+    })
+
+    // cellRendererCalls[0] is the element at rowIndex 0
+    const firstProps = cellRendererCalls[1]
+    const secondProps = cellRendererCalls[2]
+
+    expect(cellRendererCalls.length).toEqual(3)
+    expect(firstProps.style).not.toBe(secondProps.style)
   })
 })

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -22,6 +22,8 @@ export default function defaultCellRangeRenderer ({
   visibleRowIndices
 }: DefaultCellRangeRendererParams) {
   const renderedCells = []
+  const offsetAdjusted = verticalOffsetAdjustment || horizontalOffsetAdjustment
+  const canCacheStyle = !isScrolling || !offsetAdjusted
 
   for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
     let rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(rowIndex)
@@ -38,7 +40,7 @@ export default function defaultCellRangeRenderer ({
       let style
 
       // Cache style objects so shallow-compare doesn't re-render unnecessarily.
-      if (styleCache[key]) {
+      if (canCacheStyle && styleCache[key]) {
         style = styleCache[key]
       } else {
         style = {


### PR DESCRIPTION
In lists large enough to trigger scaling, the cached styles can be invalid. Causing weird banding effects and overlapping as you scroll.

![bands](https://cloud.githubusercontent.com/assets/2576091/21706962/c011233e-d37f-11e6-8d93-47d7d71a5c8f.gif)
