### PR TITLE
Add support to Table to allow components that extend Column

### DIFF
--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -103,6 +103,18 @@ describe("Table", () => {
       expect(result instanceof Error).toEqual(false);
     });
 
+    it("should accept subclasses of Column as children", () => {
+      class AnotherColumn extends Column {}
+
+      const children = [<AnotherColumn dataKey="foo" width={100} />];
+      const result = Table.propTypes.children(
+        { children },
+        "children",
+        "Table"
+      );
+      expect(result instanceof Error).toEqual(false);
+    });
+
     it("should not accept non-Column children", () => {
       const children = [<div />];
       const result = Table.propTypes.children(

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -27,7 +27,8 @@ export default class Table extends PureComponent {
     children: props => {
       const children = React.Children.toArray(props.children);
       for (let i = 0; i < children.length; i++) {
-        if (children[i].type !== Column) {
+        const childType = children[i].type;
+        if (childType !== Column && !(childType.prototype instanceof Column)) {
           return new Error("Table only accepts children of type Column");
         }
       }


### PR DESCRIPTION
This change allows the `Table` component to accept children that directly extend the `Column` component.

This allows me to create many Column types I can use directly in a Table, making code reuse simpler.

### Creating custom columns

```js
// Changing the default cellDataGetter to use lodash's `get` function
const cellDataGetter = ({ dataKey, rowData }) => {
  return get(rowData, dataKey);
};

export class GetColumn extends Column {
  static defaultProps = {
    ...Column.defaultProps,
    cellDataGetter: cellDataGetter,
  };
}

// Adding a column to render links using `react-router`
const cellLinkRenderer = ({ cellData, rowData }) => {
  if ('to' in rowData) {
    let linkUrl = rowData.to;
    if (typeof rowData.to === 'function') {
      linkUrl = rowData.to({ rowData, cellData });
    }
    return (<Link to={ linkUrl }>{ cellData }</Link>);
  }
  return cellData;
};

export class LinkColumn extends Column {
  static defaultProps = {
    ...Column.defaultProps,
    cellRenderer: cellLinkRenderer,
  };
}
```

### Using custom columns

```js
const list = [{ node: { name: 'foo' }, link: '/bar' }];

<Table
  height={100}
  width={100}
  rowCount={list.length}
  rowGetter={({ index }) => list[index]}
>
  <GetColumn
    label="Name"
    dataKey="node.name"
    width={50}
  />
  <LinkColumn
    label="More info"
    dataKey="link"
    width={50}
  />
</Table>
```