### PR TITLE
Allow stepper to be used as a controlled component

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.css
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.css
@@ -20,3 +20,11 @@
 .Radio {
   margin-left: 0.5rem;
 }
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+}
+.checkbox {
+  margin-right: 5px;
+}

--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -12,16 +12,21 @@ export default class ArrowKeyStepperExample extends PureComponent {
     super(props)
 
     this.state = {
-      mode: 'edges'
+      mode: 'edges',
+      isClickable: true,
+      scrollToColumn: 0,
+      scrollToRow: 0
     }
 
     this._getColumnWidth = this._getColumnWidth.bind(this)
     this._getRowHeight = this._getRowHeight.bind(this)
     this._cellRenderer = this._cellRenderer.bind(this)
+    this._selectCell = this._selectCell.bind(this)
+    this._onClickableChange = this._onClickableChange.bind(this)
   }
 
   render () {
-    const { mode } = this.state
+    const { mode, isClickable, scrollToColumn, scrollToRow } = this.state
 
     return (
       <ContentBox>
@@ -66,10 +71,27 @@ export default class ArrowKeyStepperExample extends PureComponent {
           </label>
         </ContentBoxParagraph>
 
+        <ContentBoxParagraph>
+          <label className={styles.checkboxLabel}>
+            <input
+              aria-label='Enable click selection? (resets selection)'
+              className={styles.checkbox}
+              type='checkbox'
+              checked={isClickable}
+              onChange={this._onClickableChange}
+            />
+            Enable click selection? (resets selection)
+          </label>
+        </ContentBoxParagraph>
+
         <ArrowKeyStepper
           columnCount={100}
+          key={isClickable}
+          onScrollToChange={isClickable ? this._selectCell : undefined}
           mode={mode}
           rowCount={100}
+          scrollToColumn={scrollToColumn}
+          scrollToRow={scrollToRow}
         >
           {({ onSectionRendered, scrollToColumn, scrollToRow }) => (
             <div>
@@ -118,10 +140,23 @@ export default class ArrowKeyStepperExample extends PureComponent {
       <div
         className={className}
         key={key}
+        onClick={this.state.isClickable && (() => this._selectCell({ scrollToColumn: columnIndex, scrollToRow: rowIndex }))}
         style={style}
       >
         {`r:${rowIndex}, c:${columnIndex}`}
       </div>
     )
+  }
+
+  _selectCell ({ scrollToColumn, scrollToRow }) {
+    this.setState({ scrollToColumn, scrollToRow })
+  }
+
+  _onClickableChange (event) {
+    this.setState({
+      isClickable: event.target.checked,
+      scrollToColumn: 0,
+      scrollToRow: 0
+    })
   }
 }

--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -87,6 +87,7 @@ export default class ArrowKeyStepperExample extends PureComponent {
         <ArrowKeyStepper
           columnCount={100}
           key={isClickable}
+          isControlled={isClickable}
           onScrollToChange={isClickable ? this._selectCell : undefined}
           mode={mode}
           rowCount={100}

--- a/source/ArrowKeyStepper/ArrowKeyStepper.jest.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.jest.js
@@ -162,6 +162,7 @@ describe('ArrowKeyStepper', () => {
       numCalls++
     }
     const { node } = renderHelper({
+      isControlled: true,
       onScrollToChange
     })
 
@@ -183,6 +184,7 @@ describe('ArrowKeyStepper', () => {
     })
 
     renderHelper({
+      isControlled: true,
       onScrollToChange,
       node,
       scrollToColumn: 0,

--- a/source/ArrowKeyStepper/ArrowKeyStepper.jest.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.jest.js
@@ -152,6 +152,45 @@ describe('ArrowKeyStepper', () => {
     assertCurrentScrollTo(node, 0, 0)
   })
 
+  it('should call :onScrollToChange for key down', () => {
+    let numCalls = 0
+    let scrollToColumn
+    let scrollToRow
+    const onScrollToChange = params => {
+      scrollToColumn = params.scrollToColumn
+      scrollToRow = params.scrollToRow
+      numCalls++
+    }
+    const { node } = renderHelper({
+      onScrollToChange
+    })
+
+    Simulate.keyDown(node, {key: 'ArrowDown'})
+    expect(numCalls).toEqual(1)
+    expect(scrollToColumn).toEqual(0)
+    expect(scrollToRow).toEqual(1)
+  })
+
+  it('should not call :onScrollToChange for prop update', () => {
+    let numCalls = 0
+    const onScrollToChange = params => {
+      numCalls++
+    }
+    const { node } = renderHelper({
+      onScrollToChange,
+      scrollToColumn: 0,
+      scrollToRow: 0
+    })
+
+    renderHelper({
+      onScrollToChange,
+      node,
+      scrollToColumn: 0,
+      scrollToRow: 1
+    })
+    expect(numCalls).toEqual(0)
+  })
+
   describe('mode === "edges"', () => {
     it('should update :scrollToColumn and :scrollToRow relative to the most recent :onSectionRendered event', () => {
       const { node, onSectionRendered } = renderHelper()

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -8,16 +8,18 @@ import React, { PureComponent } from 'react'
 export default class ArrowKeyStepper extends PureComponent {
   static defaultProps = {
     disabled: false,
+    isControlled: false,
     mode: 'edges',
     scrollToColumn: 0,
     scrollToRow: 0
   };
 
   static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+    children: PropTypes.func.isRequired,
     className: PropTypes.string,
     columnCount: PropTypes.number.isRequired,
     disabled: PropTypes.bool.isRequired,
+    isControlled: PropTypes.bool.isRequired,
     mode: PropTypes.oneOf(['cells', 'edges']),
     onScrollToChange: PropTypes.func,
     rowCount: PropTypes.number.isRequired,
@@ -43,7 +45,7 @@ export default class ArrowKeyStepper extends PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (!this._isComponentState()) {
+    if (this.props.isControlled) {
       return
     }
 
@@ -81,7 +83,7 @@ export default class ArrowKeyStepper extends PureComponent {
 
   render () {
     const { className, children } = this.props
-    const { scrollToColumn, scrollToRow } = this._getRelevantState()
+    const { scrollToColumn, scrollToRow } = this._getScrollState()
 
     return (
       <div
@@ -97,10 +99,6 @@ export default class ArrowKeyStepper extends PureComponent {
     )
   }
 
-  _isComponentState () {
-    return typeof this.props.onScrollToChange !== 'function'
-  }
-
   _onKeyDown (event) {
     const { columnCount, disabled, mode, rowCount } = this.props
 
@@ -111,9 +109,9 @@ export default class ArrowKeyStepper extends PureComponent {
     const {
       scrollToColumn: scrollToColumnPrevious,
       scrollToRow: scrollToRowPrevious
-    } = this._getRelevantState()
+    } = this._getScrollState()
 
-    let { scrollToColumn, scrollToRow } = this._getRelevantState()
+    let { scrollToColumn, scrollToRow } = this._getScrollState()
 
     // The above cases all prevent default event event behavior.
     // This is to keep the grid from scrolling after the snap-to update.
@@ -146,7 +144,7 @@ export default class ArrowKeyStepper extends PureComponent {
     ) {
       event.preventDefault()
 
-      this._setRelevantState({ scrollToColumn, scrollToRow })
+      this._updateScrollState({ scrollToColumn, scrollToRow })
     }
   }
 
@@ -157,15 +155,15 @@ export default class ArrowKeyStepper extends PureComponent {
     this._rowStopIndex = rowStopIndex
   }
 
-  _getRelevantState () {
-    return this._isComponentState() ? this.state : this.props
+  _getScrollState () {
+    return this.props.isControlled ? this.props : this.state
   }
 
-  _setRelevantState ({ scrollToColumn, scrollToRow }) {
-    if (this._isComponentState()) {
-      this.setState({ scrollToColumn, scrollToRow })
-    } else {
+  _updateScrollState ({ scrollToColumn, scrollToRow }) {
+    if (this.props.isControlled) {
       this.props.onScrollToChange({ scrollToColumn, scrollToRow })
+    } else {
+      this.setState({ scrollToColumn, scrollToRow })
     }
   }
 }

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -14,11 +14,12 @@ export default class ArrowKeyStepper extends PureComponent {
   };
 
   static propTypes = {
-    children: PropTypes.func.isRequired,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     className: PropTypes.string,
     columnCount: PropTypes.number.isRequired,
     disabled: PropTypes.bool.isRequired,
     mode: PropTypes.oneOf(['cells', 'edges']),
+    onScrollToChange: PropTypes.func,
     rowCount: PropTypes.number.isRequired,
     scrollToColumn: PropTypes.number.isRequired,
     scrollToRow: PropTypes.number.isRequired
@@ -42,6 +43,10 @@ export default class ArrowKeyStepper extends PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
+    if (!this._isComponentState()) {
+      return
+    }
+
     const { scrollToColumn, scrollToRow } = nextProps
 
     const {
@@ -76,7 +81,7 @@ export default class ArrowKeyStepper extends PureComponent {
 
   render () {
     const { className, children } = this.props
-    const { scrollToColumn, scrollToRow } = this.state
+    const { scrollToColumn, scrollToRow } = this._getRelevantState()
 
     return (
       <div
@@ -92,6 +97,10 @@ export default class ArrowKeyStepper extends PureComponent {
     )
   }
 
+  _isComponentState () {
+    return typeof this.props.onScrollToChange !== 'function'
+  }
+
   _onKeyDown (event) {
     const { columnCount, disabled, mode, rowCount } = this.props
 
@@ -102,9 +111,9 @@ export default class ArrowKeyStepper extends PureComponent {
     const {
       scrollToColumn: scrollToColumnPrevious,
       scrollToRow: scrollToRowPrevious
-    } = this.state
+    } = this._getRelevantState()
 
-    let { scrollToColumn, scrollToRow } = this.state
+    let { scrollToColumn, scrollToRow } = this._getRelevantState()
 
     // The above cases all prevent default event event behavior.
     // This is to keep the grid from scrolling after the snap-to update.
@@ -137,7 +146,7 @@ export default class ArrowKeyStepper extends PureComponent {
     ) {
       event.preventDefault()
 
-      this.setState({ scrollToColumn, scrollToRow })
+      this._setRelevantState({ scrollToColumn, scrollToRow })
     }
   }
 
@@ -146,5 +155,17 @@ export default class ArrowKeyStepper extends PureComponent {
     this._columnStopIndex = columnStopIndex
     this._rowStartIndex = rowStartIndex
     this._rowStopIndex = rowStopIndex
+  }
+
+  _getRelevantState () {
+    return this._isComponentState() ? this.state : this.props
+  }
+
+  _setRelevantState ({ scrollToColumn, scrollToRow }) {
+    if (this._isComponentState()) {
+      this.setState({ scrollToColumn, scrollToRow })
+    } else {
+      this.props.onScrollToChange({ scrollToColumn, scrollToRow })
+    }
   }
 }

--- a/source/AutoSizer/AutoSizer.example.js
+++ b/source/AutoSizer/AutoSizer.example.js
@@ -45,7 +45,7 @@ export default class AutoSizerExample extends PureComponent {
               aria-label='Hide description (to show resize)?'
               className={styles.checkbox}
               type='checkbox'
-              value={hideDescription}
+              checked={hideDescription}
               onChange={event => this.setState({ hideDescription: event.target.checked })}
             />
             Hide description (to show resize)?

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,13 +3619,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 
-loose-envify@^1.3.0:
+loose-envify@^1.1.0, loose-envify@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,13 +3619,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.3.0:
+loose-envify@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
   dependencies:


### PR DESCRIPTION
Implements #687
* Provides the ability to use `ArrowKeyStepper` as a controlled component
* My specific use case is the ability to select cells via click. Generally this allows the user to provide a single source of truth for all selection methods (include the `ArrowKeyStepper`'s state).
* When using `ArrowKeyStepper` as a controlled component:
  * Provide `onScrollToChange({ scrollToColumn, scrollToRow })` as a prop
  * Provide `scrollToColumn` as a prop
  * Provide `scrollToRow` as a prop
  * If `ArrowKeyStepper` is being used as a controlled component, it does not call `setState` for performance reasons (instead it uses the props directly).

PR checklist
* Tests are passing
* Lint is passing
* I added two new test cases: 
  * Check that `onScrollToChange` is called when key down occurs
  * Check that `onScrollToChange` is not called when props are updated (if the change occurs via props, the source of truth already knows about the change)
* I added an additional demo setting, `Enable click selection`. I have enabled this setting by default in the demo because I think users normally want to be able to click to select.

Let me know your feedback. I will be happy to make changes.

