### PR TITLE
Add scrollToIndex support in WindowScroller

### DIFF
--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -10,7 +10,7 @@ This may change with a future release but for the time being this HOC is should 
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
-| children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, isScrolling: boolean, scrollTop: number }) => PropTypes.element` |
+| children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, isScrolling: boolean, scrollTop: number, onChildScroll: function }) => PropTypes.element` |
 | onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number, width: number })`. |
 | onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number, scrollLeft: number })`. |
 | scrollElement | any |  | Element to attach scroll event listeners. Defaults to `window`. |
@@ -33,7 +33,7 @@ import 'react-virtualized/styles.css'; // only needs to be imported once
 
 ReactDOM.render(
   <WindowScroller>
-    {({ height, isScrolling, scrollTop }) => (
+    {({ height, isScrolling, scrollTop, onChildScroll }) => (
       <List
         autoHeight
         height={height}
@@ -42,6 +42,7 @@ ReactDOM.render(
         rowHeight={...}
         rowRenderer={...}
         scrollTop={scrollTop}
+        onScroll={onChildScroll}
         width={...}
       />
     )}

--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -137,7 +137,7 @@ export default class WindowScrollerExample extends PureComponent {
         className={className}
         style={style}
       >
-        <i style={{marginRight: 5}}>{index}</i>{row.name}
+        {row.name}
       </div>
     )
   }

--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -158,6 +158,8 @@ export default class WindowScrollerExample extends PureComponent {
       scrollToIndex = undefined
     }
 
-    this.setState({ scrollToIndex })
+    setTimeout(() => {
+      this.setState({ scrollToIndex })
+    }, 0)
   }
 }

--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -4,6 +4,7 @@ import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { ContentBox, ContentBoxHeader, ContentBoxParagraph } from '../demo/ContentBox'
+import { LabeledInput, InputRow } from '../demo/LabeledInput'
 import WindowScroller from './WindowScroller'
 import List from '../List'
 import AutoSizer from '../AutoSizer'
@@ -21,18 +22,20 @@ export default class WindowScrollerExample extends PureComponent {
     super(props)
 
     this.state = {
-      showHeaderText: true
+      showHeaderText: true,
+      scrollToIndex: undefined
     }
 
     this._hideHeader = this._hideHeader.bind(this)
     this._rowRenderer = this._rowRenderer.bind(this)
     this._onCheckboxChange = this._onCheckboxChange.bind(this)
+    this._onScrollToRowChange = this._onScrollToRowChange.bind(this)
     this._setRef = this._setRef.bind(this)
   }
 
   render () {
     const { list, isScrollingCustomElement, customElement } = this.context
-    const { showHeaderText } = this.state
+    const { showHeaderText, scrollToIndex } = this.state
 
     return (
       <ContentBox>
@@ -69,16 +72,25 @@ export default class WindowScrollerExample extends PureComponent {
             Use custom element for scrolling
           </label>
         </ContentBoxParagraph>
-
+        <InputRow>
+          <LabeledInput
+            label='Scroll to'
+            name='onScrollToRow'
+            placeholder='Index...'
+            onChange={this._onScrollToRowChange}
+            value={scrollToIndex || ''}
+          />
+        </InputRow>
         <div className={styles.WindowScrollerWrapper}>
           <WindowScroller
             ref={this._setRef}
             scrollElement={isScrollingCustomElement ? customElement : null}
           >
-            {({ height, isScrolling, scrollTop }) => (
+            {({ height, isScrolling, scrollTop, onChildScroll }) => (
               <AutoSizer disableHeight>
                 {({ width }) => (
                   <List
+                    ref={(el) => { window.listEl = el }}
                     autoHeight
                     className={styles.List}
                     height={height}
@@ -88,7 +100,9 @@ export default class WindowScrollerExample extends PureComponent {
                     rowHeight={30}
                     rowRenderer={this._rowRenderer}
                     scrollTop={scrollTop}
+                    scrollToIndex={scrollToIndex}
                     width={width}
+                    onScroll={onChildScroll}
                   />
                 )}
               </AutoSizer>
@@ -123,7 +137,7 @@ export default class WindowScrollerExample extends PureComponent {
         className={className}
         style={style}
       >
-        {row.name}
+        <i style={{marginRight: 5}}>{index}</i>{row.name}
       </div>
     )
   }
@@ -134,5 +148,16 @@ export default class WindowScrollerExample extends PureComponent {
 
   _onCheckboxChange (event) {
     this.context.setScrollingCustomElement(event.target.checked)
+  }
+
+  _onScrollToRowChange (event) {
+    const { list } = this.context
+    let scrollToIndex = Math.min(list.size - 1, parseInt(event.target.value, 10))
+
+    if (isNaN(scrollToIndex)) {
+      scrollToIndex = undefined
+    }
+
+    this.setState({ scrollToIndex })
   }
 }

--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -6,10 +6,14 @@ import { render } from '../TestUtils'
 import { IS_SCROLLING_TIMEOUT } from './utils/onScroll'
 import WindowScroller from './WindowScroller'
 
-function ChildComponent ({ scrollTop, isScrolling, height }) {
-  return (
-    <div>{`scrollTop:${scrollTop}, isScrolling:${isScrolling}, height:${height}`}</div>
-  )
+class ChildComponent extends React.Component {
+  render() {
+    const { scrollTop, isScrolling, height } = this.props
+
+    return (
+      <div>{`scrollTop:${scrollTop}, isScrolling:${isScrolling}, height:${height}`}</div>
+    )
+  }
 }
 
 function mockGetBoundingClientRectForHeader ({
@@ -32,15 +36,18 @@ function mockGetBoundingClientRectForHeader ({
 function getMarkup ({
   headerElements,
   documentOffset,
+  childRef,
   ...props
 } = {}) {
   const windowScroller = (
     <WindowScroller {...props}>
-      {({ height, isScrolling, scrollTop }) => (
+      {({ height, isScrolling, scrollTop, onChildScroll }) => (
         <ChildComponent
+          ref={childRef}
           height={height}
           isScrolling={isScrolling}
           scrollTop={scrollTop}
+          onScroll={onChildScroll}
         />
       )}
     </WindowScroller>
@@ -314,6 +321,94 @@ describe('WindowScroller', () => {
 
       expect(windowScroller._positionFromTop).toBe(200)
       expect(windowScroller._positionFromLeft).toBe(300)
+    })
+  })
+
+  describe('when child scrolls', () => {
+    let originalScrollTo
+    beforeEach(() => {
+      originalScrollTo = window.scrollTo
+      window.scrollTo = (scrollX, scrollY) => simulateWindowScroll({ scrollX, scrollY });
+    })
+
+    afterEach(() => {
+      window.scrollTo = originalScrollTo
+      render.unmount()
+    })
+
+    it('should scroll the scrollElement (when it is window) the desired amount', () => {
+      let windowScroller, childComponent
+
+      render(getMarkup({
+        ref: (ref) => {
+          windowScroller = ref
+        },
+        childRef: (ref) => {
+          childComponent = ref
+        }
+      }))
+
+      childComponent.props.onScroll({ scrollTop: 200 })
+
+      expect(window.scrollY).toEqual(200 + windowScroller._positionFromTop)
+    })
+
+    it('should not scroll the scrollElement if trying to scroll to where we already are', () => {
+      let windowScroller, childComponent
+
+
+      render(getMarkup({
+        ref: (ref) => {
+          windowScroller = ref
+        },
+        childRef: (ref) => {
+          childComponent = ref
+        }
+      }))
+
+      simulateWindowScroll({ scrollY: 200 })
+
+      window.scrollTo = jest.fn()
+
+      childComponent.props.onScroll({ scrollTop: 200 })
+
+      expect(window.scrollTo).not.toHaveBeenCalled()
+    })
+
+    it('should scroll the scrollElement (when it is an element) the desired amount', () => {
+      let windowScroller, childComponent
+      const divEl = document.createElement('div')
+
+      render(getMarkup({
+        ref: (ref) => {
+          windowScroller = ref
+        },
+        scrollElement: divEl,
+        childRef: (ref) => {
+          childComponent = ref
+        }
+      }))
+
+      childComponent.props.onScroll({ scrollTop: 200 })
+
+      expect(divEl.scrollTop).toEqual(200 + windowScroller._positionFromTop)
+    })
+
+    it('should update own scrollTop', () => {
+      let windowScroller, childComponent
+
+      render(getMarkup({
+        ref: (ref) => {
+          windowScroller = ref
+        },
+        childRef: (ref) => {
+          childComponent = ref
+        }
+      }))
+
+      childComponent.props.onScroll({ scrollTop: 200 })
+
+      expect(windowScroller.state.scrollTop).toEqual(200)
     })
   })
 })

--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -7,7 +7,7 @@ import { IS_SCROLLING_TIMEOUT } from './utils/onScroll'
 import WindowScroller from './WindowScroller'
 
 class ChildComponent extends React.Component {
-  render() {
+  render () {
     const { scrollTop, isScrolling, height } = this.props
 
     return (
@@ -328,7 +328,7 @@ describe('WindowScroller', () => {
     let originalScrollTo
     beforeEach(() => {
       originalScrollTo = window.scrollTo
-      window.scrollTo = (scrollX, scrollY) => simulateWindowScroll({ scrollX, scrollY });
+      window.scrollTo = (scrollX, scrollY) => simulateWindowScroll({ scrollX, scrollY })
     })
 
     afterEach(() => {
@@ -354,13 +354,9 @@ describe('WindowScroller', () => {
     })
 
     it('should not scroll the scrollElement if trying to scroll to where we already are', () => {
-      let windowScroller, childComponent
-
+      let childComponent
 
       render(getMarkup({
-        ref: (ref) => {
-          windowScroller = ref
-        },
         childRef: (ref) => {
           childComponent = ref
         }

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -129,26 +129,16 @@ export default class WindowScroller extends PureComponent {
   _onChildScroll ({ scrollTop }) {
     if (this.state.scrollTop === scrollTop) return
 
-    // Need this setTimeout here because otherwise for some reason by the time the 'scroll'
-    // event that happens after the `scrollTo` call, the `window.scrollY` value is incorrect.
-    // Visually, if setTimeout is not here, the scroll position changes back to the top
-    // even after calling `scrollTo` below.
-    // What makes this even weirder, this happens only if you scroll to a row index
-    // via the `scrollToRow` prop. This does not happen with the imperative method.
-    // setTimeout(() => {
-      const scrollElement = this.scrollElement
-      if (scrollElement.scrollTo) {
-        scrollElement.scrollTo(0, scrollTop + this._positionFromTop)
-        console.log('window.scrollY right after calling scrollTo', window.scrollY)
-      } else {
-        scrollElement.scrollTop = scrollTop + this._positionFromTop
-      }
-    // }, 0)
+    const scrollElement = this.scrollElement
+    if (scrollElement.scrollTo) {
+      scrollElement.scrollTo(0, scrollTop + this._positionFromTop)
+    } else {
+      scrollElement.scrollTop = scrollTop + this._positionFromTop
+    }
   }
 
   // Referenced by utils/onScroll
   __handleWindowScrollEvent (event) {
-    console.log('window.scrollY in scroll event', window.scrollY)
     const { onScroll } = this.props
 
     const scrollElement = this.props.scrollElement || window


### PR DESCRIPTION
Hi!

This is my attempt to tackle https://github.com/bvaughn/react-virtualized/issues/540. Since this is still not done I didn't add any tests nor updated the documentation, but will do when we decide this fix is correct and works as expected.

I modified the `WindowScroller` example to have the same `Scroll to index` input as the `List` example, so that we can test this.

The main code change is in `WindowScroller` now passing an extra field in the children callback that is `onChildScroll`, which should be wired to the child collection's `onScroll` property.

The `WindowScroller` handles that event and tries to scroll the scrollElement according to the children's `scrollTop`.

Notice however that I ran into a weird timing issue, which is why you see the `setTimeout` with `0` in the code there. Obviously I would like to know of a way to remove it if possible. When I set the `scrollIndex` prop in the list, and the `onChildScroll` callback is called, I try to change the scroll position of the scroll element. This works during that tick, but then a scroll event fires and I'm not sure why the scroll position is updated again to a value that is near the top.

The weird thing is that that _doesn't_ happen if I imperatively do `list.scrollToRow(index)` (I set a `ref` in the example and attached it to `window.listEl` so you can test this, no need to do `setTimeout` in this case), which is why it makes me thing that some other DOM stuff may be going on, or maybe I don't understand how something works.

I know you said you don't have much time to look at this, but just wanted to create the PR and see if there's anybody (either you or anybody) that could point me to what I'm doing wrong, or what I'm missing. Hopefully I'm close to solving this issue.

If you'd like further information that may help you actually take a look at this without taking much time from you, let me know as well.