### PR TITLE
Issue #589: add public setter on ArrowKeyStepper to override scroll indexes

### DIFF
--- a/docs/ArrowKeyStepper.md
+++ b/docs/ArrowKeyStepper.md
@@ -18,6 +18,11 @@ The appearance of this wrapper element can be customized using the `className` p
 | scrollToColumn | Number |  | Optional default/initial `scrollToColumn` value |
 | scrollToRow | Number |  | Optional default/initial `scrollToRow` value |
 
+### Public Methods
+
+##### setScrollIndexes
+Override the local state of the component with new values for `scrollToRow` and `scrollToColumn`.
+
 ### Children function
 
 The child function is passed the following named parameters:

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -63,6 +63,13 @@ export default class ArrowKeyStepper extends PureComponent {
     }
   }
 
+  setScrollIndexes (scrollToRow, scrollToColumn) {
+    this.setState({
+      scrollToRow,
+      scrollToColumn
+    })
+  }
+
   render () {
     const { className, children } = this.props
     const { scrollToColumn, scrollToRow } = this.state


### PR DESCRIPTION
Add a public setter on `ArrowKeyStepper` in order to override the scroll indexes in its local state.
See issue #589 for details.