### PR TITLE
MultiGrid (with rowHeight and columnWidth functions) resizing

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -99,7 +99,7 @@ export default class MultiGrid extends Component {
     const { columnWidth, fixedColumnCount, fixedRowCount, rowHeight } = this.props
 
     if (
-      columnWidth !== nextProps.columnWidth ||
+      columnWidth instanceof Function || columnWidth !== nextProps.columnWidth ||
       fixedColumnCount !== nextProps.fixedColumnCount
     ) {
       this._leftGridWidth = null
@@ -107,7 +107,7 @@ export default class MultiGrid extends Component {
 
     if (
       fixedRowCount !== nextProps.fixedRowCount ||
-      rowHeight !== nextProps.rowHeight
+      rowHeight instanceof Function || rowHeight !== nextProps.rowHeight
     ) {
       this._topGridHeight = null
     }

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -90,6 +90,10 @@ export default class MultiGrid extends Component {
       columnIndex: col,
       rowIndex: rowIndex
     })
+
+    this._leftGridWidth = null
+    this._topGridHeight = null
+    this._maybeCalculateCachedStyles(null, this.props)
   }
 
   componentWillMount () {
@@ -100,7 +104,7 @@ export default class MultiGrid extends Component {
     const { columnWidth, fixedColumnCount, fixedRowCount, rowHeight } = this.props
 
     if (
-      columnWidth instanceof Function || columnWidth !== nextProps.columnWidth ||
+      columnWidth !== nextProps.columnWidth ||
       fixedColumnCount !== nextProps.fixedColumnCount
     ) {
       this._leftGridWidth = null
@@ -108,7 +112,7 @@ export default class MultiGrid extends Component {
 
     if (
       fixedRowCount !== nextProps.fixedRowCount ||
-      rowHeight instanceof Function || rowHeight !== nextProps.rowHeight
+      rowHeight !== nextProps.rowHeight
     ) {
       this._topGridHeight = null
     }
@@ -340,7 +344,6 @@ export default class MultiGrid extends Component {
       this._bottomLeftGridStyle = {
         left: 0,
         outline: 0,
-        overflow: 'hidden',
         overflowX: 'hidden',
         overflowY: 'hidden',
         position: 'absolute',
@@ -368,7 +371,6 @@ export default class MultiGrid extends Component {
       this._topLeftGridStyle = {
         left: 0,
         outline: 0,
-        overflow: 'hidden',
         overflowX: 'hidden',
         overflowY: 'hidden',
         position: 'absolute',
@@ -385,7 +387,6 @@ export default class MultiGrid extends Component {
       this._topRightGridStyle = {
         left: this._getLeftGridWidth(props),
         outline: 0,
-        overflow: 'hidden',
         overflowX: 'hidden',
         overflowY: 'hidden',
         position: 'absolute',

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -340,6 +340,8 @@ export default class MultiGrid extends Component {
         left: 0,
         outline: 0,
         overflow: 'hidden',
+        overflowX: 'hidden',
+        overflowY: 'hidden',
         position: 'absolute',
         ...styleBottomLeftGrid
       }
@@ -366,6 +368,8 @@ export default class MultiGrid extends Component {
         left: 0,
         outline: 0,
         overflow: 'hidden',
+        overflowX: 'hidden',
+        overflowY: 'hidden',
         position: 'absolute',
         top: 0,
         ...styleTopLeftGrid
@@ -381,6 +385,8 @@ export default class MultiGrid extends Component {
         left: this._getLeftGridWidth(props),
         outline: 0,
         overflow: 'hidden',
+        overflowX: 'hidden',
+        overflowY: 'hidden',
         position: 'absolute',
         top: 0,
         ...styleTopRightGrid

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -72,22 +72,23 @@ export default class MultiGrid extends Component {
     rowIndex = 0
   } = {}) {
     const { fixedColumnCount, fixedRowCount } = this.props
-
-    this._bottomLeftGrid && this._bottomLeftGrid.measureAllCells({
-      columnIndex,
-      rowIndex: rowIndex - fixedRowCount
+    const col = (columnIndex >= fixedColumnCount ? columnIndex - fixedColumnCount : columnIndex)
+    const row = (rowIndex >= fixedRowCount ? rowIndex - fixedRowCount : rowIndex)
+    this._bottomLeftGrid && this._bottomLeftGrid.recomputeGridSize({
+      columnIndex: columnIndex,
+      rowIndex: row
     })
-    this._bottomRightGrid && this._bottomRightGrid.measureAllCells({
-      columnIndex: columnIndex - fixedColumnCount,
-      rowIndex: rowIndex - fixedRowCount
+    this._bottomRightGrid && this._bottomRightGrid.recomputeGridSize({
+      columnIndex: col,
+      rowIndex: row
     })
-    this._topLeftGrid && this._topLeftGrid.measureAllCells({
-      columnIndex,
-      rowIndex
+    this._topLeftGrid && this._topLeftGrid.recomputeGridSize({
+      columnIndex: columnIndex,
+      rowIndex: rowIndex
     })
-    this._topRightGrid && this._topRightGrid.measureAllCells({
-      columnIndex: columnIndex - fixedColumnCount,
-      rowIndex
+    this._topRightGrid && this._topRightGrid.recomputeGridSize({
+      columnIndex: col,
+      rowIndex: rowIndex
     })
   }
 

--- a/source/MultiGrid/MultiGrid.test.js
+++ b/source/MultiGrid/MultiGrid.test.js
@@ -44,7 +44,21 @@ describe('MultiGrid', () => {
         fixedColumnCount: 1,
         fixedRowCount: 1
       })))
-      expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(4)
+      const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(grids.length).toEqual(4)
+      const [topLeft, topRight, bottomLeft, bottomRight] = grids
+      expect(topLeft.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(topLeft.style.getPropertyValue('overflow-x')).toEqual('hidden')
+      expect(topLeft.style.getPropertyValue('overflow-y')).toEqual('hidden')
+      expect(topRight.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(topRight.style.getPropertyValue('overflow-x')).toEqual('hidden')
+      expect(topRight.style.getPropertyValue('overflow-y')).toEqual('hidden')
+      expect(bottomLeft.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(bottomLeft.style.getPropertyValue('overflow-x')).toEqual('hidden')
+      expect(bottomLeft.style.getPropertyValue('overflow-y')).toEqual('hidden')
+      expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
+      expect(bottomRight.style.getPropertyValue('overflow-x')).toEqual('auto')
+      expect(bottomRight.style.getPropertyValue('overflow-y')).toEqual('auto')
     })
 
     it('should render 2 Grids when configured for fixed columns only', () => {
@@ -52,7 +66,11 @@ describe('MultiGrid', () => {
         fixedColumnCount: 1,
         fixedRowCount: 0
       })))
-      expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(2)
+      const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(grids.length).toEqual(2)
+      const [bottomLeft, bottomRight] = grids
+      expect(bottomLeft.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
     })
 
     it('should render 2 Grids when configured for fixed rows only', () => {
@@ -60,7 +78,11 @@ describe('MultiGrid', () => {
         fixedColumnCount: 0,
         fixedRowCount: 1
       })))
-      expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(2)
+      const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(grids.length).toEqual(2)
+      const [topRight, bottomRight] = grids
+      expect(topRight.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
     })
 
     it('should render 1 Grid when configured for neither fixed columns and rows', () => {
@@ -68,7 +90,10 @@ describe('MultiGrid', () => {
         fixedColumnCount: 0,
         fixedRowCount: 0
       })))
-      expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(1)
+      const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(grids.length).toEqual(1)
+      const [bottomRight] = grids
+      expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
     })
 
     it('should adjust the number of Grids when fixed column or row counts change', () => {

--- a/source/MultiGrid/MultiGrid.test.js
+++ b/source/MultiGrid/MultiGrid.test.js
@@ -113,6 +113,19 @@ describe('MultiGrid', () => {
       })))
       expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(2)
     })
+
+    it('should render 4 Grids when configured for fixed columns and rows', () => {
+      let multiGrid
+      findDOMNode(render(getMarkup({
+        fixedColumnCount: 1,
+        fixedRowCount: 1,
+        ref: (ref) => {
+          multiGrid = ref
+        }
+      })))
+
+      multiGrid.recomputeGridSize()
+    })
   })
 
   describe('scrollToColumn and scrollToRow', () => {

--- a/source/MultiGrid/MultiGrid.test.js
+++ b/source/MultiGrid/MultiGrid.test.js
@@ -47,16 +47,12 @@ describe('MultiGrid', () => {
       const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
       expect(grids.length).toEqual(4)
       const [topLeft, topRight, bottomLeft, bottomRight] = grids
-      expect(topLeft.style.getPropertyValue('overflow')).toEqual('hidden')
       expect(topLeft.style.getPropertyValue('overflow-x')).toEqual('hidden')
       expect(topLeft.style.getPropertyValue('overflow-y')).toEqual('hidden')
-      expect(topRight.style.getPropertyValue('overflow')).toEqual('hidden')
       expect(topRight.style.getPropertyValue('overflow-x')).toEqual('hidden')
       expect(topRight.style.getPropertyValue('overflow-y')).toEqual('hidden')
-      expect(bottomLeft.style.getPropertyValue('overflow')).toEqual('hidden')
       expect(bottomLeft.style.getPropertyValue('overflow-x')).toEqual('hidden')
       expect(bottomLeft.style.getPropertyValue('overflow-y')).toEqual('hidden')
-      expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
       expect(bottomRight.style.getPropertyValue('overflow-x')).toEqual('auto')
       expect(bottomRight.style.getPropertyValue('overflow-y')).toEqual('auto')
     })
@@ -69,7 +65,8 @@ describe('MultiGrid', () => {
       const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
       expect(grids.length).toEqual(2)
       const [bottomLeft, bottomRight] = grids
-      expect(bottomLeft.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(bottomLeft.style.getPropertyValue('overflow-x')).toEqual('hidden')
+      expect(bottomLeft.style.getPropertyValue('overflow-y')).toEqual('hidden')
       expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
     })
 
@@ -81,7 +78,8 @@ describe('MultiGrid', () => {
       const grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
       expect(grids.length).toEqual(2)
       const [topRight, bottomRight] = grids
-      expect(topRight.style.getPropertyValue('overflow')).toEqual('hidden')
+      expect(topRight.style.getPropertyValue('overflow-x')).toEqual('hidden')
+      expect(topRight.style.getPropertyValue('overflow-y')).toEqual('hidden')
       expect(bottomRight.style.getPropertyValue('overflow')).toEqual('auto')
     })
 
@@ -113,18 +111,67 @@ describe('MultiGrid', () => {
       })))
       expect(rendered.querySelectorAll('.ReactVirtualized__Grid').length).toEqual(2)
     })
+  })
 
-    it('should render 4 Grids when configured for fixed columns and rows', () => {
+  describe('#recomputeGridSize', () => {
+    it('should clear calculated cached styles in recomputeGridSize', () => {
+      let fixedRowHeight = 75
+      let fixedColumnWidth = 100
+
+      function variableRowHeight ({index}) {
+        if (index === 0) { return fixedRowHeight }
+        return 20
+      }
+      function variableColumnWidth ({index}) {
+        if (index === 0) { return fixedColumnWidth }
+        return 50
+      }
+
       let multiGrid
-      findDOMNode(render(getMarkup({
+      let rendered = findDOMNode(render(getMarkup({
         fixedColumnCount: 1,
         fixedRowCount: 1,
-        ref: (ref) => {
-          multiGrid = ref
-        }
+        rowHeight: variableRowHeight,
+        columnWidth: variableColumnWidth,
+        ref: (ref) => { multiGrid = ref }
       })))
 
+      let grids = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(grids.length).toEqual(4)
+      let [topLeft, topRight, bottomLeft, bottomRight] = grids
+      expect(topLeft.style.getPropertyValue('height')).toEqual('75px')
+      expect(topRight.style.getPropertyValue('height')).toEqual('75px')
+      expect(bottomLeft.style.getPropertyValue('height')).toEqual('225px')
+      expect(bottomRight.style.getPropertyValue('height')).toEqual('225px')
+
+      expect(topLeft.style.getPropertyValue('width')).toEqual('100px')
+      expect(topRight.style.getPropertyValue('width')).toEqual('300px')
+      expect(bottomLeft.style.getPropertyValue('width')).toEqual('100px')
+      expect(bottomRight.style.getPropertyValue('width')).toEqual('300px')
+
+      expect(multiGrid._topGridHeight).toEqual(75)
+      expect(multiGrid._leftGridWidth).toEqual(100)
+
+      fixedRowHeight = 125
+      fixedColumnWidth = 75
       multiGrid.recomputeGridSize()
+      expect(multiGrid._topGridHeight).toEqual(125)
+      expect(multiGrid._leftGridWidth).toEqual(75)
+
+      multiGrid.forceUpdate()
+
+      let gridsAfter = rendered.querySelectorAll('.ReactVirtualized__Grid')
+      expect(gridsAfter.length).toEqual(4)
+      let [topLeftAfter, topRightAfter, bottomLeftAfter, bottomRightAfter] = gridsAfter
+      expect(topLeftAfter.style.getPropertyValue('height')).toEqual('125px')
+      expect(topRightAfter.style.getPropertyValue('height')).toEqual('125px')
+      expect(bottomLeftAfter.style.getPropertyValue('height')).toEqual('175px')
+      expect(bottomRightAfter.style.getPropertyValue('height')).toEqual('175px')
+
+      expect(topLeftAfter.style.getPropertyValue('width')).toEqual('75px')
+      expect(topRightAfter.style.getPropertyValue('width')).toEqual('325px')
+      expect(bottomLeftAfter.style.getPropertyValue('width')).toEqual('75px')
+      expect(bottomRightAfter.style.getPropertyValue('width')).toEqual('325px')
     })
   })
 


### PR DESCRIPTION
For a MultiGrid (wrapped by an AutoSizer) with rowHeight and columnWidth functions, grid sizes are not recalculated after window resizing. I attached an onResize function to the AutoSizer to explicitly force it via calling MultiGrid.recomputeGridSize(). In the course of debugging that, I encountered these 3 bugs.

Even after calling recomputeGridSize with these fixes, I still needed to call _maybeCalculateCachedStyles, but I wan't sure if that should always occur in the recomputeGridSize call or not.

