### PR TITLE
columnIndex added to table column's cellRenderer function

### DIFF
--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -259,7 +259,7 @@ describe('Table', () => {
   describe('forceUpdateGrid', () => {
     it('should refresh inner Grid content when called', () => {
       let marker = 'a'
-      function cellRenderer ({ cellData, columnData, dataKey, rowData, rowIndex }) {
+      function cellRenderer ({ cellData, columnData, dataKey, rowData, rowIndex, columnIndex }) {
         return `${rowIndex}${marker}`
       }
       const component = render(getMarkup({ cellRenderer }))
@@ -284,7 +284,7 @@ describe('Table', () => {
 
     it('should use a custom cellRenderer if specified', () => {
       const rendered = findDOMNode(render(getMarkup({
-        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex }) => `Custom ${cellData}`
+        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex, columnIndex }) => `Custom ${cellData}`
       })))
       const nameColumns = rendered.querySelectorAll('.ReactVirtualized__Table__rowColumn:first-of-type')
       Array.from(nameColumns).forEach((nameColumn, index) => {
@@ -295,7 +295,7 @@ describe('Table', () => {
 
     it('should set the rendered cell content as the cell :title if it is a string', () => {
       const rendered = findDOMNode(render(getMarkup({
-        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex }) => 'Custom'
+        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex, columnIndex }) => 'Custom'
       })))
       const nameColumn = rendered.querySelector('.ReactVirtualized__Table__rowColumn:first-of-type')
       expect(nameColumn.getAttribute('title')).toContain('Custom')
@@ -303,7 +303,7 @@ describe('Table', () => {
 
     it('should not set a cell :title if the rendered cell content is not a string', () => {
       const rendered = findDOMNode(render(getMarkup({
-        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex }) => <div>Custom</div>
+        cellRenderer: ({ cellData, columnData, dataKey, rowData, rowIndex, columnIndex }) => <div>Custom</div>
       })))
       const nameColumn = rendered.querySelector('.ReactVirtualized__Table__rowColumn:first-of-type')
       expect(nameColumn.getAttribute('title')).toEqual(null)

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -388,7 +388,7 @@ export default class Table extends PureComponent {
     } = column.props
 
     const cellData = cellDataGetter({ columnData, dataKey, rowData })
-    const renderedCell = cellRenderer({ cellData, columnData, dataKey, isScrolling, parent, rowData, rowIndex })
+    const renderedCell = cellRenderer({ cellData, columnData, dataKey, isScrolling, parent, rowData, rowIndex, columnIndex })
 
     const style = this._cachedColumnStyles[columnIndex]
 

--- a/source/Table/defaultCellRenderer.js
+++ b/source/Table/defaultCellRenderer.js
@@ -10,7 +10,8 @@ export default function defaultCellRenderer ({
   columnData,
   dataKey,
   rowData,
-  rowIndex
+  rowIndex,
+  columnIndex
 }: CellRendererParams): string {
   if (cellData == null) {
     return ''


### PR DESCRIPTION
Actually, this thing started, with `CellMeasurer` ☺️. 
`Table`'s [demo](http://localhost:3001/#/components/CellMeasurer) works fine if we have only one dynamic column.
But if we want to have two or more dynamic columns, something like [this](https://www.webpackbin.com/bins/-Kik5ZirudqCXo_U_7JE) happens. 

We have to pass `columnIndex` to `cellRenderer`, and then to `CellMeasurer`, to make it work.
Of course we can do it manually, but it would be nice if `cellRenderer` function had access to `columnIndex`.
