### PR TITLE
Update PostCSS & Autoprefixer configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run build:commonjs && npm run build:css && npm run build:es && npm run build:demo && npm run build:umd",
     "build:commonjs": "npm run clean:commonjs && cross-env NODE_ENV=production cross-env BABEL_ENV=commonjs babel source --out-dir dist/commonjs --ignore *.example.js,*.test.js,source/demo/,source/tests.js",
-    "build:css": "postcss --use autoprefixer source/styles.css > styles.css",
+    "build:css": "postcss --config postcss.config.js --use autoprefixer source/styles.css > styles.css",
     "build:demo": "npm run clean:demo && cross-env NODE_ENV=production webpack --config webpack.config.demo.js -p --bail",
     "build:es": "npm run clean:es && cross-env NODE_ENV=production cross-env BABEL_ENV=es babel source --out-dir dist/es --ignore *.example.js,*.test.js,source/demo/,source/tests.js",
     "build:umd": "npm run clean:umd && cross-env NODE_ENV=production webpack --config webpack.config.umd.js --bail",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "autoprefixer": {
+    "browsers": ["last 2 version", "Firefox 15", "iOS 8"],
+  },
+  // The plugins section is used by postcss-loader with webpack
+  plugins: [
+    require('autoprefixer'),
+  ],
+}

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -38,12 +38,9 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loaders: ['style', 'css?importLoaders=1'],
+        loaders: ['style', 'css?importLoaders=1&minimize=false'],
         include: path.join(__dirname, 'styles.css')
       }
     ]
-  },
-  postcss: function () {
-    return [autoprefixer]
   }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -35,13 +35,10 @@ const config = {
       },
       {
         test: /\.css$/,
-        loaders: ['style', 'css?importLoaders=1'],
+        loaders: ['style', 'css?importLoaders=1&minimize=false'],
         include: path.join(__dirname, 'styles.css')
       }
     ]
-  },
-  postcss: function () {
-    return [autoprefixer]
   },
   devServer: {
     contentBase: 'build',

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -1,4 +1,3 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const path = require('path')
 const webpack = require('webpack')
 
@@ -19,11 +18,6 @@ module.exports = {
     'react-addons-shallow-compare': 'var React.addons.shallowCompare'
   },
   plugins: [
-    new ExtractTextPlugin('../styles.css', {
-      allChunks: false,
-      beautify: true,
-      mangle: false
-    }),
     new webpack.optimize.UglifyJsPlugin({
       beautify: true,
       comments: true,
@@ -36,12 +30,6 @@ module.exports = {
         test: /\.js$/,
         loaders: ['babel'],
         include: path.join(__dirname, 'source')
-      },
-      {
-        test: /\.css$/,
-        loader: ExtractTextPlugin.extract('css-loader!autoprefixer-loader?{browsers:["last 2 version", "Firefox 15", "iOS 8"]}'),
-        include: path.join(__dirname, 'source')
-
       }
     ]
   }

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -39,7 +39,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('css-loader!autoprefixer-loader?{browsers:["last 2 version", "Firefox 15"]}'),
+        loader: ExtractTextPlugin.extract('css-loader!autoprefixer-loader?{browsers:["last 2 version", "Firefox 15", "iOS 8"]}'),
         include: path.join(__dirname, 'source')
 
       }


### PR DESCRIPTION
This PR adds a unified `postcss.config.js` file to avoid duplication of settings across different webpack.config files and is also shared by postcss-cli (as per the recommended [postcss-loader setup guide](https://github.com/postcss/postcss-loader))

As discussed in #578, I also added iOS8 to the list of browsers so Autoprefixer can add the right vendor-prefixed properties. 

You'll notice I had to explicitly add `&minimize=false` to `css-loader`. This is to safeguard against `webpack.optimize.UglifyJsPlugin` affecting our vendor-prefixed css (see https://github.com/webpack/webpack/issues/283 for more details).

Finally, I noticed some CSS configs in [webpack.config.umd.js](https://github.com/bvaughn/react-virtualized/blob/master/webpack.config.umd.js#L42) but I don't think these are still used (I could be wrong, I'm guessing this was later replaced by the [build:css](https://github.com/bvaughn/react-virtualized/blob/master/package.json#L16) script). Is it safe to assume this can be removed? Happy to update this PR if so.