### PR TITLE
Changed exactly prop on Route component to exact for RRV4 final

### DIFF
--- a/source/demo/Application.js
+++ b/source/demo/Application.js
@@ -138,7 +138,7 @@ export default class Application extends PureComponent {
                 />
               ))}
               <Route
-                exactly
+                exact
                 path='/'
                 render={() => (
                   <Redirect to='/components/List' />


### PR DESCRIPTION
React Router V4 changed the `exactly` prop to `exact` for path matches. This PR mirrors that change to in `demo/Application.js`

Refs #665 