### PR TITLE
cellMeasurerCache.clear() add 0 as default columnIndex

### DIFF
--- a/source/CellMeasurer/CellMeasurerCache.jest.js
+++ b/source/CellMeasurer/CellMeasurerCache.jest.js
@@ -67,6 +67,20 @@ describe("CellMeasurerCache", () => {
     expect(cache.has(1, 0)).toBe(true);
   });
 
+  it("should clear a single cached row cell in column 0 when columnIndex param is absent", () => {
+    const cache = new CellMeasurerCache({
+      fixedHeight: true,
+      fixedWidth: true
+    });
+    cache.set(0, 0, 100, 20);
+    cache.set(1, 0, 100, 20);
+    expect(cache.has(0, 0)).toBe(true);
+    expect(cache.has(1, 0)).toBe(true);
+    cache.clear(0);
+    expect(cache.has(0, 0)).toBe(false);
+    expect(cache.has(1, 0)).toBe(true);
+  })
+
   it("should clear all cached cells", () => {
     const cache = new CellMeasurerCache({
       fixedHeight: true,

--- a/source/CellMeasurer/CellMeasurerCache.js
+++ b/source/CellMeasurer/CellMeasurerCache.js
@@ -94,7 +94,7 @@ export default class CellMeasurerCache {
     }
   }
 
-  clear(rowIndex: number, columnIndex: number) {
+  clear(rowIndex: number, columnIndex: number = 0) {
     const key = this._keyMapper(rowIndex, columnIndex);
 
     delete this._cellHeightCache[key];


### PR DESCRIPTION
Bug: When calling `cellMeasurerCache.clear()` without a `columnIndex`, no cache will be deleted.

Expected behavior: Calling `cellMeasurerCache.clear()` without a `columnIndex` will clear cache at provided `rowIndex` and `columnIndex` at `0`.

Test added as well! Not sure if the test description is clear enough :D

Thank you!