### PR TITLE
Avoid double forceUpdate

### DIFF
--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -249,13 +249,9 @@ export function forceUpdateReactVirtualizedComponent (component) {
     ? component.recomputeGridSize
     : component.recomputeRowHeights
 
-  const forceUpdate = typeof component.forceUpdateGrid === 'function'
-    ? component.forceUpdateGrid
-    : component.forceUpdate
-
   if (recomputeSize) {
     recomputeSize.call(component)
+  } else {
+    component.forceUpdate()
   }
-
-  forceUpdate.call(component)
 }

--- a/source/InfiniteLoader/InfiniteLoader.test.js
+++ b/source/InfiniteLoader/InfiniteLoader.test.js
@@ -324,43 +324,6 @@ describe('isRangeVisible', () => {
 })
 
 describe('forceUpdateReactVirtualizedComponent', () => {
-  it('should call :forceUpdateGrid if defined', () => {
-    let forceUpdateCalled = false
-    let forceUpdateGridCalled = false
-    class TestComponent extends Component {
-      forceUpdate () {
-        forceUpdateCalled = true
-      }
-      forceUpdateGrid () {
-        forceUpdateGridCalled = true
-      }
-      render () {
-        return <div />
-      }
-    }
-    forceUpdateReactVirtualizedComponent(
-      render(<TestComponent />)
-    )
-    expect(forceUpdateGridCalled).toEqual(true)
-    expect(forceUpdateCalled).toEqual(false)
-  })
-
-  it('should called :forceUpdate if :forceUpdateGrid is not defined', () => {
-    let forceUpdateCalled = false
-    class TestComponent extends Component {
-      forceUpdate () {
-        forceUpdateCalled = true
-      }
-      render () {
-        return <div />
-      }
-    }
-    forceUpdateReactVirtualizedComponent(
-      render(<TestComponent />)
-    )
-    expect(forceUpdateCalled).toEqual(true)
-  })
-
   it('should call :recomputeGridSize if defined', () => {
     let recomputedGridSize = false
     class TestComponent extends Component {
@@ -391,5 +354,21 @@ describe('forceUpdateReactVirtualizedComponent', () => {
       render(<TestComponent />)
     )
     expect(recomputedRowHeights).toEqual(true)
+  })
+
+  it('should call :forceUpdate otherwise', () => {
+    let forceUpdated = false
+    class TestComponent extends Component {
+      forceUpdate () {
+        forceUpdated = true
+      }
+      render () {
+        return <div />
+      }
+    }
+    forceUpdateReactVirtualizedComponent(
+      render(<TestComponent />)
+    )
+    expect(forceUpdated).toEqual(true)
   })
 })


### PR DESCRIPTION
I realized that recomputeGridSize and recomputeRowHeights already call force update, causing this nice little performance hit.

<img width="609" alt="screen shot 2017-01-06 at 2 52 50 pm" src="https://cloud.githubusercontent.com/assets/2576091/21735591/dd0242b6-d41f-11e6-9ad2-a5e1030ac137.png">

The diff on the tests looks a little weird, but basically I deleted the `forceUpdate` and `forceUpdateGrid` tests and added one to fallback to `forceUpdate` only if neither `recomputeGridSize` or `recomputeRowHeights` exist.

Here's what the new profile looks like

<img width="439" alt="screen shot 2017-01-06 at 2 56 20 pm" src="https://cloud.githubusercontent.com/assets/2576091/21735655/575fe022-d420-11e6-9dfc-04f1f3bb2b7b.png">
