### PR TITLE
Fix positionFromTop when scrolling window after window resize

### DIFF
--- a/source/WindowScroller/utils/dimensions.js
+++ b/source/WindowScroller/utils/dimensions.js
@@ -15,12 +15,13 @@ export function getHeight (element) {
  * In this case the body’s top position will be a negative number and this element’s top will be increased (by that amount).
  */
 export function getPositionFromTop (element, container) {
+  const offset = container === window ? 0 : getScrollTop(container)
   const containerElement = container === window
     ? document.documentElement
     : container
   return (
     element.getBoundingClientRect().top +
-    getScrollTop(container) -
+    offset -
     containerElement.getBoundingClientRect().top
   )
 }


### PR DESCRIPTION
Fixes #544 😱 

I am unable to explain why this fixes the issue, but I can verify that it does. The `getScrollTop(container)` term here is necessary when scrolling a custom element. Apparently it breaks things when scrolling `window`. This keeps the calculation for `window` scrolling the same as it was pre-8.10.0, while adding the necessary offset to the calculation for scrolling a custom `scrollElement`.