### PR TITLE
Fixed compat with CellMeasurer and List/Table

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -3,6 +3,7 @@
 import type {
   CellRenderer,
   CellRangeRenderer,
+  CellPosition,
   CellSize,
   CellSizeGetter,
   NoContentRenderer,
@@ -47,8 +48,6 @@ type ScrollPosition = {
   scrollTop?: number,
   scrollLeft?: number
 };
-
-type CellPosition = { columnIndex: number, rowIndex: number };
 
 type Props = {
   "aria-label": string,

--- a/source/Grid/index.js
+++ b/source/Grid/index.js
@@ -3,6 +3,7 @@
 export type {
   NoContentRenderer,
   Alignment,
+  CellPosition,
   CellSize,
   OverscanIndicesGetter,
   RenderedSection,

--- a/source/Grid/types.js
+++ b/source/Grid/types.js
@@ -3,6 +3,8 @@
 import React from "react";
 import ScalingCellSizeAndPositionManager from "./utils/ScalingCellSizeAndPositionManager";
 
+export type CellPosition = { columnIndex: number, rowIndex: number };
+
 export type CellRendererParams = {
   columnIndex: number,
   isScrolling: boolean,

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -4,6 +4,7 @@ import type {
   NoContentRenderer,
   Alignment,
   CellSize,
+  CellPosition,
   OverscanIndicesGetter,
   RenderedSection,
   CellRendererParams,
@@ -111,10 +112,12 @@ export default class List extends React.PureComponent {
 
   props: Props;
 
-  Grid: Grid;
+  Grid: ?Grid;
 
   forceUpdateGrid() {
-    this.Grid.forceUpdate();
+    if (this.Grid) {
+      this.Grid.forceUpdate();
+    }
   }
 
   /** See Grid#getOffsetForCell */
@@ -125,39 +128,70 @@ export default class List extends React.PureComponent {
     alignment: Alignment,
     index: number
   }) {
-    const { scrollTop } = this.Grid.getOffsetForCell({
-      alignment,
-      rowIndex: index,
-      columnIndex: 0
-    });
+    if (this.Grid) {
+      const { scrollTop } = this.Grid.getOffsetForCell({
+        alignment,
+        rowIndex: index,
+        columnIndex: 0
+      });
 
-    return scrollTop;
+      return scrollTop;
+    }
+    return 0;
+  }
+
+  /** CellMeasurer compatibility */
+  invalidateCellSizeAfterRender({ columnIndex, rowIndex }: CellPosition) {
+    if (this.Grid) {
+      this.Grid.invalidateCellSizeAfterRender({
+        rowIndex,
+        columnIndex
+      });
+    }
   }
 
   /** See Grid#measureAllCells */
   measureAllRows() {
-    this.Grid.measureAllCells();
+    if (this.Grid) {
+      this.Grid.measureAllCells();
+    }
+  }
+
+  /** CellMeasurer compatibility */
+  recomputeGridSize({ columnIndex = 0, rowIndex = 0 }: CellPosition = {}) {
+    if (this.Grid) {
+      this.Grid.recomputeGridSize({
+        rowIndex,
+        columnIndex
+      });
+    }
   }
 
   /** See Grid#recomputeGridSize */
   recomputeRowHeights(index: number = 0) {
-    this.Grid.recomputeGridSize({
-      rowIndex: index,
-      columnIndex: 0
-    });
+    if (this.Grid) {
+      this.Grid.recomputeGridSize({
+        rowIndex: index,
+        columnIndex: 0
+      });
+    }
   }
 
   /** See Grid#scrollToPosition */
   scrollToPosition(scrollTop: number = 0) {
-    this.Grid.scrollToPosition({ scrollTop });
+    if (this.Grid) {
+      this.Grid.scrollToPosition({ scrollTop });
+    }
   }
 
   /** See Grid#scrollToCell */
   scrollToRow(index: number = 0) {
-    this.Grid.scrollToCell({
-      columnIndex: 0,
-      rowIndex: index
-    });
+    if (this.Grid) {
+      this.Grid.scrollToCell({
+        columnIndex: 0,
+        rowIndex: index
+      });
+    }
   }
 
   render() {

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -1,4 +1,7 @@
 /** @flow */
+
+import type { CellPosition } from "../Grid";
+
 import cn from "classnames";
 import Column from "./Column";
 import PropTypes from "prop-types";
@@ -247,42 +250,75 @@ export default class Table extends PureComponent {
   }
 
   forceUpdateGrid() {
-    this.Grid.forceUpdate();
+    if (this.Grid) {
+      this.Grid.forceUpdate();
+    }
   }
 
   /** See Grid#getOffsetForCell */
   getOffsetForRow({ alignment, index }) {
-    const { scrollTop } = this.Grid.getOffsetForCell({
-      alignment,
-      rowIndex: index
-    });
+    if (this.Grid) {
+      const { scrollTop } = this.Grid.getOffsetForCell({
+        alignment,
+        rowIndex: index
+      });
 
-    return scrollTop;
+      return scrollTop;
+    }
+    return 0;
+  }
+
+  /** CellMeasurer compatibility */
+  invalidateCellSizeAfterRender({ columnIndex, rowIndex }: CellPosition) {
+    if (this.Grid) {
+      this.Grid.invalidateCellSizeAfterRender({
+        rowIndex,
+        columnIndex
+      });
+    }
   }
 
   /** See Grid#measureAllCells */
   measureAllRows() {
-    this.Grid.measureAllCells();
+    if (this.Grid) {
+      this.Grid.measureAllCells();
+    }
+  }
+
+  /** CellMeasurer compatibility */
+  recomputeGridSize({ columnIndex = 0, rowIndex = 0 }: CellPosition = {}) {
+    if (this.Grid) {
+      this.Grid.recomputeGridSize({
+        rowIndex,
+        columnIndex
+      });
+    }
   }
 
   /** See Grid#recomputeGridSize */
   recomputeRowHeights(index = 0) {
-    this.Grid.recomputeGridSize({
-      rowIndex: index
-    });
+    if (this.Grid) {
+      this.Grid.recomputeGridSize({
+        rowIndex: index
+      });
+    }
   }
 
   /** See Grid#scrollToPosition */
   scrollToPosition(scrollTop = 0) {
-    this.Grid.scrollToPosition({ scrollTop });
+    if (this.Grid) {
+      this.Grid.scrollToPosition({ scrollTop });
+    }
   }
 
   /** See Grid#scrollToCell */
   scrollToRow(index = 0) {
-    this.Grid.scrollToCell({
-      columnIndex: 0,
-      rowIndex: index
-    });
+    if (this.Grid) {
+      this.Grid.scrollToCell({
+        columnIndex: 0,
+        rowIndex: index
+      });
+    }
   }
 
   componentDidMount() {
@@ -659,11 +695,13 @@ export default class Table extends PureComponent {
   }
 
   _setScrollbarWidth() {
-    const Grid = findDOMNode(this.Grid);
-    const clientWidth = Grid.clientWidth || 0;
-    const offsetWidth = Grid.offsetWidth || 0;
-    const scrollbarWidth = offsetWidth - clientWidth;
+    if (this.Grid) {
+      const Grid = findDOMNode(this.Grid);
+      const clientWidth = Grid.clientWidth || 0;
+      const offsetWidth = Grid.offsetWidth || 0;
+      const scrollbarWidth = offsetWidth - clientWidth;
 
-    this.setState({ scrollbarWidth });
+      this.setState({ scrollbarWidth });
+    }
   }
 }


### PR DESCRIPTION
I noticed that the `measure` callback seems to have gotten broken somewhere along the way when `CellMeasurer` is used within a `List` or `Table`. This PR fixes it and adds some better null checks for the `Grid` ref.