### PR TITLE
Update WindowScroller propTypes and docs

### DIFF
--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -13,6 +13,7 @@ This may change with a future release but for the time being this HOC is should 
 | children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, isScrolling: boolean, scrollTop: number }) => PropTypes.element` |
 | onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number })`. | 
 | onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number })`. | 
+| scrollElement | any |  | Element to attach scroll event listeners. Defaults to window. |
 
 ### Public Methods
 

--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -13,7 +13,7 @@ This may change with a future release but for the time being this HOC is should 
 | children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, isScrolling: boolean, scrollTop: number }) => PropTypes.element` |
 | onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number })`. | 
 | onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number })`. | 
-| scrollElement | any |  | Element to attach scroll event listeners. Defaults to window. |
+| scrollElement | any |  | Element to attach scroll event listeners. Defaults to `window`. |
 
 ### Public Methods
 

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -14,10 +14,10 @@ export default class WindowScroller extends PureComponent {
     children: PropTypes.func.isRequired,
 
     /** Callback to be invoked on-resize: ({ height }) */
-    onResize: PropTypes.func.isRequired,
+    onResize: PropTypes.func,
 
     /** Callback to be invoked on-scroll: ({ scrollTop }) */
-    onScroll: PropTypes.func.isRequired,
+    onScroll: PropTypes.func,
 
     /** Element to attach scroll event listeners. Defaults to window. */
     scrollElement: PropTypes.any

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -14,10 +14,10 @@ export default class WindowScroller extends PureComponent {
     children: PropTypes.func.isRequired,
 
     /** Callback to be invoked on-resize: ({ height }) */
-    onResize: PropTypes.func,
+    onResize: PropTypes.func.isRequired,
 
     /** Callback to be invoked on-scroll: ({ scrollTop }) */
-    onScroll: PropTypes.func,
+    onScroll: PropTypes.func.isRequired,
 
     /** Element to attach scroll event listeners. Defaults to window. */
     scrollElement: PropTypes.any


### PR DESCRIPTION
- Make WindowScroller's propTypes **onScroll**, **onResize** optional.
- Add missing prop **scrollElement** in WindowScroller's docs.
