### PR TITLE
Fix some typos in the docs

### DIFF
--- a/docs/Collection.md
+++ b/docs/Collection.md
@@ -4,7 +4,7 @@ Collection
 Renders scattered or non-linear data.
 Unlike `Grid`, which renders checkerboard data, `Collection` can render arbitrarily positioned- even overlapping- data.
 
-**Note** that this component's measuring and layout phase is more expensive than `Grid` since it can not assume a correlation between a cell's index and position. For this reason it will take signifnicantly longer to initialize than the more linear/checkerboard components.
+**Note** that this component's measuring and layout phase is more expensive than `Grid` since it can not assume a correlation between a cell's index and position. For this reason it will take significantly longer to initialize than the more linear/checkerboard components.
 
 ### Prop Types
 | Property | Type | Required? | Description |
@@ -16,7 +16,7 @@ Unlike `Grid`, which renders checkerboard data, `Collection` can render arbitrar
 | cellRenderer | Function | ✓ | Responsible for rendering a cell given an row and column index: `({ index: number, isScrolling: boolean, key: string, style: object }): PropTypes.element` |
 | cellSizeAndPositionGetter | Function | ✓ | Callback responsible for returning size and offset/position information for a given cell (index): `({ index: number }): { height: number, width: number, x: number, y: number }` |
 | height | Number | ✓ | Height of Collection; this property determines the number of visible (vs virtualized) rows. |
-| horizontalOverscanSize | Number |  | Enables the `Collection` to horiontally "overscan" its content similar to how `Grid` does. This can reduce flicker around the edges when a user scrolls quickly. This property defaults to `0`; |
+| horizontalOverscanSize | Number |  | Enables the `Collection` to horizontally "overscan" its content similar to how `Grid` does. This can reduce flicker around the edges when a user scrolls quickly. This property defaults to `0`; |
 | id | String |  | Optional custom id to attach to root `Collection` element. |
 | noContentRenderer | Function |  | Optional renderer to be rendered inside the grid when `cellCount` is 0: `(): PropTypes.node` |
 | onSectionRendered | Function |  | Callback invoked with information about the section of the Collection that was just rendered: `({ indices: Array<number> }): void` |

--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -21,8 +21,8 @@ A windowed grid of elements. `Grid` only renders cells necessary to fill itself 
 | noContentRenderer | Function |  | Optional renderer to be rendered inside the grid when either `rowCount` or `columnCount` is empty: `(): PropTypes.node` |
 | onSectionRendered | Function |  | Callback invoked with information about the section of the Grid that was just rendered. This callback is only invoked when visible rows have changed: `({ columnOverscanStartIndex: number, columnOverscanStopIndex: number, columnStartIndex: number, columnStopIndex: number, rowOverscanStartIndex: number, rowOverscanStopIndex: number, rowStartIndex: number, rowStopIndex: number }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, clientWidth: number, scrollHeight: number, scrollLeft: number, scrollTop: number, scrollWidth: number }): void` |
-| overscanColumnCount | Number |  | Number of columns to render before/after the visible slice of the grid. This can help reduce flickering during scrolling on certain browers/devices. |
-| overscanRowCount | Number |  | Number of rows to render above/below the visible slice of the grid. This can help reduce flickering during scrolling on certain browers/devices. |
+| overscanColumnCount | Number |  | Number of columns to render before/after the visible slice of the grid. This can help reduce flickering during scrolling on certain browsers/devices. |
+| overscanRowCount | Number |  | Number of rows to render above/below the visible slice of the grid. This can help reduce flickering during scrolling on certain browsers/devices. |
 | rowCount | Number | ✓ | Number of rows in grid. |
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | scrollingResetTimeInterval | Number |  | Wait this amount of time after the last scroll event before resetting Grid `pointer-events`; defaults to 150ms. |

--- a/docs/InfiniteLoader.md
+++ b/docs/InfiniteLoader.md
@@ -3,7 +3,7 @@ InfiniteLoader
 
 Higher-order component that manages just-in-time fetching of data as a user scrolls up or down in a list.
 
-Note that this component is inteded to assist with row-loading.
+Note that this component is intended to assist with row-loading.
 As such it is best suited for use with `Table` and `List` (although it can also be used with `Grid`).
 This HOC is not compatible with the `Collection` component.
 
@@ -155,7 +155,7 @@ _isRowLoaded ({ index }) {
 ###### Memoization and rowCount changes
 
 `InfiniteLoader` memoizes calls to `loadMoreRows` in order to avoid multiple calls with the same parameters while a user is scrolling.
-This can have an unexpected impact though if the underlying colleection data changes.
+This can have an unexpected impact though if the underlying collection data changes.
 In that case it is possible that `InfiniteLoader` will not _know_ to call `loadMoreRows` again because- from its point of view- it already made that call for a given row.
 (React Virtualized components do not know anything about the underlying data after all, only the number of items in the collection.)
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -15,7 +15,7 @@ Elements can have fixed or varying heights.
 | noRowsRenderer | Function |  | Callback used to render placeholder content when `rowCount` is 0 |
 | onRowsRendered | Function |  | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number, scrollTop: number }): void` |
-| overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
+| overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browsers/devices. |
 | rowCount | Number | ✓ | Number of rows in list. |
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | rowRenderer | Function | ✓ | Responsible for rendering a row. Signature should look like `({ index: number, key: string, style: Object, isScrolling: boolean }): React.PropTypes.node` and the returned element must handle index, key and style.|
@@ -29,7 +29,7 @@ Elements can have fixed or varying heights.
 ### Public Methods
 
 ##### forceUpdateGrid
-Forcefull re-render the inner `Grid` component.
+Forcefully re-render the inner `Grid` component.
 
 Calling `forceUpdate` on `List` may not re-render the inner `Grid` since it uses `shallowCompare` as a performance optimization.
 Use this method if you want to manually trigger a re-render.

--- a/docs/ScrollSync.md
+++ b/docs/ScrollSync.md
@@ -16,7 +16,7 @@ The child function is passed the following named parameters:
 |:---|:---|:---|
 | clientHeight | Number | Height of the visible portion of the `Grid` (or other scroll-synced component) |
 | clientWidth | Number | Width of the visible portion of the `Grid` (or other scroll-synced component) |
-| onScroll | Function | This function should be passed through to at least one of the virtualized child components. Updates to it will trigger updates to the scroll ofset parameters which will in turn update the other virtualized children. |
+| onScroll | Function | This function should be passed through to at least one of the virtualized child components. Updates to it will trigger updates to the scroll offset parameters which will in turn update the other virtualized children. |
 | scrollHeight | Number | Total height of all rows in the `Grid` (or other scroll-synced component) |
 | scrollLeft | Number | The current scroll-left offset. |
 | scrollTop | Number | The current scroll-top offset. |

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -27,7 +27,7 @@ This component expects explicit `width` and `height` parameters.
 | onRowMouseOut | Function | | Callback invoked when the mouse leaves a table row. `({ index: number }): void` |
 | onRowMouseOver | Function |  | Callback invoked when a user moves the mouse over a table row. `({ index: number }): void` |
 | onRowsRendered | Function |  | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
-| overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browers/devices. |
+| overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browsers/devices. |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number, scrollTop: number }): void` |
 | rowClassName | String or Function |  | CSS class to apply to all table rows (including the header row). This value may be either a static string or a function with the signature `({ index: number }): string`. Note that for the header row an index of `-1` is provided. |
 | rowCount | Number | ✓ | Number of rows in table. |
@@ -48,7 +48,7 @@ This component expects explicit `width` and `height` parameters.
 ### Public Methods
 
 ##### forceUpdateGrid
-Forcefull re-render the inner `Grid` component.
+Forcefully re-render the inner `Grid` component.
 
 Calling `forceUpdate` on `Table` may not re-render the inner `Grid` since it uses `shallowCompare` as a performance optimization.
 Use this method if you want to manually trigger a re-render.

--- a/docs/reverseList.md
+++ b/docs/reverseList.md
@@ -1,7 +1,7 @@
 Displaying Items in Reverse Order
 ---------------
 
-Sometimes it is desirable to dislpay a list in reverse order.
+Sometimes it is desirable to display a list in reverse order.
 The simplest way to do this is to add items to the front of the list (`unshift`) instead of the end (`push`).
 Here is a high level template for doing this:
 


### PR DESCRIPTION
This fixes some minor typos that I noticed while reading the docs.