### PR TITLE
Enable autoWidth on Grid in combination with horizontal WindowScroller

### DIFF
--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -11,8 +11,8 @@ This may change with a future release but for the time being this HOC is should 
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
 | children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, isScrolling: boolean, scrollTop: number }) => PropTypes.element` |
-| onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number })`. | 
-| onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number })`. | 
+| onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number, width: number })`. |
+| onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number, scrollLeft: number })`. |
 | scrollElement | any |  | Element to attach scroll event listeners. Defaults to `window`. |
 
 ### Public Methods

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1470,6 +1470,35 @@ describe('Grid', () => {
     })
   })
 
+  describe('autoWidth', () => {
+    it('should set the container width to auto to adjust to innerScrollContainer width', () => {
+      const props = {
+        autoWidth: true
+      }
+      const rendered = findDOMNode(render(getMarkup(props)))
+      expect(rendered.style.width).toEqual('auto')
+    })
+
+    it('should have container width still affecting number of columns rendered', () => {
+      const props = {
+        width: 500,
+        autoWidth: true
+      }
+      const rendered = findDOMNode(render(getMarkup(props)))
+      expect(rendered.querySelectorAll('.gridItem').length).toEqual(50) // 5 rows x 10 columns
+    })
+
+    it('should have innerScrollContainer width to be equal number of columns * columnWidth', () => {
+      const props = {
+        autoWidth: true
+      }
+      const grid = render(getMarkup(props))
+      const rendered = findDOMNode(grid)
+      expect(rendered.querySelector('.ReactVirtualized__Grid__innerScrollContainer').style.width).toEqual('2500px') // 50 columns * 50px columnWidth
+      expect(grid._rowSizeAndPositionManager.getTotalSize()).toEqual(2000)
+    })
+  })
+
   describe('tabIndex', () => {
     it('should be focusable by default', () => {
       const rendered = findDOMNode(render(getMarkup()))

--- a/source/WindowScroller/utils/dimensions.js
+++ b/source/WindowScroller/utils/dimensions.js
@@ -1,45 +1,67 @@
 /**
- * Gets the height of the element, accounting for API differences between
+ * Gets the dimensions of the element, accounting for API differences between
  * `window` and other DOM elements.
  */
-export function getHeight (element) {
+
+export function getDimensions (element) {
   if (element === window) {
-    return typeof window.innerHeight === 'number'
-      ? window.innerHeight
-      : 0
+    return {
+      height: typeof window.innerHeight === 'number'
+        ? window.innerHeight
+        : 0,
+      width: typeof window.innerWidth === 'number'
+        ? window.innerWidth
+        : 0
+    }
   }
 
-  return element.getBoundingClientRect().height
+  const { width, height } = element.getBoundingClientRect()
+  return { width, height }
 }
 
 /**
- * Gets the vertical position of an element within its scroll container.
+ * Gets the vertical and horizontal position of an element within its scroll container.
  * Elements that have been “scrolled past” return negative values.
  * Handles edge-case where a user is navigating back (history) from an already-scrolled page.
- * In this case the body’s top position will be a negative number and this element’s top will be increased (by that amount).
+ * In this case the body’s top or left position will be a negative number and this element’s top or left will be increased (by that amount).
  */
-export function getPositionFromTop (element, container) {
-  const offset = container === window ? 0 : getScrollTop(container)
+export function getPositionOffset (element, container) {
+  const scrollOffset = container === window
+    ? { top: 0, left: 0 }
+    : getScrollOffset(container)
   const containerElement = container === window
     ? document.documentElement
     : container
-  return (
-    element.getBoundingClientRect().top +
-    offset -
-    containerElement.getBoundingClientRect().top
-  )
+  const elementRect = element.getBoundingClientRect()
+  const containerRect = containerElement.getBoundingClientRect()
+  return {
+    top: elementRect.top +
+      scrollOffset.top -
+      containerRect.top,
+    left: elementRect.left +
+      scrollOffset.left -
+      containerRect.left
+  }
 }
 
 /**
- * Gets the vertical scroll amount of the element, accounting for IE compatibility
+ * Gets the vertical and horizontal scroll amount of the element, accounting for IE compatibility
  * and API differences between `window` and other DOM elements.
  */
-export function getScrollTop (element) {
+export function getScrollOffset (element) {
   if (element === window) {
-    return ('scrollY' in window)
-      ? window.scrollY
-      : document.documentElement.scrollTop
+    return {
+      top: ('scrollY' in window)
+        ? window.scrollY
+        : document.documentElement.scrollTop,
+      left: ('scrollX' in window)
+        ? window.scrollX
+        : document.documentElement.scrollLeft
+    }
   } else {
-    return element.scrollTop
+    return {
+      top: element.scrollTop,
+      left: element.scrollLeft
+    }
   }
 }


### PR DESCRIPTION
Adds the ability to use `WindowScroller` to detect horizontal scrolling. This allows the usage of `autoWidth` on the `Grid` component.
I'm not sure why these two cases weren't already implemented.