### PR TITLE
Clear cell cache when external scrolling ends

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1383,6 +1383,45 @@ describe('Grid', () => {
       done()
     })
 
+    it('should clear cache once :isScrolling via props is false', async () => {
+      const cellRendererCalls = []
+      function cellRenderer ({ columnIndex, key, rowIndex, style }) {
+        cellRendererCalls.push({ columnIndex, rowIndex })
+        return defaultCellRenderer({ columnIndex, key, rowIndex, style })
+      }
+      const props = {
+        cellRenderer,
+        columnWidth: 100,
+        height: 40,
+        rowHeight: 20,
+        scrollTop: 0,
+        isScrolling: true,
+        width: 100
+      }
+
+      render(getMarkup(props))
+      expect(cellRendererCalls).toEqual([
+        { columnIndex: 0, rowIndex: 0 },
+        { columnIndex: 0, rowIndex: 1 }
+      ])
+
+      render(getMarkup({
+        ...props,
+        isScrolling: false
+      }))
+
+      // Allow scrolling timeout to complete so that cell cache is reset
+      await new Promise(resolve => setTimeout(resolve, DEFAULT_SCROLLING_RESET_TIME_INTERVAL * 2))
+
+      cellRendererCalls.splice(0)
+
+      render(getMarkup({
+        ...props,
+        isScrolling: true
+      }))
+      expect(cellRendererCalls.length).not.toEqual(0)
+    })
+
     it('should clear cache if :recomputeGridSize is called', () => {
       const cellRendererCalls = []
       function cellRenderer ({ columnIndex, key, rowIndex, style }) {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -552,6 +552,12 @@ export default class Grid extends PureComponent {
     // Update onRowsRendered callback if start/stop indices have changed
     this._invokeOnGridRenderedHelper()
 
+    // If scrolling is controlled outside this component, trigger a scroll end
+    // whenever we are no longer scrolling
+    if (prevProps.isScrolling === true && this.props.isScrolling === false) {
+      this._debounceScrollEnded()
+    }
+
     // Changes to :scrollLeft or :scrollTop should also notify :onScroll listeners
     if (
       scrollLeft !== prevState.scrollLeft ||


### PR DESCRIPTION
With the fix in 9.5.0 for using the cell cache in`WindowScroller` (https://github.com/bvaughn/react-virtualized/blob/master/CHANGELOG.md#950), another bug was unveiled:

Since the `Grid` when used with `WindowScroller` does not emit `onScroll` events when the user scrolls, the cell cache is never cleaned up because the `_debounceScrollEnded` function is never called.

This PR fixes that by detecting if `props.isScrolling` changed from `true` to `false`, and call `this._debounceScrollEnded()` in that case.