### PR TITLE
Prevent calling setState on an unmounted WindowScroller component

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -88,6 +88,8 @@ export default class WindowScroller extends PureComponent {
     registerScrollListener(this, scrollElement)
 
     window.addEventListener('resize', this._onResize, false)
+    
+    this._isMounted = true
   }
 
   componentWillReceiveProps (nextProps) {
@@ -106,6 +108,8 @@ export default class WindowScroller extends PureComponent {
     unregisterScrollListener(this, this.props.scrollElement || window)
 
     window.removeEventListener('resize', this._onResize, false)
+    
+    this._isMounted = false
   }
 
   render () {
@@ -127,6 +131,8 @@ export default class WindowScroller extends PureComponent {
 
   // Referenced by utils/onScroll
   __handleWindowScrollEvent (event) {
+    if (!this._isMounted) return;
+    
     const { onScroll } = this.props
 
     const scrollElement = this.props.scrollElement || window

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -88,7 +88,7 @@ export default class WindowScroller extends PureComponent {
     registerScrollListener(this, scrollElement)
 
     window.addEventListener('resize', this._onResize, false)
-    
+
     this._isMounted = true
   }
 
@@ -108,7 +108,7 @@ export default class WindowScroller extends PureComponent {
     unregisterScrollListener(this, this.props.scrollElement || window)
 
     window.removeEventListener('resize', this._onResize, false)
-    
+
     this._isMounted = false
   }
 
@@ -131,8 +131,8 @@ export default class WindowScroller extends PureComponent {
 
   // Referenced by utils/onScroll
   __handleWindowScrollEvent (event) {
-    if (!this._isMounted) return;
-    
+    if (!this._isMounted) return
+
     const { onScroll } = this.props
 
     const scrollElement = this.props.scrollElement || window


### PR DESCRIPTION
This is a bit of an edge case, when rendering several WindowScroller components on the same page inside a virtual list, the scroll listener can sometimes call setState on an unmounted WindowScroller component (that has been scrolled out of view in the virtual list), triggering react's warning.

This PR prevents calling setState in this scenario if the component has been unmounted.