### PR TITLE
Add childrenClassName for inner Grid element 

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -85,6 +85,9 @@ type Props = {
   /** Optional custom CSS class name to attach to root Grid element.  */
   className?: string,
 
+  /** Optional custom CSS class name to attach to inner children Grid element. */
+  childrenClassName?: string,
+
   /** Number of columns in grid.  */
   columnCount: number,
 
@@ -857,6 +860,7 @@ export default class Grid extends React.PureComponent {
       autoHeight,
       autoWidth,
       className,
+      childrenClassName,
       containerProps,
       containerRole,
       containerStyle,
@@ -934,7 +938,10 @@ export default class Grid extends React.PureComponent {
       >
         {childrenToDisplay.length > 0 &&
           <div
-            className="ReactVirtualized__Grid__innerScrollContainer"
+            className={cn(
+              "ReactVirtualized__Grid__innerScrollContainer",
+              childrenClassName
+            )}
             role={containerRole}
             style={{
               width: autoContainerWidth ? "auto" : totalColumnsWidth,

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -37,6 +37,9 @@ type Props = {
   /** Optional CSS class name */
   className?: string,
 
+  /** Optional inner children Grid CSS class name */
+  childrenClassName?: string,
+
   /**
    * Used to estimate the total height of a List before all of its rows have actually been measured.
    * The estimated total height is adjusted as rows are rendered.
@@ -195,7 +198,13 @@ export default class List extends React.PureComponent {
   }
 
   render() {
-    const { className, noRowsRenderer, scrollToIndex, width } = this.props;
+    const {
+      className,
+      childrenClassName,
+      noRowsRenderer,
+      scrollToIndex,
+      width
+    } = this.props;
 
     const classNames = cn("ReactVirtualized__List", className);
 
@@ -205,6 +214,7 @@ export default class List extends React.PureComponent {
         autoContainerWidth
         cellRenderer={this._cellRenderer}
         className={classNames}
+        childrenClassName={childrenClassName}
         columnWidth={width}
         columnCount={1}
         noContentRenderer={noRowsRenderer}


### PR DESCRIPTION
Using a List element is not possible to attach a custom CSS class name for the Grid element that is being used internally. This solution allows it.

Example
```
<List
  className="wraper"
  childrenClassName="items"
  height={height}
  width={width}
  ref={registerChild}
  rowCount={this.state.animals.length}
  rowHeight={rowHeight}
  rowRenderer={this._rowRenderer}
/>
```
will generate
```
<div aria-label="grid" aria-readonly="true" class="ReactVirtualized__Grid ReactVirtualized__List wraper" role="grid" tabindex="0" style="box-sizing: border-box; direction: ltr; height: 915px; position: relative; width: 723px; will-change: transform; overflow: auto;">
  <div class="ReactVirtualized__Grid__innerScrollContainer items" role="rowgroup" style="width: auto; height: 2400px; max-width: 723px; max-height: 2400px; overflow: hidden; position: relative;">
    <div class="item">Item value</div>
  </div>
</div>
```

Hope could be useful :)
