### PR TITLE
Remove babel-plugin-typecheck to fix flow bindings error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -17,7 +17,6 @@
     },
     "development": {
       "plugins": [
-        "typecheck",
         [
           "react-transform",
           {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.6",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-plugin-typecheck": "^3.9.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2015-rollup": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,7 +356,7 @@ babel-eslint@^7.2.3:
     babel-types "^6.23.0"
     babylon "^6.17.0"
 
-babel-generator@^6.18.0, babel-generator@^6.7.7:
+babel-generator@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.18.0.tgz#e4f104cb3063996d9850556a45aae4a022060a07"
   dependencies:
@@ -1181,12 +1181,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
-
-babel-plugin-typecheck@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-typecheck/-/babel-plugin-typecheck-3.9.0.tgz#0edac7573ae24ee58c6f91319f574bc5124b0f0f"
-  dependencies:
-    babel-generator "^6.7.7"
 
 babel-polyfill@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
typecheck is deprecated so conflict with flow ast won't be fixed.
https://github.com/codemix/babel-plugin-typecheck#deprecated