### PR TITLE
InfiniteLoader resetLoadMoreRowsCache: reload last batch feature added

### DIFF
--- a/docs/InfiniteLoader.md
+++ b/docs/InfiniteLoader.md
@@ -22,8 +22,8 @@ This is an advanced component and can be confusing in certain situations.
 
 ### Public Methods
 
-##### resetLoadMoreRowsCache
-Reset any cached data about already-loaded rows. This method should be called if any/all loaded data needs to be refetched (eg a filtered list where the search criteria changes).
+##### resetLoadMoreRowsCache (callLoadMoreRows: boolean)
+Reset any cached data about already-loaded rows. This method should be called if any/all loaded data needs to be refetched (eg a filtered list where the search criteria changes). If `callLoadMoreRows` passed as true, the last loaded batch would be automatically reloaded.
 
 ### Children function
 

--- a/source/InfiniteLoader/InfiniteLoader.jest.js
+++ b/source/InfiniteLoader/InfiniteLoader.jest.js
@@ -245,7 +245,24 @@ describe('InfiniteLoader', () => {
     innerOnRowsRendered({ startIndex: 0, stopIndex: 15 })
     expect(loadMoreRowsCalls).toEqual([{ startIndex: 0, stopIndex: 19 }])
   })
+
+  it('resetLoadMoreRowsCache should call :loadMoreRows if parameter passed', () => {
+    const component = render(getMarkup({
+      isRowLoaded: () => false,
+      minimumBatchSize: 20,
+      threshold: 0
+    }));
+    expect(loadMoreRowsCalls).toEqual([{ startIndex: 0, stopIndex: 19 }])
+    innerOnRowsRendered({ startIndex: 0, stopIndex: 15 })
+    loadMoreRowsCalls.splice(0)
+    expect(loadMoreRowsCalls).toEqual([])
+    component.resetLoadMoreRowsCache(true)
+    expect(loadMoreRowsCalls).toEqual([{ startIndex: 0, stopIndex: 15 }])
+  })
+
 })
+
+
 
 describe('scanForUnloadedRanges', () => {
   function createIsRowLoaded (rows) {

--- a/source/InfiniteLoader/InfiniteLoader.jest.js
+++ b/source/InfiniteLoader/InfiniteLoader.jest.js
@@ -259,10 +259,7 @@ describe('InfiniteLoader', () => {
     component.resetLoadMoreRowsCache(true)
     expect(loadMoreRowsCalls).toEqual([{ startIndex: 0, stopIndex: 15 }])
   })
-
 })
-
-
 
 describe('scanForUnloadedRanges', () => {
   function createIsRowLoaded (rows) {

--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -69,8 +69,12 @@ export default class InfiniteLoader extends PureComponent {
     this._registerChild = this._registerChild.bind(this)
   }
 
-  resetLoadMoreRowsCache () {
+  resetLoadMoreRowsCache (callLoadMoreRows) {
+    const { loadMoreRows } = this.props
     this._loadMoreRowsMemoizer = createCallbackMemoizer()
+    if (callLoadMoreRows) {
+      loadMoreRows({ startIndex: this._lastRenderedStartIndex, stopIndex: this._lastRenderedStopIndex })
+    }
   }
 
   render () {


### PR DESCRIPTION
`InfiniteLoader`'s method `resetLoadMoreCache` now accepts a boolean parameter: `callLoadMoreRows`. 
If `callLoadMoreRows` is true, then `loadMoreRows` function will be called with last saved indices.