### PR TITLE
Fix invalid rendering in scroll synced list with height/width exceeding browser limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 node_modules
 npm-debug.log
 styles.css
+.vscode

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -8,7 +8,7 @@ import getScrollbarSize from 'dom-helpers/util/scrollbarSize'
 // @TODO Merge Collection and CollectionView
 
 /**
- * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.
+ * Specifies the number of milliseconds during which to disable pointer events while a scroll is in progress.
  * This improves performance and makes scrolling smoother.
  */
 const IS_SCROLLING_TIMEOUT = 150

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1355,6 +1355,43 @@ describe('Grid', () => {
       ])
     })
 
+    it('should not cache cells if the offsets are not adjusted', () => {
+      const cellRendererCalls = []
+      function cellRenderer ({ columnIndex, key, rowIndex, style }) {
+        cellRendererCalls.push({ columnIndex, rowIndex })
+        return defaultCellRenderer({ columnIndex, key, rowIndex, style })
+      }
+      const props = {
+        cellRenderer,
+        columnWidth: 100,
+        height: 40,
+        rowHeight: 20,
+        rowCount: 100000,
+        scrollToRow: 0,
+        width: 100
+      }
+
+      render(getMarkup({
+        ...props,
+        scrollToRow: 0
+      }))
+      expect(cellRendererCalls).toEqual([
+        { columnIndex: 0, rowIndex: 0 },
+        { columnIndex: 0, rowIndex: 1 }
+      ])
+
+      cellRendererCalls.splice(0)
+
+      render(getMarkup({
+        ...props,
+        scrollToRow: 1
+      }))
+      expect(cellRendererCalls).toEqual([
+        { columnIndex: 0, rowIndex: 0 },
+        { columnIndex: 0, rowIndex: 1 }
+      ])
+    })
+
     it('should cache a cell once it has been rendered while scrolling', () => {
       const cellRendererCalls = []
       function cellRenderer ({ columnIndex, key, rowIndex, style }) {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -11,7 +11,7 @@ import defaultCellRangeRenderer from './defaultCellRangeRenderer'
 import scrollbarSize from 'dom-helpers/util/scrollbarSize'
 
 /**
- * Specifies the number of miliseconds during which to disable pointer events while a scroll is in progress.
+ * Specifies the number of milliseconds during which to disable pointer events while a scroll is in progress.
  * This improves performance and makes scrolling smoother.
  */
 export const DEFAULT_SCROLLING_RESET_TIME_INTERVAL = 150
@@ -587,7 +587,7 @@ export default class Grid extends PureComponent {
 
     // Special case where the previous size was 0:
     // In this case we don't show any windowed cells at all.
-    // So we should always recalculate offset aftward.
+    // So we should always recalculate offset afterwards.
     const sizeJustIncreasedFromZero = (
       (prevProps.width === 0 || prevProps.height === 0) &&
       (height > 0 && width > 0)

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -37,7 +37,7 @@ export default function defaultCellRangeRenderer ({
     rowSizeAndPositionManager.areOffsetsAdjusted()
   )
 
-  const canCacheStyle = !isScrolling || !areOffsetsAdjusted
+  const canCacheStyle = !isScrolling && !areOffsetsAdjusted;
 
   for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
     let rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(rowIndex)

--- a/source/Grid/utils/CellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.jest.js
@@ -81,7 +81,7 @@ describe('CellSizeAndPositionManager', () => {
       expect(() => cellSizeAndPositionManager.getSizeAndPositionOfCell(100)).toThrow()
     })
 
-    it('should returnt he correct size and position information for the requested cell', () => {
+    it('should return the correct size and position information for the requested cell', () => {
       const { cellSizeAndPositionManager } = getCellSizeAndPositionManager()
       expect(cellSizeAndPositionManager.getSizeAndPositionOfCell(0).offset).toEqual(0)
       expect(cellSizeAndPositionManager.getSizeAndPositionOfCell(0).size).toEqual(10)

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -111,7 +111,7 @@ export default class CellSizeAndPositionManager {
 
   /**
    * Total size of all cells being measured.
-   * This value will be completedly estimated initially.
+   * This value will be completely estimated initially.
    * As cells as measured the estimate will be updated.
    */
   getTotalSize (): number {

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.jest.js
@@ -19,7 +19,7 @@ describe('ScalingCellSizeAndPositionManager', () => {
   }
 
   describe('_getOffsetPercentage', () => {
-    it('should eturn the correct offset fraction', () => {
+    it('should return the correct offset fraction', () => {
       var expectations = [
         { offset: 0, expectedOffsetPercentage: 0 },
         { offset: 35, expectedOffsetPercentage: 0.5 },

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -43,7 +43,7 @@ export default class ScalingCellSizeAndPositionManager {
 
   /**
    * Number of pixels a cell at the given position (offset) should be shifted in order to fit within the scaled container.
-   * The offset passed to this function is scalled (safe) as well.
+   * The offset passed to this function is scaled (safe) as well.
    */
   getOffsetAdjustment ({
     containerSize,


### PR DESCRIPTION
See issue: https://github.com/bvaughn/react-virtualized/issues/725

It seems that when syncing two or more scrollable lists whose total height exceeds DEFAULT_MAX_SCROLL_SIZE here: https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/utils/ScalingCellSizeAndPositionManager.js#L9, the cell offset calculation does not produce correct results.

Here is a fiddle demonstrating the problem: https://jsfiddle.net/nathanpower/823w11xr/1/
Note that using the scroll-bar is fine, but using a scroll wheel or two-finger trackpad scroll results in messed up rendering of the synced list.

This PR changes to only caching the style when not scrolling AND offsets are not adjusted. Maybe this was the original intention here? 

Also some minor typos are corrected and `.vscode` folder added to `.gitignore`, hope that's ok.