### PR TITLE
iOS scroll bounce fix - skip event if scrollTop < 0

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -900,6 +900,12 @@ export default class Grid extends Component {
       return
     }
 
+    // On iOS, we can arrive at negative offsets by swiping past the start
+    // To prevent flicker here, we make playing in the negative offset zone cause nothing to happen.
+    if (event.target.scrollTop < 0) {
+      return
+    }
+
     // Prevent pointer events from interrupting a smooth scroll
     this._debounceScrollEnded()
 


### PR DESCRIPTION
If we're at a scrollTop above 0, just avoid triggering the scroll event entirely, or maybe I should pass the event through.
This is a McDonalds fix, feel free to critique this as needed. Thanks!
Resolves #532
