### PR TITLE
MultiGrid with fixedRowCount is rendering incorrect width

### DIFF
--- a/source/CellMeasurer/CellMeasurer.jest.js
+++ b/source/CellMeasurer/CellMeasurer.jest.js
@@ -223,6 +223,39 @@ describe('CellMeasurer', () => {
       (params) => <div style={{ width: 100, height: 30 }}></div>
     )
 
+    let measurer;
+    const node = findDOMNode(render(
+      <CellMeasurer
+        ref={(ref) => { measurer = ref }}
+        cache={cache}
+        columnIndex={0}
+        parent={parent}
+        rowIndex={0}
+        style={{}}
+      >
+        {child}
+      </CellMeasurer>
+    ))
+
+    const { height, width } = measurer._getCellMeasures(node)
+    expect(height).toBeGreaterThan(0)
+    expect(width).toBeGreaterThan(0)
+
+    expect(node.style.height).toBe('auto')
+    expect(node.style.width).not.toBe('auto')
+  })
+
+  // See issue #660
+  it('should set widht/height style to values before measuring with style "auto"', () => {
+    const cache = new CellMeasurerCache({
+      fixedHeight: true
+    })
+    const parent = createParent({ cache })
+    const child = jest.fn()
+    child.mockImplementation(
+      (params) => <div style={{ width: 100, height: 30 }}></div>
+    )
+
     const node = findDOMNode(render(
       <CellMeasurer
         cache={cache}
@@ -235,12 +268,12 @@ describe('CellMeasurer', () => {
       </CellMeasurer>
     ))
 
-    node.style.width = 100
-    node.style.height = 30
+    node.style.width = 200
+    node.style.height = 60
 
     child.mock.calls[0][0].measure()
 
-    expect(node.style.height).toBe('auto')
-    expect(node.style.width).not.toBe('auto')
+    expect(node.style.height).toBe('30px')
+    expect(node.style.width).toBe('100px')
   })
 })

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -41,6 +41,22 @@ export default class CellMeasurer extends PureComponent {
       : children
   }
 
+  _getCellMeasures (node) {
+    const { cache } = this.props
+
+    if (!cache.hasFixedWidth()) {
+      node.style.width = 'auto'
+    }
+    if (!cache.hasFixedHeight()) {
+      node.style.height = 'auto'
+    }
+
+    const height = Math.ceil(node.offsetHeight)
+    const width = Math.ceil(node.offsetWidth)
+
+    return { height, width };
+  }
+
   _maybeMeasureCell () {
     const {
       cache,
@@ -51,6 +67,8 @@ export default class CellMeasurer extends PureComponent {
 
     if (!cache.has(rowIndex, columnIndex)) {
       const node = findDOMNode(this)
+      const oldWidth = node.style.width
+      const oldHeight = node.style.height
 
       // TODO Check for a bad combination of fixedWidth and missing numeric width or vice versa with height
 
@@ -58,15 +76,14 @@ export default class CellMeasurer extends PureComponent {
       // Explicitly clear width/height before measuring to avoid being tainted by another Grid.
       // eg top/left Grid renders before bottom/right Grid
       // Since the CellMeasurerCache is shared between them this taints derived cell size values.
-      if (!cache.hasFixedWidth()) {
-        node.style.width = 'auto'
-      }
-      if (!cache.hasFixedHeight()) {
-        node.style.height = 'auto'
-      }
+      const { height, width } = this._getCellMeasures(node);
 
-      const height = Math.ceil(node.offsetHeight)
-      const width = Math.ceil(node.offsetWidth)
+      if (oldWidth) {
+        node.style.width = oldWidth
+      }
+      if (oldHeight) {
+        node.style.height = oldHeight
+      }
 
       cache.set(
         rowIndex,
@@ -97,21 +114,22 @@ export default class CellMeasurer extends PureComponent {
     } = this.props
 
     const node = findDOMNode(this)
+    const oldWidth = node.style.width
+    const oldHeight = node.style.height
 
     // If we are re-measuring a cell that has already been measured,
     // It will have a hard-coded width/height from the previous measurement.
     // The fact that we are measuring indicates this measurement is probably stale,
     // So explicitly clear it out (eg set to "auto") so we can recalculate.
     // See issue #593 for more info.
-    if (!cache.hasFixedWidth()) {
-      node.style.width = 'auto'
-    }
-    if (!cache.hasFixedHeight()) {
-      node.style.height = 'auto'
-    }
+    const { height, width } = this._getCellMeasures(node)
 
-    const height = Math.ceil(node.offsetHeight)
-    const width = Math.ceil(node.offsetWidth)
+    if (oldWidth) {
+      node.style.width = oldWidth
+    }
+    if (oldHeight) {
+      node.style.height = oldHeight
+    }
 
     if (
       height !== cache.getHeight(rowIndex, columnIndex) ||


### PR DESCRIPTION
Issue: https://github.com/bvaughn/react-virtualized/issues/660

I am first time contributor to react-virtualized. Please excuse me for not providing a code example. I can create one if it will be necessary for accepting PR.

CellMeasurer during rerendering of the table is setting width: "auto" to the table cells in measure methods. This width "auto" is causing incorrect cell rendering mostly visible on cell backgrounds.

![widthauto](https://cloud.githubusercontent.com/assets/6388074/25433247/fb228cec-2a87-11e7-889e-6ceb37592894.png)

This fix of CellMeasurer is remembering width and height of the cell before measuring. 
Measuring is setting styles for width and height to "auto" prior measuring. 
The fix is setting remembered width and height back after measuring.