### PR TITLE
Fixed infinite loader jumping to the top row when scrolling fast

### DIFF
--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -99,7 +99,7 @@ export default class InfiniteLoader extends PureComponent {
             })
           ) {
             if (this._registeredChild) {
-              forceUpdateReactVirtualizedComponent(this._registeredChild)
+              forceUpdateReactVirtualizedComponent(this._registeredChild, this._lastRenderedStartIndex)
             }
           }
         })
@@ -243,13 +243,13 @@ export function scanForUnloadedRanges ({
  * So it's important to invalidate that cache by recalculating sizes
  * before forcing a rerender.
  */
-export function forceUpdateReactVirtualizedComponent (component) {
+export function forceUpdateReactVirtualizedComponent (component, currentIndex = 0) {
   const recomputeSize = typeof component.recomputeGridSize === 'function'
     ? component.recomputeGridSize
     : component.recomputeRowHeights
 
   if (recomputeSize) {
-    recomputeSize.call(component)
+    recomputeSize.call(component, currentIndex)
   } else {
     component.forceUpdate()
   }


### PR DESCRIPTION
Hi,
I've been using react-virtualized recently for my personal project to build an electronjs app. And, this turns out to be such an awesome library to use. Thanks for the amazing work!

Anyway, I've found some weird glitch on InfiniteLoader, so I figured I'd give it a go at fixing it.
I'm not sure if I should create an issue first or if a straight pull request is ok. 
Anyway, I created a pull request so here it is:

The glitch is happening when you scroll too fast on infinite loader while using an ArrowKeyStepper. Every time you scroll fast it just seems to jump straight to the top row. I've created a [plunkr](https://plnkr.co/edit/NAf1LnmENXZpfb7YQviF?p=preview) to demonstrate this.

After debugging through the code, I noticed that:
forceUpdateReactVirtualizedComponent is called when refreshing visible
rows after loading data. This resulted in a call chain from
recomputeRowHeights with no args, which eventually led to a call to
recomputeGridSize with 0 rowIndex.

The fix was to pass in the currentIndex to preserve the current visible
row.

Let me know if this fix is correct and/or if i need to do anything more like writing test cases for this.

Thanks!


