### PR TITLE
Use typeof function instead of instanceof Function

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -954,7 +954,7 @@ export default class Grid extends PureComponent {
   }
 
   _wrapPropertyGetter (value) {
-    return value instanceof Function
+    return typeof value === 'function'
       ? value
       : () => value
   }

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -206,7 +206,7 @@ export default class MultiGrid extends PureComponent {
   _columnWidthRightGrid ({ index }) {
     const { fixedColumnCount, columnWidth } = this.props
 
-    return columnWidth instanceof Function
+    return typeof columnWidth === 'function'
       ? columnWidth({ index: index + fixedColumnCount })
       : columnWidth
   }
@@ -223,7 +223,7 @@ export default class MultiGrid extends PureComponent {
     const { fixedColumnCount, columnWidth } = props
 
     if (this._leftGridWidth == null) {
-      if (columnWidth instanceof Function) {
+      if (typeof columnWidth === 'function') {
         let leftGridWidth = 0
 
         for (let index = 0; index < fixedColumnCount; index++) {
@@ -251,7 +251,7 @@ export default class MultiGrid extends PureComponent {
     const { fixedRowCount, rowHeight } = props
 
     if (this._topGridHeight == null) {
-      if (rowHeight instanceof Function) {
+      if (typeof rowHeight === 'function') {
         let topGridHeight = 0
 
         for (let index = 0; index < fixedRowCount; index++) {
@@ -516,7 +516,7 @@ export default class MultiGrid extends PureComponent {
   _rowHeightBottomGrid ({ index }) {
     const { fixedRowCount, rowHeight } = this.props
 
-    return rowHeight instanceof Function
+    return typeof rowHeight === 'function'
       ? rowHeight({ index: index + fixedRowCount })
       : rowHeight
   }

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -271,8 +271,8 @@ export default class Table extends PureComponent {
 
     const availableRowsHeight = disableHeader ? height : height - headerHeight
 
-    const rowClass = rowClassName instanceof Function ? rowClassName({ index: -1 }) : rowClassName
-    const rowStyleObject = rowStyle instanceof Function ? rowStyle({ index: -1 }) : rowStyle
+    const rowClass = typeof rowClassName === 'function' ? rowClassName({ index: -1 }) : rowClassName
+    const rowStyleObject = typeof rowStyle === 'function' ? rowStyle({ index: -1 }) : rowStyle
 
     // Precompute and cache column styles before rendering rows and columns to speed things up
     this._cachedColumnStyles = []
@@ -456,8 +456,8 @@ export default class Table extends PureComponent {
 
     const { scrollbarWidth } = this.state
 
-    const rowClass = rowClassName instanceof Function ? rowClassName({ index }) : rowClassName
-    const rowStyleObject = rowStyle instanceof Function ? rowStyle({ index }) : rowStyle
+    const rowClass = typeof rowClassName === 'function' ? rowClassName({ index }) : rowClassName
+    const rowStyleObject = typeof rowStyle === 'function' ? rowStyle({ index }) : rowStyle
     const rowData = rowGetter({ index })
 
     const columns = React.Children.toArray(children).map(
@@ -532,7 +532,7 @@ export default class Table extends PureComponent {
   _getRowHeight (rowIndex) {
     const { rowHeight } = this.props
 
-    return rowHeight instanceof Function
+    return typeof rowHeight === 'function'
       ? rowHeight({ index: rowIndex })
       : rowHeight
   }

--- a/source/Table/defaultCellDataGetter.js
+++ b/source/Table/defaultCellDataGetter.js
@@ -11,7 +11,7 @@ export default function defaultCellDataGetter ({
   dataKey,
   rowData
 }: CellDataGetterParams) {
-  if (rowData.get instanceof Function) {
+  if (typeof rowData.get === 'function') {
     return rowData.get(dataKey)
   } else {
     return rowData[dataKey]

--- a/source/utils/initCellMetadata.js
+++ b/source/utils/initCellMetadata.js
@@ -10,7 +10,7 @@ export default function initCellMetadata ({
   cellCount,
   size
 }) {
-  const sizeGetter = size instanceof Function
+  const sizeGetter = typeof size === 'function'
     ? size
     : ({ index }) => size
 


### PR DESCRIPTION
Using ```instanceof Function``` would be error prone and always return false if the ```Function``` instance comes from another iframe window,. Replace it by typeof check can be safer.