### PR TITLE
use keyMapper of deferredMeasurementCache to cache styles

### DIFF
--- a/source/CellMeasurer/CellMeasurerCache.js
+++ b/source/CellMeasurer/CellMeasurerCache.js
@@ -1,4 +1,5 @@
 /** @flow */
+import defaultKeyMapper from '../utils/defaultKeyMapper'
 
 export const DEFAULT_HEIGHT = 30
 export const DEFAULT_WIDTH = 100
@@ -240,11 +241,4 @@ export default class CellMeasurerCache {
     this._columnWidthCache[columnKey] = columnWidth
     this._rowHeightCache[rowKey] = rowHeight
   }
-}
-
-function defaultKeyMapper (
-  rowIndex: number,
-  columnIndex: number
-): any {
-  return `${rowIndex}-${columnIndex}`
 }

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1858,6 +1858,25 @@ describe('Grid', () => {
     expect(keys).toEqual(['0-0', '1-1'])
   })
 
+  it('should use the keyMapper of :deferredMeasurementCache to cache the styles', () => {
+    const cache = new CellMeasurerCache({
+      fixedWidth: true,
+      keyMapper: (rowIndex, columnIndex) => `${rowIndex}|${columnIndex}`
+    })
+    cache.set(0, 0, 100, 100)
+    cache.set(1, 1, 100, 100)
+
+    const grid = render(getMarkup({
+      columnCount: 2,
+      deferredMeasurementCache: cache,
+      rowCount: 2
+    }))
+
+    const keys = Object.keys(grid._styleCache)
+
+    expect(keys).toEqual(['0|0', '1|1'])
+  })
+
   describe('DEV warnings', () => {
     it('should warn about cells that forget to include the :style property', () => {
       spyOn(console, 'warn')

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -9,6 +9,7 @@ import defaultOverscanIndicesGetter, { SCROLL_DIRECTION_BACKWARD, SCROLL_DIRECTI
 import updateScrollIndexHelper from './utils/updateScrollIndexHelper'
 import defaultCellRangeRenderer from './defaultCellRangeRenderer'
 import scrollbarSize from 'dom-helpers/util/scrollbarSize'
+import defaultKeyMapper from '../utils/defaultKeyMapper'
 
 /**
  * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.
@@ -282,6 +283,8 @@ export default class Grid extends PureComponent {
 
     const deferredMeasurementCache = props.deferredMeasurementCache
     const deferredMode = typeof deferredMeasurementCache !== 'undefined'
+
+    this._keyMapper = deferredMode ? deferredMeasurementCache._keyMapper : defaultKeyMapper
 
     this._columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       batchAllCells: deferredMode && !deferredMeasurementCache.hasFixedHeight(),
@@ -873,6 +876,7 @@ export default class Grid extends PureComponent {
         deferredMeasurementCache,
         horizontalOffsetAdjustment,
         isScrolling,
+        keyMapper: this._keyMapper,
         parent: this,
         rowSizeAndPositionManager: this._rowSizeAndPositionManager,
         rowStartIndex: this._rowStartIndex,
@@ -1086,7 +1090,7 @@ export default class Grid extends PureComponent {
     // Copy over the visible cell styles so avoid unnecessary re-render.
     for (let rowIndex = this._rowStartIndex; rowIndex <= this._rowStopIndex; rowIndex++) {
       for (let columnIndex = this._columnStartIndex; columnIndex <= this._columnStopIndex; columnIndex++) {
-        let key = `${rowIndex}-${columnIndex}`
+        let key = this._keyMapper(rowIndex, columnIndex)
         this._styleCache[key] = styleCache[key]
       }
     }

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -12,6 +12,7 @@ export default function defaultCellRangeRenderer ({
   deferredMeasurementCache,
   horizontalOffsetAdjustment,
   isScrolling,
+  keyMapper,
   parent, // Grid (or List or Table)
   rowSizeAndPositionManager,
   rowStartIndex,
@@ -50,7 +51,7 @@ export default function defaultCellRangeRenderer ({
         rowIndex >= visibleRowIndices.start &&
         rowIndex <= visibleRowIndices.stop
       )
-      let key = `${rowIndex}-${columnIndex}`
+      let key = keyMapper(rowIndex, columnIndex)
       let style
 
       // Cache style objects so shallow-compare doesn't re-render unnecessarily.
@@ -171,6 +172,7 @@ type DefaultCellRangeRendererParams = {
   columnStopIndex: number,
   horizontalOffsetAdjustment: number,
   isScrolling: boolean,
+  keyMapper: Function,
   rowSizeAndPositionManager: Object,
   rowStartIndex: number,
   rowStopIndex: number,

--- a/source/utils/defaultKeyMapper.js
+++ b/source/utils/defaultKeyMapper.js
@@ -1,0 +1,6 @@
+export default function defaultKeyMapper (
+  rowIndex: number,
+  columnIndex: number
+): any {
+  return `${rowIndex}-${columnIndex}`
+}


### PR DESCRIPTION
The defaultCellRangeRenderer should use the same keyMapper as deferredMeasurementCache to ensure that the cached styles are applied to the correct elements.