### PR TITLE
Allow extra props to be passed transparently through the `CellMeasurer`

### DIFF
--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -1,5 +1,5 @@
 /** @flow */
-import { PureComponent } from 'react'
+import { PureComponent, cloneElement } from 'react'
 import { findDOMNode } from 'react-dom'
 
 type Props = {
@@ -34,11 +34,19 @@ export default class CellMeasurer extends PureComponent {
   }
 
   render () {
-    const { children } = this.props
+    const {
+      children,
+      cache, // eslint-disable-line no-unused-vars
+      columnIndex, // eslint-disable-line no-unused-vars
+      parent, // eslint-disable-line no-unused-vars
+      rowIndex, // eslint-disable-line no-unused-vars
+      style, // eslint-disable-line no-unused-vars
+      ...rest
+    } = this.props
 
     return typeof children === 'function'
-      ? children({ measure: this._measure })
-      : children
+      ? children({ ...rest, measure: this._measure })
+      : cloneElement(children, rest)
   }
 
   _maybeMeasureCell () {


### PR DESCRIPTION
Firstly the CellMeasurer is a great tool!!, however I have a use-case where I need the props past into the CellMeasurer to be forwarded onto its Child. This is because the props are added via a higher order component, in the parent component's render function (out of my control). Having the ability to transparently pass the props though would solve this problem.

Thanks

✅  Tests Pass Locally
✅  Lint Pass Locally