### PR TITLE
Optimizing column/row cache update mechanism.

### DIFF
--- a/source/CellMeasurer/CellMeasurerCache.js
+++ b/source/CellMeasurer/CellMeasurerCache.js
@@ -230,10 +230,9 @@ export default class CellMeasurerCache {
     let columnWidth = 0
     if (this._hasFixedWidth) {
       // if has fixed width columns, no need to calculate width for each row
-      columnWidth = this._columnWidthCache[columnKey] || columnWidth;
+      columnWidth = this._columnWidthCache[columnKey] || columnWidth
       columnWidth = Math.max(columnWidth, this.getWidth(rowIndex, columnIndex))
-    }
-    else {
+    } else {
       for (let i = 0; i < this._rowCount; i++) {
         columnWidth = Math.max(columnWidth, this.getWidth(i, columnIndex))
       }
@@ -241,10 +240,9 @@ export default class CellMeasurerCache {
     let rowHeight = 0
     if (this._hasFixedHeight) {
       // if has fixed height rows, no need to calculate height for each column
-      rowHeight = this._rowHeightCache[rowKey] || rowHeight;
+      rowHeight = this._rowHeightCache[rowKey] || rowHeight
       rowHeight = Math.max(rowHeight, this.getHeight(rowIndex, columnIndex))
-    }
-    else {
+    } else {
       for (let i = 0; i < this._columnCount; i++) {
         rowHeight = Math.max(rowHeight, this.getHeight(rowIndex, i))
       }

--- a/source/CellMeasurer/CellMeasurerCache.js
+++ b/source/CellMeasurer/CellMeasurerCache.js
@@ -225,17 +225,30 @@ export default class CellMeasurerCache {
     // :columnWidth and :rowHeight are derived based on all cells in a column/row.
     // Pre-cache these derived values for faster lookup later.
     // Reads are expected to occur more frequently than writes in this case.
-    let columnWidth = 0
-    for (let i = 0; i < this._rowCount; i++) {
-      columnWidth = Math.max(columnWidth, this.getWidth(i, columnIndex))
-    }
-    let rowHeight = 0
-    for (let i = 0; i < this._columnCount; i++) {
-      rowHeight = Math.max(rowHeight, this.getHeight(rowIndex, i))
-    }
-
     const columnKey = this._keyMapper(0, columnIndex)
     const rowKey = this._keyMapper(rowIndex, 0)
+    let columnWidth = 0
+    if (this._hasFixedWidth) {
+      // if has fixed width columns, no need to calculate width for each row
+      columnWidth = this._columnWidthCache[columnKey] || columnWidth;
+      columnWidth = Math.max(columnWidth, this.getWidth(rowIndex, columnIndex))
+    }
+    else {
+      for (let i = 0; i < this._rowCount; i++) {
+        columnWidth = Math.max(columnWidth, this.getWidth(i, columnIndex))
+      }
+    }
+    let rowHeight = 0
+    if (this._hasFixedHeight) {
+      // if has fixed height rows, no need to calculate height for each column
+      rowHeight = this._rowHeightCache[rowKey] || rowHeight;
+      rowHeight = Math.max(rowHeight, this.getHeight(rowIndex, columnIndex))
+    }
+    else {
+      for (let i = 0; i < this._columnCount; i++) {
+        rowHeight = Math.max(rowHeight, this.getHeight(rowIndex, i))
+      }
+    }
 
     this._columnWidthCache[columnKey] = columnWidth
     this._rowHeightCache[rowKey] = rowHeight


### PR DESCRIPTION
First of all, thanks for this great library.

The issue I faced was, when I used Table with CellMeasurer columns with high volume data (around 200 thousand records) the scroll performance is super bad :( . And this performance issue is directly proportionate to the rowCount and number of Columns with CellMeasurer. So I imagined there must be a loop involved, so I profiled and found this issue in CellMeasurerCache. 

If you want to see the issue yourself, you could bump up the record count for "CELL MEASURER: mixed fixed and dynamic height text" - demo and start scrolling.

With this fix we get huge performance improvement when CellMeasurer is used.

Cheers,
Ravi Dasari
