### PR TITLE
Added "scrollToOffset" feature to Grid/List

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -331,6 +331,22 @@ describe('Grid', () => {
       expect(grid.state.scrollTop).toEqual(940)
     })
 
+    it('should scroll to the correct position for :scrollToOffset', () => {
+      const grid = render(getMarkup({
+        scrollToAlignment: 'start',
+        scrollToOffset: 20,
+        scrollToColumn: 24,
+        scrollToRow: 49
+      }))
+      // 100 columns * 50 item width = 5,000 total item width
+      // 100 rows * 20 item height = 2,000 total item height
+      // 4 columns and 5 rows can be visible at a time.
+      // The minimum amount of scrolling leaves the specified cell in the bottom/right corner (just scrolled into view).
+      // Since alignment is set to "start" we should scroll past this point until the cell is aligned top/left.
+      expect(grid.state.scrollLeft).toEqual(1200)
+      expect(grid.state.scrollTop).toEqual(1000)
+    })
+
     // Tests issue #691
     it('should set the correct :scrollLeft after height increases from 0', () => {
       render.unmount()

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -212,6 +212,9 @@ export default class Grid extends PureComponent {
      */
     scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
 
+    /** How far from the calculated 'alignment' position to scroll to (default: 0) */
+    scrollToOffset: PropTypes.number.isRequired,
+
     /**
      * Column index to ensure visible (by forcefully scrolling if necessary)
      */
@@ -253,6 +256,7 @@ export default class Grid extends PureComponent {
     role: 'grid',
     scrollingResetTimeInterval: DEFAULT_SCROLLING_RESET_TIME_INTERVAL,
     scrollToAlignment: 'auto',
+    scrollToOffset: 0,
     scrollToColumn: -1,
     scrollToRow: -1,
     style: {},
@@ -314,16 +318,18 @@ export default class Grid extends PureComponent {
   }
 
   /**
-   * Gets offsets for a given cell and alignment.
+   * Gets offsets for a given cell, alignment and user-provided offset.
    */
   getOffsetForCell ({
     alignment = this.props.scrollToAlignment,
+    userOffset = this.props.scrollToOffset,
     columnIndex = this.props.scrollToColumn,
     rowIndex = this.props.scrollToRow
   } = {}) {
     const offsetProps = {
       ...this.props,
       scrollToAlignment: alignment,
+      scrollToOffset: userOffset,
       scrollToColumn: columnIndex,
       scrollToRow: rowIndex
     }
@@ -1181,7 +1187,7 @@ export default class Grid extends PureComponent {
   }
 
   _getCalculatedScrollTop (props = this.props, state = this.state) {
-    const { height, rowCount, scrollToAlignment, scrollToRow, width } = props
+    const { height, rowCount, scrollToAlignment, scrollToOffset, scrollToRow, width } = props
     const { scrollTop } = state
 
     if (scrollToRow >= 0 && rowCount > 0) {
@@ -1191,6 +1197,7 @@ export default class Grid extends PureComponent {
 
       return this._rowSizeAndPositionManager.getUpdatedOffsetForIndex({
         align: scrollToAlignment,
+        userOffset: scrollToOffset,
         containerSize: height - scrollBarSize,
         currentOffset: scrollTop,
         targetIndex

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -126,6 +126,7 @@ export default class CellSizeAndPositionManager {
    * If the current offset is too great or small, it will be adjusted just enough to ensure the specified index is visible.
    *
    * @param align Desired alignment within container; one of "auto" (default), "start", or "end"
+   * @param userOffset User-provided offset distance from the calculated alignment (default: 0)
    * @param containerSize Size (width or height) of the container viewport
    * @param currentOffset Container's current (x or y) offset
    * @param totalSize Total size (width or height) of all cells
@@ -133,6 +134,7 @@ export default class CellSizeAndPositionManager {
    */
   getUpdatedOffsetForIndex ({
     align = 'auto',
+    userOffset = 0,
     containerSize,
     currentOffset,
     targetIndex
@@ -164,7 +166,7 @@ export default class CellSizeAndPositionManager {
 
     const totalSize = this.getTotalSize()
 
-    return Math.max(0, Math.min(totalSize - containerSize, idealOffset))
+    return Math.max(0, Math.min(totalSize - containerSize, idealOffset)) + userOffset
   }
 
   getVisibleCellRange (params: GetVisibleCellRangeParams): VisibleCellRange {

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -76,6 +76,7 @@ export default class ScalingCellSizeAndPositionManager {
   /** See CellSizeAndPositionManager#getUpdatedOffsetForIndex */
   getUpdatedOffsetForIndex ({
     align = 'auto',
+    userOffset = 0,
     containerSize,
     currentOffset, // safe
     targetIndex,
@@ -88,6 +89,7 @@ export default class ScalingCellSizeAndPositionManager {
 
     const offset = this._cellSizeAndPositionManager.getUpdatedOffsetForIndex({
       align,
+      userOffset,
       containerSize,
       currentOffset,
       targetIndex,

--- a/source/List/List.example.js
+++ b/source/List/List.example.js
@@ -25,6 +25,7 @@ export default class ListExample extends PureComponent {
       overscanRowCount: 10,
       rowCount: context.list.size,
       scrollToIndex: undefined,
+      scrollToOffset: 0,
       showScrollingPlaceholder: false,
       useDynamicRowHeight: false
     }
@@ -33,6 +34,7 @@ export default class ListExample extends PureComponent {
     this._noRowsRenderer = this._noRowsRenderer.bind(this)
     this._onRowCountChange = this._onRowCountChange.bind(this)
     this._onScrollToRowChange = this._onScrollToRowChange.bind(this)
+    this._onScrollToOffsetChange = this._onScrollToOffsetChange.bind(this)
     this._rowRenderer = this._rowRenderer.bind(this)
   }
 
@@ -43,6 +45,7 @@ export default class ListExample extends PureComponent {
       overscanRowCount,
       rowCount,
       scrollToIndex,
+      scrollToOffset,
       showScrollingPlaceholder,
       useDynamicRowHeight
     } = this.state
@@ -99,6 +102,13 @@ export default class ListExample extends PureComponent {
             value={scrollToIndex || ''}
           />
           <LabeledInput
+            label='"Scroll to" offset'
+            name='scrollToOffset'
+            placeholder='0'
+            onChange={this._onScrollToOffsetChange}
+            value={scrollToOffset}
+          />
+          <LabeledInput
             label='List height'
             name='listHeight'
             onChange={event => this.setState({ listHeight: parseInt(event.target.value, 10) || 1 })}
@@ -132,6 +142,7 @@ export default class ListExample extends PureComponent {
                 rowHeight={useDynamicRowHeight ? this._getRowHeight : listRowHeight}
                 rowRenderer={this._rowRenderer}
                 scrollToIndex={scrollToIndex}
+                scrollToOffset={scrollToOffset}
                 width={width}
               />
             )}
@@ -174,6 +185,16 @@ export default class ListExample extends PureComponent {
     }
 
     this.setState({ scrollToIndex })
+  }
+
+  _onScrollToOffsetChange (event) {
+    let scrollToOffset = parseInt(event.target.value, 10)
+
+    if (isNaN(scrollToOffset)) {
+      scrollToOffset = undefined
+    }
+
+    this.setState({ scrollToOffset })
   }
 
   _rowRenderer ({ index, isScrolling, key, style }) {

--- a/source/List/List.jest.js
+++ b/source/List/List.jest.js
@@ -131,6 +131,17 @@ describe('List', () => {
       expect(rendered.textContent).toContain('Name 44')
       expect(rendered.textContent).toContain('Name 54')
     })
+
+    it('should scroll to the correct position for :scrollToOffset', () => {
+      const rendered = findDOMNode(render(getMarkup({
+        scrollToAlignment: 'start',
+        scrollToOffset: 10,
+        scrollToIndex: 49
+      })))
+      // 100 items * 10 item height = 1,000 total item height; 10 items can be visible at a time.
+      expect(rendered.textContent).toContain('Name 50')
+      expect(rendered.textContent).toContain('Name 59')
+    })
   })
 
   describe('property updates', () => {

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -74,6 +74,9 @@ export default class List extends PureComponent {
     /** See Grid#scrollToAlignment */
     scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center']).isRequired,
 
+    /** See Grid#scrollToOffset */
+    scrollToOffset: PropTypes.number.isRequired,
+
     /** Row index to ensure visible (by forcefully scrolling if necessary) */
     scrollToIndex: PropTypes.number.isRequired,
 
@@ -98,6 +101,7 @@ export default class List extends PureComponent {
     overscanIndicesGetter: accessibilityOverscanIndicesGetter,
     overscanRowCount: 10,
     scrollToAlignment: 'auto',
+    scrollToOffset: 0,
     scrollToIndex: -1,
     style: {}
   };


### PR DESCRIPTION
This lets the user add to (or subtract from) the calculated `scrollTo` position. 

E.g., if you have a list of posts in a `WindowScroller` and need to have a margin between the top of the page and the top of the post (when using `scrollTo`), this let's you do that with the `scrollToOffset` prop.



