### PR TITLE
Add `keyGetter` prop (10x performance improvement)

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -1,6 +1,7 @@
 /** @flow */
 
 import type {
+  CellKeyGetter,
   CellRenderer,
   CellRangeRenderer,
   CellPosition,
@@ -25,6 +26,7 @@ import defaultOverscanIndicesGetter, {
   SCROLL_DIRECTION_FORWARD
 } from "./defaultOverscanIndicesGetter";
 import updateScrollIndexHelper from "./utils/updateScrollIndexHelper";
+import defaultCellKeyGetter from "./defaultCellKeyGetter";
 import defaultCellRangeRenderer from "./defaultCellRangeRenderer";
 import scrollbarSize from "dom-helpers/util/scrollbarSize";
 import {
@@ -75,6 +77,8 @@ type Props = {
    * Intended for use with WindowScroller
    */
   autoWidth: boolean,
+
+  cellKeyGetter: CellKeyGetter,
 
   /** Responsible for rendering a cell given an row and column index.  */
   cellRenderer: CellRenderer,
@@ -234,6 +238,7 @@ export default class Grid extends React.PureComponent {
     autoContainerWidth: false,
     autoHeight: false,
     autoWidth: false,
+    cellKeyGetter: defaultCellKeyGetter,
     cellRangeRenderer: defaultCellRangeRenderer,
     containerRole: "rowgroup",
     containerStyle: Object,
@@ -961,6 +966,7 @@ export default class Grid extends React.PureComponent {
     state: State = this.state
   ) {
     const {
+      cellKeyGetter,
       cellRenderer,
       cellRangeRenderer,
       columnCount,
@@ -1057,6 +1063,7 @@ export default class Grid extends React.PureComponent {
 
       this._childrenToDisplay = cellRangeRenderer({
         cellCache: this._cellCache,
+        cellKeyGetter,
         cellRenderer,
         columnSizeAndPositionManager: this._columnSizeAndPositionManager,
         columnStartIndex: this._columnStartIndex,

--- a/source/Grid/defaultCellKeyGetter.js
+++ b/source/Grid/defaultCellKeyGetter.js
@@ -1,0 +1,10 @@
+/** @flow */
+
+import type { CellKeyGetterParams } from "./types";
+
+export default function defaultKeyGetter({
+  rowIndex,
+  columnIndex
+}: CellKeyGetterParams) {
+  return `${rowIndex}-${columnIndex}`
+}

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -16,6 +16,7 @@ export default function defaultCellRangeRenderer({
   deferredMeasurementCache,
   horizontalOffsetAdjustment,
   isScrolling,
+  cellKeyGetter,
   parent, // Grid (or List or Table)
   rowSizeAndPositionManager,
   rowStartIndex,
@@ -54,7 +55,14 @@ export default function defaultCellRangeRenderer({
         columnIndex <= visibleColumnIndices.stop &&
         rowIndex >= visibleRowIndices.start &&
         rowIndex <= visibleRowIndices.stop;
-      let key = `${rowIndex}-${columnIndex}`;
+      let key = cellKeyGetter({
+        rowStartIndex,
+        rowStopIndex,
+        rowIndex,
+        columnStartIndex,
+        columnStopIndex,
+        columnIndex
+      });
       let style;
 
       // Cache style objects so shallow-compare doesn't re-render unnecessarily.

--- a/source/Grid/index.js
+++ b/source/Grid/index.js
@@ -7,6 +7,7 @@ export type {
   CellSize,
   OverscanIndicesGetter,
   RenderedSection,
+  CellKeyGetterParams,
   CellRendererParams,
   Scroll
 } from "./types";

--- a/source/Grid/types.js
+++ b/source/Grid/types.js
@@ -3,6 +3,17 @@
 import React from "react";
 import ScalingCellSizeAndPositionManager from "./utils/ScalingCellSizeAndPositionManager";
 
+export type CellKeyGetterParams = {
+  rowStartIndex: number,
+  rowStopIndex: number,
+  rowIndex: number,
+  columnStartIndex: number,
+  columnStopIndex: number,
+  columnIndex: number
+};
+
+export type CellKeyGetter = (props: CellKeyGetterParams) => string;
+
 export type CellPosition = { columnIndex: number, rowIndex: number };
 
 export type CellRendererParams = {
@@ -19,6 +30,7 @@ export type CellRenderer = (props: CellRendererParams) => React.Element<*>;
 
 export type CellRangeRendererParams = {
   cellCache: Object,
+  cellKeyGetter: CellKeyGetter,
   cellRenderer: CellRenderer,
   columnSizeAndPositionManager: ScalingCellSizeAndPositionManager,
   columnStartIndex: number,

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -8,9 +8,10 @@ import type {
   OverscanIndicesGetter,
   RenderedSection,
   CellRendererParams,
+  CellKeyGetterParams,
   Scroll as GridScroll
 } from "../Grid";
-import type { RowRenderer, RenderedRows, Scroll } from "./types";
+import type { KeyGetter, RowRenderer, RenderedRows, Scroll } from "./types";
 
 import Grid, { accessibilityOverscanIndicesGetter } from "../Grid";
 import React from "react";
@@ -45,6 +46,8 @@ type Props = {
 
   /** Height constraint for list (determines how many actual rows are rendered) */
   height: number,
+
+  keyGetter: KeyGetter,
 
   /** Optional renderer to be used in place of rows when rowCount is 0 */
   noRowsRenderer: NoContentRenderer,
@@ -100,6 +103,7 @@ export default class List extends React.PureComponent {
   static defaultProps = {
     autoHeight: false,
     estimatedRowSize: 30,
+    keyGetter: ({index}) => `${index}`,
     onScroll: () => {},
     noRowsRenderer: () => null,
     onRowsRendered: () => {},
@@ -195,7 +199,7 @@ export default class List extends React.PureComponent {
   }
 
   render() {
-    const { className, noRowsRenderer, scrollToIndex, width } = this.props;
+    const { className, keyGetter, noRowsRenderer, scrollToIndex, width } = this.props;
 
     const classNames = cn("ReactVirtualized__List", className);
 
@@ -207,6 +211,7 @@ export default class List extends React.PureComponent {
         className={classNames}
         columnWidth={width}
         columnCount={1}
+        cellKeyGetter={this._keyGetter}
         noContentRenderer={noRowsRenderer}
         onScroll={this._onScroll}
         onSectionRendered={this._onSectionRendered}
@@ -256,6 +261,23 @@ export default class List extends React.PureComponent {
 
     onScroll({ clientHeight, scrollHeight, scrollTop });
   };
+
+  _keyGetter = ({
+    rowStartIndex,
+    rowStopIndex,
+    rowIndex,
+    columnStartIndex,
+    columnStopIndex,
+    columnIndex
+  }: CellKeyGetterParams) => {
+    const {keyGetter} = this.props
+
+    return keyGetter({
+      startIndex: rowStartIndex,
+      stopIndex: rowStopIndex,
+      index: rowIndex
+    })
+  }
 
   _onSectionRendered = ({
     rowOverscanStartIndex,

--- a/source/List/types.js
+++ b/source/List/types.js
@@ -2,6 +2,14 @@
 
 import React from "react";
 
+export type KeyGetterParams = {
+  startIndex: number,
+  stopIndex: number,
+  index: number
+};
+
+export type KeyGetter = (params: KeyGetterParams) => string;
+
 export type RowRendererParams = {
   index: number,
   isScrolling: boolean,


### PR DESCRIPTION
**Motivation**

My app has complex rows which take a long time to mount, but negligible time to re-render. As I scroll down React Virtualized seems to unmount rows from the top of my list & create brand new rows at the bottom. I want to move rows from the top to the bottom instead. Additionally, I want to avoid unnecessary rendering when inserting/deleting rows & sorting short lists. ie, I require custom logic to manage the keys passed to each row in a list.

**Solution**

> Made possible with the new `keyGetter` prop (`cellKeyGetter` in `Grid`)

Track the index each document should be displayed at manually & associate a key to that document. If the document has no associated key it should grab one from the released key pool or generate a new key & then reinitialize the row associated with that document by dispatching an action.

Release keys into the pool by watching for changes in `startIndex` & `endIndex` (indicates a section re-render - the intersection can be released).

**API**

```js
keyGetter={({startIndex, stopIndex, index}) => key}
```

**FYI**

My app is a relatively unique use case, with lots of features built around React Virtualized. It uses `List`, connects each visible row to a state management library for re-rendering, has a custom height cache & calls `List.prototype.repositionRowsAfterIndex` directly.

11 tests were failing when I tested locally (before & after I made any changes), haven't added any myself yet.

I would have done this without modifying React Virtualized if `Grid` didn't have style/cell caches.

Thanks for making this library! ❤