### PR TITLE
Support for passing event objects thru to various event handlers

### DIFF
--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -403,17 +403,17 @@ export default class Table extends PureComponent {
         ? SortDirection.ASC
         : SortDirection.DESC
 
-      const onClick = () => {
+      const onClick = (evt) => {
         sortEnabled && sort({
           sortBy: dataKey,
           sortDirection: newSortDirection
         })
-        onHeaderClick && onHeaderClick({ columnData, dataKey })
+        onHeaderClick && onHeaderClick({ evt, columnData, dataKey })
       }
 
       const onKeyDown = (event) => {
         if (event.key === 'Enter' || event.key === ' ') {
-          onClick()
+          onClick(event)
         }
       }
 

--- a/source/Table/defaultRowRenderer.js
+++ b/source/Table/defaultRowRenderer.js
@@ -31,16 +31,16 @@ export default function defaultRowRenderer ({
     a11yProps.tabIndex = 0
 
     if (onRowClick) {
-      a11yProps.onClick = () => onRowClick({ index, rowData })
+      a11yProps.onClick = (evt) => onRowClick({ evt, index, rowData })
     }
     if (onRowDoubleClick) {
-      a11yProps.onDoubleClick = () => onRowDoubleClick({ index, rowData })
+      a11yProps.onDoubleClick = (evt) => onRowDoubleClick({ evt, index, rowData })
     }
     if (onRowMouseOut) {
-      a11yProps.onMouseOut = () => onRowMouseOut({ index, rowData })
+      a11yProps.onMouseOut = (evt) => onRowMouseOut({ evt, index, rowData })
     }
     if (onRowMouseOver) {
-      a11yProps.onMouseOver = () => onRowMouseOver({ index, rowData })
+      a11yProps.onMouseOver = (evt) => onRowMouseOver({ evt, index, rowData })
     }
   }
 


### PR DESCRIPTION
So in addition to the change we made to support horizontal scrolling, we also added support for passing event objects thru the various event handlers, particularly in defaultCellRenderer.  Yes, we can (and did) build our own cellRenderer to accomodate passing these event objects thru (which we needed to check the CTRL and ALT key state for some behaviors we were looking at add), but it seemed to me that it would be nice if the default renderer passed these thru.