### PR TITLE
Horizontal table scrolling

### DIFF
--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -819,6 +819,7 @@ describe('Table', () => {
       expect(onScrollCalls).toEqual([{
         clientHeight: 80,
         scrollHeight: 1000,
+        scrollLeft: 0,
         scrollTop: 0
       }])
     })
@@ -838,6 +839,7 @@ describe('Table', () => {
       expect(onScrollCalls[1]).toEqual({
         clientHeight: 80,
         scrollHeight: 1000,
+        scrollLeft: 0,
         scrollTop: 100
       })
     })


### PR DESCRIPTION
Hey!  We love your react-virtualized tables.  We recently migrated from fixed-data-table to react-virtualized, but we discovered that react-virtualized tables don't support horizontal scrolling.  We created some hacky fixes in our project to deal with this (forcing overflowX to on and cleaning up the row widths and header translation in a componentDidUpdate), but I wanted to contribute these enhancements back to react-virtualized itself!

Note that I ran npm test and got some failures which were pre-existing before my changes.  I did make a minor change to fix something which did actually break as a result of these changes.
