### PR TITLE
Add public methods for animation

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -379,34 +379,20 @@ describe('Grid', () => {
       expect(grid.state.scrollTop).toEqual(50)
     })
 
-    it('should support getScrollLeft() method', () => {
+    it('should support getOffsetForCell() public method', () => {
       const grid = render(getMarkup())
-      const initialScrollLeft = grid.getScrollLeft()
-      const calculatedScrollLeft = grid.getScrollLeft({
-        ...grid.props,
-        scrollToColumn: 24
+      const { scrollLeft, scrollTop } = grid.getOffsetForCell({
+        columnIndex: 24,
+        rowIndex: 49
       })
-
-      expect(initialScrollLeft).toEqual(0)
       // 100 columns * 50 item width = 5,000 total item width
       // 4 columns can be visible at a time and :scrollLeft is initially 0,
       // So the minimum amount of scrolling leaves the 25th item at the right (just scrolled into view).
-      expect(calculatedScrollLeft).toEqual(1050)
-    })
-
-    it('should support getScrollTop() method', () => {
-      const grid = render(getMarkup())
-      const initialScrollTop = grid.getScrollTop()
-      const calculatedScrollTop = grid.getScrollTop({
-        ...grid.props,
-        scrollToRow: 49
-      })
-
-      expect(initialScrollTop).toEqual(0)
+      expect(scrollLeft).toEqual(1050)
       // 100 rows * 20 item height = 2,000 total item height
       // 5 rows can be visible at a time and :scrollTop is initially 0,
       // So the minimum amount of scrolling leaves the 50th item at the bottom (just scrolled into view).
-      expect(calculatedScrollTop).toEqual(900)
+      expect(scrollTop).toEqual(900)
     })
 
     // See issue #565

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -366,6 +366,21 @@ describe('Grid', () => {
       expect(grid.state.scrollTop).toEqual(900)
     })
 
+    it('should support getScrollLeft() method', () => {
+      const grid = render(getMarkup())
+      const initialScrollLeft = grid.getScrollLeft()
+      const calculatedScrollLeft = grid.getScrollLeft({
+        ...grid.props,
+        scrollToColumn: 24
+      })
+
+      expect(initialScrollLeft).toEqual(0)
+      // 100 columns * 50 item width = 5,000 total item width
+      // 4 columns can be visible at a time and :scrollLeft is initially 0,
+      // So the minimum amount of scrolling leaves the 25th item at the right (just scrolled into view).
+      expect(calculatedScrollLeft).toEqual(1050)
+    })
+
     it('should support getScrollTop() method', () => {
       const grid = render(getMarkup())
       const initialScrollTop = grid.getScrollTop()

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -366,6 +366,21 @@ describe('Grid', () => {
       expect(grid.state.scrollTop).toEqual(900)
     })
 
+    it('should support getScrollTop() method', () => {
+      const grid = render(getMarkup())
+      const initialScrollTop = grid.getScrollTop()
+      const calculatedScrollTop = grid.getScrollTop({
+        ...grid.props,
+        scrollToRow: 49
+      })
+
+      expect(initialScrollTop).toEqual(0)
+      // 100 rows * 20 item height = 2,000 total item height
+      // 5 rows can be visible at a time and :scrollTop is initially 0,
+      // So the minimum amount of scrolling leaves the 50th item at the bottom (just scrolled into view).
+      expect(calculatedScrollTop).toEqual(900)
+    })
+
     // See issue #565
     it('should update scroll position to account for changed cell sizes within a function prop wrapper', () => {
       let rowHeight = 20

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -366,6 +366,19 @@ describe('Grid', () => {
       expect(grid.state.scrollTop).toEqual(900)
     })
 
+    it('should support scrollToPosition() public method', () => {
+      const grid = render(getMarkup())
+      expect(grid.state.scrollLeft).toEqual(0)
+      expect(grid.state.scrollTop).toEqual(0)
+
+      grid.scrollToPosition({
+        scrollLeft: 50,
+        scrollTop: 50
+      })
+      expect(grid.state.scrollLeft).toEqual(50)
+      expect(grid.state.scrollTop).toEqual(50)
+    })
+
     it('should support getScrollLeft() method', () => {
       const grid = render(getMarkup())
       const initialScrollLeft = grid.getScrollLeft()

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -264,6 +264,7 @@ export default class Grid extends PureComponent {
     this._invokeOnGridRenderedHelper = this._invokeOnGridRenderedHelper.bind(this)
     this._onScroll = this._onScroll.bind(this)
     this._setScrollingContainerRef = this._setScrollingContainerRef.bind(this)
+    this._getCalculatedScrollLeft = this._getCalculatedScrollLeft.bind(this)
     this._updateScrollLeftForScrollToColumn = this._updateScrollLeftForScrollToColumn.bind(this)
     this._getCalculatedScrollTop = this._getCalculatedScrollTop.bind(this)
     this._updateScrollTopForScrollToRow = this._updateScrollTopForScrollToRow.bind(this)
@@ -380,6 +381,13 @@ export default class Grid extends PureComponent {
       ...props,
       scrollToRow: rowIndex
     })
+  }
+
+  /**
+   * Gets a calculated value to be used for `scrollLeft`
+   */
+  getScrollLeft (props = this.props, state = this.state) {
+    return this._getCalculatedScrollLeft(props, state) || 0;
   }
 
   /**
@@ -1007,7 +1015,7 @@ export default class Grid extends PureComponent {
     return this._wrapPropertyGetter(size)
   }
 
-  _updateScrollLeftForScrollToColumn (props = this.props, state = this.state) {
+  _getCalculatedScrollLeft (props = this.props, state = this.state) {
     const { columnCount, height, scrollToAlignment, scrollToColumn, width } = props
     const { scrollLeft } = state
 
@@ -1016,18 +1024,23 @@ export default class Grid extends PureComponent {
       const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize()
       const scrollBarSize = totalRowsHeight > height ? this._scrollbarSize : 0
 
-      const calculatedScrollLeft = this._columnSizeAndPositionManager.getUpdatedOffsetForIndex({
+      return this._columnSizeAndPositionManager.getUpdatedOffsetForIndex({
         align: scrollToAlignment,
         containerSize: width - scrollBarSize,
         currentOffset: scrollLeft,
         targetIndex
       })
+    }
+  }
 
-      if (scrollLeft !== calculatedScrollLeft) {
-        this._setScrollPosition({
-          scrollLeft: calculatedScrollLeft
-        })
-      }
+  _updateScrollLeftForScrollToColumn (props = this.props, state = this.state) {
+    const { scrollLeft } = state
+    const calculatedScrollLeft = this._getCalculatedScrollLeft(props, state)
+
+    if (calculatedScrollLeft >= 0 && scrollLeft !== calculatedScrollLeft) {
+      this._setScrollPosition({
+        scrollLeft: calculatedScrollLeft
+      })
     }
   }
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -268,6 +268,7 @@ export default class Grid extends PureComponent {
     this._updateScrollLeftForScrollToColumn = this._updateScrollLeftForScrollToColumn.bind(this)
     this._getCalculatedScrollTop = this._getCalculatedScrollTop.bind(this)
     this._updateScrollTopForScrollToRow = this._updateScrollTopForScrollToRow.bind(this)
+    this._setScrollPosition = this._setScrollPosition.bind(this)
 
     this._columnWidthGetter = this._wrapSizeGetter(props.columnWidth)
     this._rowHeightGetter = this._wrapSizeGetter(props.rowHeight)
@@ -381,6 +382,17 @@ export default class Grid extends PureComponent {
       ...props,
       scrollToRow: rowIndex
     })
+  }
+
+  /**
+   * Ensure offset position is visible
+   * Useful for animating position changes
+   */
+  scrollToPosition ({
+    scrollLeft = 0,
+    scrollTop = 0
+  } = {}) {
+    this._setScrollPosition({ scrollLeft, scrollTop })
   }
 
   /**

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -265,6 +265,7 @@ export default class Grid extends PureComponent {
     this._onScroll = this._onScroll.bind(this)
     this._setScrollingContainerRef = this._setScrollingContainerRef.bind(this)
     this._updateScrollLeftForScrollToColumn = this._updateScrollLeftForScrollToColumn.bind(this)
+    this._getCalculatedScrollTop = this._getCalculatedScrollTop.bind(this)
     this._updateScrollTopForScrollToRow = this._updateScrollTopForScrollToRow.bind(this)
 
     this._columnWidthGetter = this._wrapSizeGetter(props.columnWidth)
@@ -379,6 +380,13 @@ export default class Grid extends PureComponent {
       ...props,
       scrollToRow: rowIndex
     })
+  }
+
+  /**
+   * Gets a calculated value to be used for `scrollTop`
+   */
+  getScrollTop (props = this.props, state = this.state) {
+    return this._getCalculatedScrollTop(props, state) || 0;
   }
 
   componentDidMount () {
@@ -1023,7 +1031,7 @@ export default class Grid extends PureComponent {
     }
   }
 
-  _updateScrollTopForScrollToRow (props = this.props, state = this.state) {
+  _getCalculatedScrollTop (props = this.props, state = this.state) {
     const { height, rowCount, scrollToAlignment, scrollToRow, width } = props
     const { scrollTop } = state
 
@@ -1032,18 +1040,23 @@ export default class Grid extends PureComponent {
       const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
       const scrollBarSize = totalColumnsWidth > width ? this._scrollbarSize : 0
 
-      const calculatedScrollTop = this._rowSizeAndPositionManager.getUpdatedOffsetForIndex({
+      return this._rowSizeAndPositionManager.getUpdatedOffsetForIndex({
         align: scrollToAlignment,
         containerSize: height - scrollBarSize,
         currentOffset: scrollTop,
         targetIndex
       })
+    }
+  }
 
-      if (scrollTop !== calculatedScrollTop) {
-        this._setScrollPosition({
-          scrollTop: calculatedScrollTop
-        })
-      }
+  _updateScrollTopForScrollToRow (props = this.props, state = this.state) {
+    const { scrollTop } = state
+    const calculatedScrollTop = this._getCalculatedScrollTop(props, state)
+
+    if (calculatedScrollTop >= 0 && scrollTop !== calculatedScrollTop) {
+      this._setScrollPosition({
+        scrollTop: calculatedScrollTop
+      })
     }
   }
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -264,11 +264,6 @@ export default class Grid extends PureComponent {
     this._invokeOnGridRenderedHelper = this._invokeOnGridRenderedHelper.bind(this)
     this._onScroll = this._onScroll.bind(this)
     this._setScrollingContainerRef = this._setScrollingContainerRef.bind(this)
-    this._getCalculatedScrollLeft = this._getCalculatedScrollLeft.bind(this)
-    this._updateScrollLeftForScrollToColumn = this._updateScrollLeftForScrollToColumn.bind(this)
-    this._getCalculatedScrollTop = this._getCalculatedScrollTop.bind(this)
-    this._updateScrollTopForScrollToRow = this._updateScrollTopForScrollToRow.bind(this)
-    this._setScrollPosition = this._setScrollPosition.bind(this)
 
     this._columnWidthGetter = this._wrapSizeGetter(props.columnWidth)
     this._rowHeightGetter = this._wrapSizeGetter(props.rowHeight)
@@ -389,24 +384,33 @@ export default class Grid extends PureComponent {
    * Useful for animating position changes
    */
   scrollToPosition ({
-    scrollLeft = 0,
-    scrollTop = 0
+    scrollLeft,
+    scrollTop
   } = {}) {
     this._setScrollPosition({ scrollLeft, scrollTop })
   }
 
   /**
-   * Gets a calculated value to be used for `scrollLeft`
+   * Gets offsets for a given cell and alignment
    */
-  getScrollLeft (props = this.props, state = this.state) {
-    return this._getCalculatedScrollLeft(props, state) || 0;
-  }
+  getOffsetForCell ({
+    columnIndex,
+    rowIndex,
+    scrollToAlignment = this.props.scrollToAlignment
+  } = {}) {
+    const scrollToColumn = columnIndex >= 0 ? columnIndex : this.props.scrollToColumn
+    const scrollToRow = rowIndex >= 0 ? rowIndex : this.props.scrollToRow
+    const offsetProps = {
+      ...this.props,
+      scrollToColumn,
+      scrollToRow,
+      scrollToAlignment
+    }
 
-  /**
-   * Gets a calculated value to be used for `scrollTop`
-   */
-  getScrollTop (props = this.props, state = this.state) {
-    return this._getCalculatedScrollTop(props, state) || 0;
+    return {
+      scrollLeft: this._getCalculatedScrollLeft(offsetProps),
+      scrollTop: this._getCalculatedScrollTop(offsetProps)
+    }
   }
 
   componentDidMount () {

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -122,9 +122,17 @@ export default class List extends PureComponent {
     })
   }
 
-  /** See Grid#getScrollTop */
-  getScrollTop (props = this.props) {
-    return this.Grid.getScrollTop(props)
+  /** See Grid#getOffsetForCell */
+  getOffsetForRow ({
+    rowIndex,
+    scrollToAlignment
+  }) {
+    const { scrollTop } = this.Grid.getOffsetForCell({
+      columnIndex: 0,
+      rowIndex,
+      scrollToAlignment
+    })
+    return scrollTop
   }
 
   /** See Grid#scrollToCell */

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -122,6 +122,11 @@ export default class List extends PureComponent {
     })
   }
 
+  /** See Grid#getScrollTop */
+  getScrollTop (props = this.props) {
+    return this.Grid.getScrollTop(props)
+  }
+
   /** See Grid#scrollToCell */
   scrollToRow (index = 0) {
     this.Grid.scrollToCell({

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -135,6 +135,11 @@ export default class List extends PureComponent {
     })
   }
 
+  /** See Grid#scrollToPosition */
+  scrollToPosition (scrollTop = 0) {
+    this.Grid.scrollToPosition({ scrollTop })
+  }
+
   render () {
     const {
       className,


### PR DESCRIPTION
This PR adds the following public methods to `Grid`:
 - `getScrollTop`
 - `getScrollLeft`
 - `scrollToPosition`

The `List` component also gets, which passes thru to its own `Grid`:
 - `getScrollTop`
 - `scrollToPosition`

`Grid.getScrollTop` and `Grid.getScrollLeft` are to be used by components that need to know the calculated offsets in pixels for given row and/or column indexes. This is useful for animating. 

:link: See the comment in this [Plunker](https://plnkr.co/edit/1S9UT7) for a use case: 
```
// TODO This works for numeric rowHeights but it's hacky for function props.
// react-virtualized should expose this as a new List/Grid instance method.
```

`Grid.scrollToPosition` is intended to be used much like `Grid.scrollToRow`, so that a component can call it from its `Grid` instance and scroll to a specific offset. This is also useful for animation, so that a component does not have to reset its own internal state after animating, or `forceUpdate` in order to force a change in props.

Added tests to illustrate how they would work. Commits are atomic. ⚛️ 

💬 Original conversation in Slack where this came from: https://react-virtualized.slack.com/archives/C1XUJH7HB/p1490898846575686