### PR TITLE
Grid: Improve accessibility by adding props `aria-readonly` & `role="rowgroup"`

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -35,6 +35,7 @@ const SCROLL_POSITION_CHANGE_REASONS = {
 export default class Grid extends PureComponent {
   static propTypes = {
     "aria-label": PropTypes.string,
+    "aria-readonly": PropTypes.bool,
 
     /**
      * Set the width of the inner scrollable container to 'auto'.
@@ -94,6 +95,11 @@ export default class Grid extends PureComponent {
      */
     columnWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
       .isRequired,
+
+    /**
+     * ARIA role for the cell-container.
+     */
+    containerRole: PropTypes.string,
 
     /** Optional inline style applied to inner cell-container */
     containerStyle: PropTypes.object,
@@ -245,7 +251,9 @@ export default class Grid extends PureComponent {
 
   static defaultProps = {
     "aria-label": "grid",
+    "aria-readonly": true,
     cellRangeRenderer: defaultCellRangeRenderer,
+    containerRole: "rowgroup",
     estimatedColumnSize: 100,
     estimatedRowSize: 30,
     getScrollbarSize: scrollbarSize,
@@ -836,6 +844,7 @@ export default class Grid extends PureComponent {
       autoHeight,
       autoWidth,
       className,
+      containerRole,
       containerStyle,
       height,
       id,
@@ -897,6 +906,7 @@ export default class Grid extends PureComponent {
       <div
         ref={this._setScrollingContainerRef}
         aria-label={this.props["aria-label"]}
+        aria-readonly={this.props["aria-readonly"]}
         className={cn("ReactVirtualized__Grid", className)}
         id={id}
         onScroll={this._onScroll}
@@ -910,6 +920,7 @@ export default class Grid extends PureComponent {
         {childrenToDisplay.length > 0 &&
           <div
             className="ReactVirtualized__Grid__innerScrollContainer"
+            role={containerRole}
             style={{
               width: autoContainerWidth ? "auto" : totalColumnsWidth,
               height: totalRowsHeight,


### PR DESCRIPTION
## What changed?

1. [`aria-readonly`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-readonly) is set on the _outer `<div>` with [`role="grid"`](https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/Grid.js#L259)_ to indicate it contains elements which are operable but not editable (contra the [`grid` role](https://www.w3.org/TR/wai-aria/roles#grid) default). It can be overridden. The default value is `true`.

2. [`role="rowgroup"`](https://www.w3.org/TR/wai-aria/roles#rowgroup) is set on the _inner container `<div>`_ to establish the relationship between the _outer `<div>` with [`role="grid"`](https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/Grid.js#L259)_ and _children with `role="row"`_. It helps assistive technologies identify the inner container as something akin to a `<tbody>`. It can be overridden. The default value is `"rowgroup"`.

## Why did it change?

Together, these props allow [JAWS](http://www.freedomscientific.com/downloads/jaws) to recognize `Grid` as a table and enable “Table Layer” reading [commands](http://www.freedomscientific.com/training/Surfs-Up/Table_Reading_Commands.htm).