### PR TITLE
Cover CellMeasurer with types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,3 +19,4 @@
 [libs]
 
 [options]
+unsafe.enable_getters_and_setters=true

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,7 +2,6 @@
 .*/node_modules/.*
 .*/ArrowKeyStepper/.*
 .*/AutoSizer/.*
-.*/CellMeasurer/.*
 .*/Collection/.*
 .*/ColumnSizer/.*
 .*/Grid/.*

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       "fdescribe",
       "fit",
       "getComputedStyle",
+      "HTMLElement",
       "it",
       "jest",
       "spyOn"

--- a/source/CellMeasurer/CellMeasurer.DynamiHeightGrid.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamiHeightGrid.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.DynamiWidthMultiGrid.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamiWidthMultiGrid.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.DynamicHeightList.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamicHeightList.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.DynamicHeightTableColumn.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamicHeightTableColumn.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.DynamicWidthGrid.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamicWidthGrid.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.example.js
+++ b/source/CellMeasurer/CellMeasurer.example.js
@@ -1,4 +1,3 @@
-/** @flow */
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -1,7 +1,7 @@
 /** @flow */
 import React from 'react'
 import { findDOMNode } from 'react-dom'
-import CellMeasurerCache from './CellMeasurerCache.js';
+import CellMeasurerCache from './CellMeasurerCache.js'
 
 type Children = (params: { measure: () => void }) => React.Element<*>
 

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { findDOMNode } from 'react-dom'
 import CellMeasurerCache from './CellMeasurerCache.js';
 
-type Children = (params: { measure: () => void }) => React.Children
+type Children = (params: { measure: () => void }) => React.Element<*>
 
 type Cell = {
   columnIndex: number,
@@ -12,7 +12,7 @@ type Cell = {
 
 type Props = {
   cache: CellMeasurerCache,
-  children: Children | React.Children,
+  children: Children | React.Element<*>,
   columnIndex?: number,
   index?: number,
   parent: {

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -1,35 +1,42 @@
 /** @flow */
-import { PureComponent } from 'react'
+import React from 'react'
 import { findDOMNode } from 'react-dom'
+import CellMeasurerCache from './CellMeasurerCache.js';
+
+type Children = (params: { measure: () => void }) => React.Children
+
+type Cell = {
+  columnIndex: number,
+  rowIndex: number
+}
 
 type Props = {
-  cache: mixed,
-  children: mixed,
-  columnIndex: ?number,
-  index: ?number,
-  parent: mixed,
-  rowIndex: ?number,
-};
+  cache: CellMeasurerCache,
+  children: Children | React.Children,
+  columnIndex?: number,
+  index?: number,
+  parent: {
+    invalidateCellSizeAfterRender?: (cell: Cell) => void,
+    recomputeGridSize?: (cell: Cell) => void
+  },
+  rowIndex?: number,
+}
 
 /**
  * Wraps a cell and measures its rendered content.
  * Measurements are stored in a per-cell cache.
  * Cached-content is not be re-measured.
  */
-export default class CellMeasurer extends PureComponent {
-  props: Props;
+export default class CellMeasurer extends React.PureComponent {
+  static __internalCellMeasurerFlag = false
 
-  constructor (props, context) {
-    super(props, context)
-
-    this._measure = this._measure.bind(this)
-  }
+  props: Props
 
   componentDidMount () {
     this._maybeMeasureCell()
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate () {
     this._maybeMeasureCell()
   }
 
@@ -48,37 +55,41 @@ export default class CellMeasurer extends PureComponent {
 
     // TODO Check for a bad combination of fixedWidth and missing numeric width or vice versa with height
 
-    const styleWidth = node.style.width
-    const styleHeight = node.style.height
+    if (node instanceof HTMLElement) {
+      const styleWidth = node.style.width
+      const styleHeight = node.style.height
 
-    // If we are re-measuring a cell that has already been measured,
-    // It will have a hard-coded width/height from the previous measurement.
-    // The fact that we are measuring indicates this measurement is probably stale,
-    // So explicitly clear it out (eg set to "auto") so we can recalculate.
-    // See issue #593 for more info.
-    // Even if we are measuring initially- if we're inside of a MultiGrid component,
-    // Explicitly clear width/height before measuring to avoid being tainted by another Grid.
-    // eg top/left Grid renders before bottom/right Grid
-    // Since the CellMeasurerCache is shared between them this taints derived cell size values.
-    if (!cache.hasFixedWidth()) {
-      node.style.width = 'auto'
-    }
-    if (!cache.hasFixedHeight()) {
-      node.style.height = 'auto'
-    }
+      // If we are re-measuring a cell that has already been measured,
+      // It will have a hard-coded width/height from the previous measurement.
+      // The fact that we are measuring indicates this measurement is probably stale,
+      // So explicitly clear it out (eg set to "auto") so we can recalculate.
+      // See issue #593 for more info.
+      // Even if we are measuring initially- if we're inside of a MultiGrid component,
+      // Explicitly clear width/height before measuring to avoid being tainted by another Grid.
+      // eg top/left Grid renders before bottom/right Grid
+      // Since the CellMeasurerCache is shared between them this taints derived cell size values.
+      if (!cache.hasFixedWidth()) {
+        node.style.width = 'auto'
+      }
+      if (!cache.hasFixedHeight()) {
+        node.style.height = 'auto'
+      }
 
-    const height = Math.ceil(node.offsetHeight)
-    const width = Math.ceil(node.offsetWidth)
+      const height = Math.ceil(node.offsetHeight)
+      const width = Math.ceil(node.offsetWidth)
 
-    // Reset after measuring to avoid breaking styles; see #660
-    if (styleWidth) {
-      node.style.width = styleWidth
-    }
-    if (styleHeight) {
-      node.style.height = styleHeight
-    }
+      // Reset after measuring to avoid breaking styles; see #660
+      if (styleWidth) {
+        node.style.width = styleWidth
+      }
+      if (styleHeight) {
+        node.style.height = styleHeight
+      }
 
-    return { height, styleHeight, styleWidth, width }
+      return { height, width }
+    } else {
+      return { height: 0, width: 0 }
+    }
   }
 
   _maybeMeasureCell () {
@@ -86,7 +97,7 @@ export default class CellMeasurer extends PureComponent {
       cache,
       columnIndex = 0,
       parent,
-      rowIndex = this.props.index
+      rowIndex = this.props.index || 0
     } = this.props
 
     if (!cache.has(rowIndex, columnIndex)) {
@@ -112,12 +123,12 @@ export default class CellMeasurer extends PureComponent {
     }
   }
 
-  _measure () {
+  _measure = () => {
     const {
       cache,
       columnIndex = 0,
       parent,
-      rowIndex = this.props.index
+      rowIndex = this.props.index || 0
     } = this.props
 
     const { height, width } = this._getCellMeasurements()

--- a/source/CellMeasurer/CellMeasurerCache.js
+++ b/source/CellMeasurer/CellMeasurerCache.js
@@ -15,8 +15,8 @@ type CellMeasurerCacheParams = {
   defaultWidth ?: number,
   fixedHeight ?: boolean,
   fixedWidth ?: boolean,
-  minHeight?: number,
-  minWidth?: number,
+  minHeight ?: number,
+  minWidth ?: number,
   keyMapper ?: KeyMapper
 };
 
@@ -32,15 +32,19 @@ type IndexParam = {
  * Caches measurements for a given cell.
  */
 export default class CellMeasurerCache {
-  _cellHeightCache: Cache;
-  _cellWidthCache: Cache;
-  _columnWidthCache: Cache;
-  _defaultHeight: ?number;
-  _defaultWidth: ?number;
-  _minHeight: ?number;
-  _minWidth: ?number;
+  _cellHeightCache: Cache = {};
+  _cellWidthCache: Cache = {};
+  _columnWidthCache: Cache = {};
+  _rowHeightCache: Cache = {};
+  _defaultHeight: number;
+  _defaultWidth: number;
+  _minHeight: number;
+  _minWidth: number;
   _keyMapper: KeyMapper;
-  _rowHeightCache: Cache;
+  _hasFixedHeight: boolean;
+  _hasFixedWidth: boolean;
+  _columnCount = 0;
+  _rowCount = 0;
 
   constructor (params : CellMeasurerCacheParams = {}) {
     const {
@@ -104,20 +108,9 @@ export default class CellMeasurerCache {
         )
       }
     }
-
-    this._columnCount = 0
-    this._rowCount = 0
-
-    this._cellHeightCache = {}
-    this._cellWidthCache = {}
-    this._columnWidthCache = {}
-    this._rowHeightCache = {}
   }
 
-  clear (
-    rowIndex: number,
-    columnIndex: number
-  ) : void {
+  clear (rowIndex: number, columnIndex: number) {
     const key = this._keyMapper(rowIndex, columnIndex)
 
     delete this._cellHeightCache[key]
@@ -126,7 +119,7 @@ export default class CellMeasurerCache {
     this._updateCachedColumnAndRowSizes(rowIndex, columnIndex)
   }
 
-  clearAll () : void {
+  clearAll () {
     this._cellHeightCache = {}
     this._cellWidthCache = {}
     this._columnWidthCache = {}
@@ -157,10 +150,7 @@ export default class CellMeasurerCache {
     return this._hasFixedWidth
   }
 
-  getHeight (
-    rowIndex: number,
-    columnIndex: ?number = 0
-  ) : ?number {
+  getHeight (rowIndex: number, columnIndex: number = 0) : number {
     if (this._hasFixedHeight) {
       return this._defaultHeight
     } else {
@@ -172,10 +162,7 @@ export default class CellMeasurerCache {
     }
   }
 
-  getWidth (
-    rowIndex: number,
-    columnIndex: ?number = 0
-  ) : ?number {
+  getWidth (rowIndex: number, columnIndex: number = 0) : number {
     if (this._hasFixedWidth) {
       return this._defaultWidth
     } else {
@@ -187,10 +174,7 @@ export default class CellMeasurerCache {
     }
   }
 
-  has (
-    rowIndex: number,
-    columnIndex: ?number = 0
-  ) : boolean {
+  has (rowIndex: number, columnIndex: number = 0) : boolean {
     const key = this._keyMapper(rowIndex, columnIndex)
 
     return this._cellHeightCache.hasOwnProperty(key)
@@ -204,12 +188,7 @@ export default class CellMeasurerCache {
       : this._defaultHeight
   }
 
-  set (
-    rowIndex: number,
-    columnIndex: number,
-    width: number,
-    height: number
-  ) : void {
+  set (rowIndex: number, columnIndex: number, width: number, height: number) {
     const key = this._keyMapper(rowIndex, columnIndex)
 
     if (columnIndex >= this._columnCount) {
@@ -226,10 +205,7 @@ export default class CellMeasurerCache {
     this._updateCachedColumnAndRowSizes(rowIndex, columnIndex)
   }
 
-  _updateCachedColumnAndRowSizes (
-    rowIndex: number,
-    columnIndex: number
-  ) : void {
+  _updateCachedColumnAndRowSizes (rowIndex: number, columnIndex: number) {
     // :columnWidth and :rowHeight are derived based on all cells in a column/row.
     // Pre-cache these derived values for faster lookup later.
     // Reads are expected to occur more frequently than writes in this case.
@@ -253,9 +229,6 @@ export default class CellMeasurerCache {
   }
 }
 
-function defaultKeyMapper (
-  rowIndex: number,
-  columnIndex: number
-): any {
+function defaultKeyMapper (rowIndex: number, columnIndex: number) {
   return `${rowIndex}-${columnIndex}`
 }


### PR DESCRIPTION
Temporary removed flow from examples until `List` will be covered