### PR TITLE
Fix mouse wheel tear in scroll synced grids

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "lodash.throttle": "^4.1.1",
     "phantomjs-prebuilt": "^2.1.14",
     "postcss": "^5.0.14",
     "postcss-cli": "^2.3.3",

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -7,6 +7,7 @@ import createCallbackMemoizer from '../utils/createCallbackMemoizer'
 import getOverscanIndices, { SCROLL_DIRECTION_BACKWARD, SCROLL_DIRECTION_FORWARD } from './utils/getOverscanIndices'
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize'
 import shallowCompare from 'react-addons-shallow-compare'
+import throttle from 'lodash.throttle'
 import updateScrollIndexHelper from './utils/updateScrollIndexHelper'
 import defaultCellRangeRenderer from './defaultCellRangeRenderer'
 
@@ -24,6 +25,8 @@ const SCROLL_POSITION_CHANGE_REASONS = {
   OBSERVED: 'observed',
   REQUESTED: 'requested'
 }
+
+const defaultOnScroll = () => null
 
 /**
  * Renders tabular data with virtualization along the vertical and horizontal axes.
@@ -195,7 +198,7 @@ export default class Grid extends Component {
     estimatedColumnSize: 100,
     estimatedRowSize: 30,
     noContentRenderer: () => null,
-    onScroll: () => null,
+    onScroll: defaultOnScroll,
     onSectionRendered: () => null,
     overscanColumnCount: 0,
     overscanRowCount: 10,
@@ -223,6 +226,8 @@ export default class Grid extends Component {
     // Bind functions to instance so they don't lose context when passed around
     this._debounceScrollEndedCallback = this._debounceScrollEndedCallback.bind(this)
     this._invokeOnGridRenderedHelper = this._invokeOnGridRenderedHelper.bind(this)
+    this._onWheelHandler = this._onWheelHandler.bind(this)
+    this._onThrottledWheel = throttle(this._onWheelHandler, 1000 / 60)
     this._onWheel = this._onWheel.bind(this)
     this._onScroll = this._onScroll.bind(this)
     this._updateScrollLeftForScrollToColumn = this._updateScrollLeftForScrollToColumn.bind(this)
@@ -873,9 +878,7 @@ export default class Grid extends Component {
     }
   }
 
-  _onWheel (event) {
-    event.preventDefault()
-
+  _onWheelHandler (deltaX, deltaY) {
     // Prevent pointer events from interrupting a smooth scroll
     this._debounceScrollEnded()
 
@@ -889,11 +892,11 @@ export default class Grid extends Component {
     const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
     const scrollLeft = Math.min(
       Math.max(0, totalColumnsWidth - width + scrollbarSize),
-      Math.max(0, this._scrollingContainer.scrollLeft + event.deltaX)
+      Math.max(0, this._scrollingContainer.scrollLeft + deltaX)
     )
     const scrollTop = Math.min(
       Math.max(0, totalRowsHeight - height + scrollbarSize),
-      Math.max(0, this._scrollingContainer.scrollTop + event.deltaY)
+      Math.max(0, this._scrollingContainer.scrollTop + deltaY)
     )
 
     // Certain devices (like Apple touchpad) rapid-fire duplicate events.
@@ -913,13 +916,28 @@ export default class Grid extends Component {
         scrollDirectionHorizontal,
         scrollDirectionVertical,
         scrollLeft,
-        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.REQUESTED
       }
 
       this.setState(newState)
     }
 
     this._invokeOnScrollMemoizer({ scrollLeft, scrollTop, totalColumnsWidth, totalRowsHeight })
+  }
+
+  _onWheel (event) {
+    // On Windows / Linux machines, scrollSync experiences tearing across multiple Grid elements.
+    // The tearing exists because the call to _onScroll happens post-scroll on Windows / Linux boxes.
+    // If we're supplied an onScroll callback, we will assume we are synchronizing Grids, and we will force scrolling
+    // to occur across all Grids simultaneously.
+    if (this.props.onScroll === defaultOnScroll) {
+      return
+    }
+
+    event.preventDefault()
+    const { deltaX, deltaY } = event
+
+    this._onThrottledWheel(deltaX, deltaY)
   }
 
   _onScroll (event) {


### PR DESCRIPTION
Addresses tearing across scroll synced Grids in Chrome: https://github.com/bvaughn/react-virtualized/issues/453.

This is accomplished by forcing Grids that receive an onScroll prop to use the onWheel event. The onWheel event occurs before any scrolling occurs in the browser. We grab that event, modify the scrollTop/scrollLeft ourselves, and then toss that into the scrollCallback and observe a scroll change.

Tearing in the browser is occurring, because onScroll events actually occur _post_ scroll in windows/linux on chrome. Interestingly, the tearing behavior is only associated with mouse wheel / track pad events. Grabbing the scroll bar and dragging it works as expected where the onScroll event occurs before the browser actually scrolls the contents, so this bug is not present under scrollbar dragging conditions.

Further, as this only happens in scroll sync situations and the current scroll behavior is acceptable for singular grids, we only apply this change when provided an onScroll prop in Grid.