### PR TITLE
Add ability to pass classNames to MultiGrid Grids

### DIFF
--- a/docs/MultiGrid.md
+++ b/docs/MultiGrid.md
@@ -10,6 +10,10 @@ Some properties (eg `columnCount`, `rowCount`) are adjusted slightly to supporte
 ### Prop Types
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
+| classNameBottomLeftGrid | string |  | Optional custom className to attach to bottom-left `Grid` element. |
+| classNameBottomRightGrid | string |  | Optional custom className to attach to bottom-right `Grid` element. |
+| classNameTopLeftGrid | string |  | Optional custom className to attach to top-left `Grid` element. |
+| classNameTopRightGrid | string |  | Optional custom className to attach to top-right `Grid` element. |
 | enableFixedColumnScroll | boolean |  | Fixed column can be actively scrolled; disabled by default |
 | enableFixedRowScroll | boolean |  | Fixed row can be actively scrolled; disabled by default |
 | fixedColumnCount | number |  | Number of fixed columns; defaults to `0` |

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -15,6 +15,10 @@ const SCROLLBAR_SIZE_BUFFER = 20;
  */
 export default class MultiGrid extends PureComponent {
   static propTypes = {
+    classNameBottomLeftGrid: PropTypes.string.isRequired,
+    classNameBottomRightGrid: PropTypes.string.isRequired,
+    classNameTopLeftGrid: PropTypes.string.isRequired,
+    classNameTopRightGrid: PropTypes.string.isRequired,
     enableFixedColumnScroll: PropTypes.bool.isRequired,
     enableFixedRowScroll: PropTypes.bool.isRequired,
     fixedColumnCount: PropTypes.number.isRequired,
@@ -27,6 +31,10 @@ export default class MultiGrid extends PureComponent {
   };
 
   static defaultProps = {
+    classNameBottomLeftGrid: "",
+    classNameBottomRightGrid: "",
+    classNameTopLeftGrid: "",
+    classNameTopRightGrid: "",
     enableFixedColumnScroll: false,
     enableFixedRowScroll: false,
     fixedColumnCount: 0,
@@ -615,6 +623,7 @@ export default class MultiGrid extends PureComponent {
       <Grid
         {...props}
         cellRenderer={this._cellRendererBottomLeftGrid}
+        className={this.props.classNameBottomLeftGrid}
         columnCount={fixedColumnCount}
         deferredMeasurementCache={this._deferredMeasurementCacheBottomLeftGrid}
         height={this._getBottomGridHeight(props)}
@@ -644,6 +653,7 @@ export default class MultiGrid extends PureComponent {
       <Grid
         {...props}
         cellRenderer={this._cellRendererBottomRightGrid}
+        className={this.props.classNameBottomRightGrid}
         columnCount={Math.max(0, columnCount - fixedColumnCount)}
         columnWidth={this._columnWidthRightGrid}
         deferredMeasurementCache={this._deferredMeasurementCacheBottomRightGrid}
@@ -671,6 +681,7 @@ export default class MultiGrid extends PureComponent {
     return (
       <Grid
         {...props}
+        className={this.props.classNameTopLeftGrid}
         columnCount={fixedColumnCount}
         height={this._getTopGridHeight(props)}
         ref={this._topLeftGridRef}
@@ -702,6 +713,7 @@ export default class MultiGrid extends PureComponent {
       <Grid
         {...props}
         cellRenderer={this._cellRendererTopRightGrid}
+        className={this.props.classNameTopRightGrid}
         columnCount={
           Math.max(0, columnCount - fixedColumnCount) + additionalColumnCount
         }


### PR DESCRIPTION
The API let you pass inline styles, but not `className`s. This allows you to style pseudoelements, etc.