### PR TITLE
Make CellSizeAndPositionManager.getTotalSize() more explicit so it's easier to understand.

### DIFF
--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -151,14 +151,12 @@ export default class CellSizeAndPositionManager {
    */
   getTotalSize(): number {
     const lastMeasuredCellSizeAndPosition = this.getSizeAndPositionOfLastMeasuredCell();
+    const totalSizeOfMeasuredCells =
+      lastMeasuredCellSizeAndPosition.offset +
+      lastMeasuredCellSizeAndPosition.size;
     const numUnmeasuredCells = this._cellCount - this._lastMeasuredIndex - 1;
-
-    const totalSizeOfMeasuredCells = (
-        lastMeasuredCellSizeAndPosition.offset +
-        lastMeasuredCellSizeAndPosition.size
-    );
-    const totalSizeOfUnmeasuredCells = numUnmeasuredCells * this._estimatedCellSize;
-
+    const totalSizeOfUnmeasuredCells =
+      numUnmeasuredCells * this._estimatedCellSize;
     return totalSizeOfMeasuredCells + totalSizeOfUnmeasuredCells;
   }
 

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -147,16 +147,19 @@ export default class CellSizeAndPositionManager {
   /**
    * Total size of all cells being measured.
    * This value will be completely estimated initially.
-   * As cells as measured the estimate will be updated.
+   * As cells are measured, the estimate will be updated.
    */
   getTotalSize(): number {
     const lastMeasuredCellSizeAndPosition = this.getSizeAndPositionOfLastMeasuredCell();
+    const numUnmeasuredCells = this._cellCount - this._lastMeasuredIndex - 1;
 
-    return (
-      lastMeasuredCellSizeAndPosition.offset +
-      lastMeasuredCellSizeAndPosition.size +
-      (this._cellCount - this._lastMeasuredIndex - 1) * this._estimatedCellSize
+    const totalSizeOfMeasuredCells = (
+        lastMeasuredCellSizeAndPosition.offset +
+        lastMeasuredCellSizeAndPosition.size
     );
+    const totalSizeOfUnmeasuredCells = numUnmeasuredCells * this._estimatedCellSize;
+
+    return totalSizeOfMeasuredCells + totalSizeOfUnmeasuredCells;
   }
 
   /**


### PR DESCRIPTION
- The underlying logic is untouched.
- Adds intermediate variables so it's clear as to what the logic is doing.

My goal here is to make this function more explicit so that it's easier for the next person who reads it to understand what it's doing. My hope is that setting some intermediate variables will accomplish this, but if comments are preferable, or you feel like it's too verbose, I can totally understand.
