### PR TITLE
allow skipping of prerendering when using CellMeasurer

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -15,6 +15,7 @@ A windowed grid of elements. `Grid` only renders cells necessary to fill itself 
 | columnWidth | Number or Function | ✓ | Either a fixed column width (number) or a function that returns the width of a column given its index: `({ index: number }): number` |
 | containerStyle | Object |  | Optional custom inline style to attach to inner cell-container element. |
 | deferredMeasurementCache | `CellMeasurer` |  | If CellMeasurer is used to measure this Grid's children, this should be a pointer to its CellMeasurerCache. A shared CellMeasurerCache reference enables Grid and CellMeasurer to share measurement data. |
+| deferredMeasurementBatchAll | Boolean |  | When Using deferredMeasurementCache, set this to false to skip pre-rendering of all cells for size calculations.
 | estimatedColumnSize | Number |  | Used to estimate the total width of a `Grid` before all of its columns have actually been measured. The estimated total width is adjusted as columns are rendered. |
 | estimatedRowSize | Number |  | Used to estimate the total height of a `Grid` before all of its rows have actually been measured. The estimated total height is adjusted as rows are rendered. |
 | height | Number | ✓ | Height of Grid; this property determines the number of visible (vs virtualized) rows. |

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -101,6 +101,12 @@ export default class Grid extends PureComponent {
     deferredMeasurementCache: PropTypes.object,
 
     /**
+     * When Using deferredMeasurementCache, set this to false to skip pre-rendering
+     * of all cells for size calculations.
+     */
+    deferredMeasurementBatchAll: PropTypes.bool,
+
+    /**
      * Used to estimate the total width of a Grid before all of its columns have actually been measured.
      * The estimated total width is adjusted as columns are rendered.
      */
@@ -248,7 +254,8 @@ export default class Grid extends PureComponent {
     scrollToColumn: -1,
     scrollToRow: -1,
     style: {},
-    tabIndex: 0
+    tabIndex: 0,
+    deferredMeasurementBatchAll: true,
   };
 
   constructor (props, context) {
@@ -284,13 +291,13 @@ export default class Grid extends PureComponent {
     const deferredMode = typeof deferredMeasurementCache !== 'undefined'
 
     this._columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
-      batchAllCells: deferredMode && !deferredMeasurementCache.hasFixedHeight(),
+      batchAllCells: deferredMode && props.deferredMeasurementBatchAll && !deferredMeasurementCache.hasFixedHeight(),
       cellCount: props.columnCount,
       cellSizeGetter: (params) => this._columnWidthGetter(params),
       estimatedCellSize: this._getEstimatedColumnSize(props)
     })
     this._rowSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
-      batchAllCells: deferredMode && !deferredMeasurementCache.hasFixedWidth(),
+      batchAllCells: deferredMode && props.deferredMeasurementBatchAll && !deferredMeasurementCache.hasFixedWidth(),
       cellCount: props.rowCount,
       cellSizeGetter: (params) => this._rowHeightGetter(params),
       estimatedCellSize: this._getEstimatedRowSize(props)


### PR DESCRIPTION
I am using CellMeasurer to render a Grid with unknown column sizes.

The Grid has many rows, and by default it renders all of them so that CellMeasurer can determine the width of the largest cells for each column.  Because it renders all of the rows, the performance is poor.

I don't really care if the cell widths change slightly as I scroll down and larger cells are found, so i've added an option to skip this prerendering of all the cells to dramatically improve performance.