### PR TITLE
Make Grid.props.tabIndex: ?number

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -11,52 +11,52 @@ import type {
   ScrollbarPresenceChange,
   RenderedSection,
   OverscanIndicesGetter,
-  Alignment
-} from "./types";
-import type { AnimationTimeoutId } from "../utils/requestAnimationTimeout";
+  Alignment,
+} from './types'
+import type { AnimationTimeoutId } from '../utils/requestAnimationTimeout'
 
-import React from "react";
-import cn from "classnames";
-import calculateSizeAndPositionDataAndUpdateScrollOffset from "./utils/calculateSizeAndPositionDataAndUpdateScrollOffset";
-import ScalingCellSizeAndPositionManager from "./utils/ScalingCellSizeAndPositionManager";
-import createCallbackMemoizer from "../utils/createCallbackMemoizer";
+import React from 'react'
+import cn from 'classnames'
+import calculateSizeAndPositionDataAndUpdateScrollOffset from './utils/calculateSizeAndPositionDataAndUpdateScrollOffset'
+import ScalingCellSizeAndPositionManager from './utils/ScalingCellSizeAndPositionManager'
+import createCallbackMemoizer from '../utils/createCallbackMemoizer'
 import defaultOverscanIndicesGetter, {
   SCROLL_DIRECTION_BACKWARD,
-  SCROLL_DIRECTION_FORWARD
-} from "./defaultOverscanIndicesGetter";
-import updateScrollIndexHelper from "./utils/updateScrollIndexHelper";
-import defaultCellRangeRenderer from "./defaultCellRangeRenderer";
-import scrollbarSize from "dom-helpers/util/scrollbarSize";
+  SCROLL_DIRECTION_FORWARD,
+} from './defaultOverscanIndicesGetter'
+import updateScrollIndexHelper from './utils/updateScrollIndexHelper'
+import defaultCellRangeRenderer from './defaultCellRangeRenderer'
+import scrollbarSize from 'dom-helpers/util/scrollbarSize'
 import {
   requestAnimationTimeout,
-  cancelAnimationTimeout
-} from "../utils/requestAnimationTimeout";
+  cancelAnimationTimeout,
+} from '../utils/requestAnimationTimeout'
 
 /**
  * Specifies the number of milliseconds during which to disable pointer events while a scroll is in progress.
  * This improves performance and makes scrolling smoother.
  */
-export const DEFAULT_SCROLLING_RESET_TIME_INTERVAL = 150;
+export const DEFAULT_SCROLLING_RESET_TIME_INTERVAL = 150
 
 /**
  * Controls whether the Grid updates the DOM element's scrollLeft/scrollTop based on the current state or just observes it.
  * This prevents Grid from interrupting mouse-wheel animations (see issue #2).
  */
 const SCROLL_POSITION_CHANGE_REASONS = {
-  OBSERVED: "observed",
-  REQUESTED: "requested"
-};
+  OBSERVED: 'observed',
+  REQUESTED: 'requested',
+}
 
-const renderNull: NoContentRenderer = () => null;
+const renderNull: NoContentRenderer = () => null
 
 type ScrollPosition = {
   scrollTop?: number,
-  scrollLeft?: number
-};
+  scrollLeft?: number,
+}
 
 type Props = {
-  "aria-label": string,
-  "aria-readonly"?: boolean,
+  'aria-label': string,
+  'aria-readonly'?: boolean,
 
   /**
    * Set the width of the inner scrollable container to 'auto'.
@@ -208,11 +208,11 @@ type Props = {
   style: Object,
 
   /** Tab index for focus */
-  tabIndex: number | null,
+  tabIndex: ?number,
 
   /** Width of Grid; this property determines the number of visible (vs virtualized) columns.  */
-  width: number
-};
+  width: number,
+}
 
 type State = {
   isScrolling: boolean,
@@ -220,8 +220,8 @@ type State = {
   scrollDirectionVertical: -1 | 1,
   scrollLeft: number,
   scrollTop: number,
-  scrollPositionChangeReason?: "observed" | "requested"
-};
+  scrollPositionChangeReason?: 'observed' | 'requested',
+}
 
 /**
  * Renders tabular data with virtualization along the vertical and horizontal axes.
@@ -229,13 +229,13 @@ type State = {
  */
 export default class Grid extends React.PureComponent {
   static defaultProps = {
-    "aria-label": "grid",
-    "aria-readonly": true,
+    'aria-label': 'grid',
+    'aria-readonly': true,
     autoContainerWidth: false,
     autoHeight: false,
     autoWidth: false,
     cellRangeRenderer: defaultCellRangeRenderer,
-    containerRole: "rowgroup",
+    containerRole: 'rowgroup',
     containerStyle: {},
     estimatedColumnSize: 100,
     estimatedRowSize: 30,
@@ -247,73 +247,73 @@ export default class Grid extends React.PureComponent {
     overscanColumnCount: 0,
     overscanIndicesGetter: defaultOverscanIndicesGetter,
     overscanRowCount: 10,
-    role: "grid",
+    role: 'grid',
     scrollingResetTimeInterval: DEFAULT_SCROLLING_RESET_TIME_INTERVAL,
-    scrollToAlignment: "auto",
+    scrollToAlignment: 'auto',
     scrollToColumn: -1,
     scrollToRow: -1,
     style: {},
-    tabIndex: 0
-  };
+    tabIndex: 0,
+  }
 
-  props: Props;
+  props: Props
 
   state: State = {
     isScrolling: false,
     scrollDirectionHorizontal: SCROLL_DIRECTION_FORWARD,
     scrollDirectionVertical: SCROLL_DIRECTION_FORWARD,
     scrollLeft: 0,
-    scrollTop: 0
-  };
+    scrollTop: 0,
+  }
 
   // Invokes onSectionRendered callback only when start/stop row or column indices change
-  _onGridRenderedMemoizer = createCallbackMemoizer();
-  _onScrollMemoizer = createCallbackMemoizer(false);
+  _onGridRenderedMemoizer = createCallbackMemoizer()
+  _onScrollMemoizer = createCallbackMemoizer(false)
 
-  _deferredInvalidateColumnIndex = null;
-  _deferredInvalidateRowIndex = null;
-  _recomputeScrollLeftFlag = false;
-  _recomputeScrollTopFlag = false;
+  _deferredInvalidateColumnIndex = null
+  _deferredInvalidateRowIndex = null
+  _recomputeScrollLeftFlag = false
+  _recomputeScrollTopFlag = false
 
-  _horizontalScrollBarSize = 0;
-  _verticalScrollBarSize = 0;
-  _scrollbarPresenceChanged = false;
+  _horizontalScrollBarSize = 0
+  _verticalScrollBarSize = 0
+  _scrollbarPresenceChanged = false
 
-  _columnWidthGetter: CellSizeGetter;
-  _rowHeightGetter: CellSizeGetter;
+  _columnWidthGetter: CellSizeGetter
+  _rowHeightGetter: CellSizeGetter
 
-  _columnSizeAndPositionManager: ScalingCellSizeAndPositionManager;
-  _rowSizeAndPositionManager: ScalingCellSizeAndPositionManager;
+  _columnSizeAndPositionManager: ScalingCellSizeAndPositionManager
+  _rowSizeAndPositionManager: ScalingCellSizeAndPositionManager
 
   // See defaultCellRangeRenderer() for more information on the usage of these caches
-  _cellCache = {};
-  _styleCache = {};
+  _cellCache = {}
+  _styleCache = {}
 
-  _scrollbarSize: number;
-  _scrollbarSizeMeasured = false;
-  _scrollingContainer: Element;
+  _scrollbarSize: number
+  _scrollbarSizeMeasured = false
+  _scrollingContainer: Element
 
-  _childrenToDisplay: React.Element<*>[];
+  _childrenToDisplay: React.Element<*>[]
 
-  _renderedColumnStartIndex = 0;
-  _renderedColumnStopIndex = 0;
-  _renderedRowStartIndex = 0;
-  _renderedRowStopIndex = 0;
+  _renderedColumnStartIndex = 0
+  _renderedColumnStopIndex = 0
+  _renderedRowStartIndex = 0
+  _renderedRowStopIndex = 0
 
-  _columnStartIndex: number;
-  _columnStopIndex: number;
-  _rowStartIndex: number;
-  _rowStopIndex: number;
+  _columnStartIndex: number
+  _columnStopIndex: number
+  _rowStartIndex: number
+  _rowStopIndex: number
 
-  _disablePointerEventsTimeoutId: ?AnimationTimeoutId;
+  _disablePointerEventsTimeoutId: ?AnimationTimeoutId
 
   constructor(props: Props) {
-    super(props);
+    super(props)
 
-    this._columnWidthGetter = this._wrapSizeGetter(props.columnWidth);
-    this._rowHeightGetter = this._wrapSizeGetter(props.rowHeight);
+    this._columnWidthGetter = this._wrapSizeGetter(props.columnWidth)
+    this._rowHeightGetter = this._wrapSizeGetter(props.rowHeight)
 
-    const deferredMeasurementCache = props.deferredMeasurementCache;
+    const deferredMeasurementCache = props.deferredMeasurementCache
 
     this._columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       batchAllCells:
@@ -321,16 +321,16 @@ export default class Grid extends React.PureComponent {
         !deferredMeasurementCache.hasFixedHeight(),
       cellCount: props.columnCount,
       cellSizeGetter: params => this._columnWidthGetter(params),
-      estimatedCellSize: this._getEstimatedColumnSize(props)
-    });
+      estimatedCellSize: this._getEstimatedColumnSize(props),
+    })
     this._rowSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       batchAllCells:
         deferredMeasurementCache !== undefined &&
         !deferredMeasurementCache.hasFixedWidth(),
       cellCount: props.rowCount,
       cellSizeGetter: params => this._rowHeightGetter(params),
-      estimatedCellSize: this._getEstimatedRowSize(props)
-    });
+      estimatedCellSize: this._getEstimatedRowSize(props),
+    })
   }
 
   /**
@@ -340,24 +340,24 @@ export default class Grid extends React.PureComponent {
     {
       alignment = this.props.scrollToAlignment,
       columnIndex = this.props.scrollToColumn,
-      rowIndex = this.props.scrollToRow
+      rowIndex = this.props.scrollToRow,
     }: {
       alignment?: Alignment,
       columnIndex?: number,
-      rowIndex?: number
+      rowIndex?: number,
     } = {}
   ) {
     const offsetProps = {
       ...this.props,
       scrollToAlignment: alignment,
       scrollToColumn: columnIndex,
-      scrollToRow: rowIndex
-    };
+      scrollToRow: rowIndex,
+    }
 
     return {
       scrollLeft: this._getCalculatedScrollLeft(offsetProps),
-      scrollTop: this._getCalculatedScrollTop(offsetProps)
-    };
+      scrollTop: this._getCalculatedScrollTop(offsetProps),
+    }
   }
 
   /**
@@ -366,34 +366,34 @@ export default class Grid extends React.PureComponent {
    */
   handleScrollEvent({
     scrollLeft: scrollLeftParam = 0,
-    scrollTop: scrollTopParam = 0
+    scrollTop: scrollTopParam = 0,
   }: ScrollPosition) {
     // On iOS, we can arrive at negative offsets by swiping past the start.
     // To prevent flicker here, we make playing in the negative offset zone cause nothing to happen.
     if (scrollTopParam < 0) {
-      return;
+      return
     }
 
     // Prevent pointer events from interrupting a smooth scroll
-    this._debounceScrollEnded();
+    this._debounceScrollEnded()
 
-    const { autoHeight, autoWidth, height, width } = this.props;
+    const { autoHeight, autoWidth, height, width } = this.props
 
     // When this component is shrunk drastically, React dispatches a series of back-to-back scroll events,
     // Gradually converging on a scrollTop that is within the bounds of the new, smaller height.
     // This causes a series of rapid renders that is slow for long lists.
     // We can avoid that by doing some simple bounds checking to ensure that scroll offsets never exceed their bounds.
-    const scrollbarSize = this._scrollbarSize;
-    const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize();
-    const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize();
+    const scrollbarSize = this._scrollbarSize
+    const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize()
+    const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
     const scrollLeft = Math.min(
       Math.max(0, totalColumnsWidth - width + scrollbarSize),
       scrollLeftParam
-    );
+    )
     const scrollTop = Math.min(
       Math.max(0, totalRowsHeight - height + scrollbarSize),
       scrollTopParam
-    );
+    )
 
     // Certain devices (like Apple touchpad) rapid-fire duplicate events.
     // Don't force a re-render if this is the case.
@@ -410,38 +410,38 @@ export default class Grid extends React.PureComponent {
           ? scrollLeft > this.state.scrollLeft
             ? SCROLL_DIRECTION_FORWARD
             : SCROLL_DIRECTION_BACKWARD
-          : this.state.scrollDirectionHorizontal;
+          : this.state.scrollDirectionHorizontal
       const scrollDirectionVertical =
         scrollTop !== this.state.scrollTop
           ? scrollTop > this.state.scrollTop
             ? SCROLL_DIRECTION_FORWARD
             : SCROLL_DIRECTION_BACKWARD
-          : this.state.scrollDirectionVertical;
+          : this.state.scrollDirectionVertical
 
       const newState: Object = {
         isScrolling: true,
         scrollDirectionHorizontal,
         scrollDirectionVertical,
-        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED
-      };
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.OBSERVED,
+      }
 
       if (!autoHeight) {
-        newState.scrollTop = scrollTop;
+        newState.scrollTop = scrollTop
       }
 
       if (!autoWidth) {
-        newState.scrollLeft = scrollLeft;
+        newState.scrollLeft = scrollLeft
       }
 
-      this.setState(newState);
+      this.setState(newState)
     }
 
     this._invokeOnScrollMemoizer({
       scrollLeft,
       scrollTop,
       totalColumnsWidth,
-      totalRowsHeight
-    });
+      totalRowsHeight,
+    })
   }
 
   /**
@@ -453,13 +453,13 @@ export default class Grid extends React.PureComponent {
   // @TODO (bvaughn) Add automated test coverage for this.
   invalidateCellSizeAfterRender({ columnIndex, rowIndex }: CellPosition) {
     this._deferredInvalidateColumnIndex =
-      typeof this._deferredInvalidateColumnIndex === "number"
+      typeof this._deferredInvalidateColumnIndex === 'number'
         ? Math.min(this._deferredInvalidateColumnIndex, columnIndex)
-        : columnIndex;
+        : columnIndex
     this._deferredInvalidateRowIndex =
-      typeof this._deferredInvalidateRowIndex === "number"
+      typeof this._deferredInvalidateRowIndex === 'number'
         ? Math.min(this._deferredInvalidateRowIndex, rowIndex)
-        : rowIndex;
+        : rowIndex
   }
 
   /**
@@ -468,12 +468,10 @@ export default class Grid extends React.PureComponent {
    * This method ensures that the next call to getTotalSize() returns an exact size (as opposed to just an estimated one).
    */
   measureAllCells() {
-    const { columnCount, rowCount } = this.props;
+    const { columnCount, rowCount } = this.props
 
-    this._columnSizeAndPositionManager.getSizeAndPositionOfCell(
-      columnCount - 1
-    );
-    this._rowSizeAndPositionManager.getSizeAndPositionOfCell(rowCount - 1);
+    this._columnSizeAndPositionManager.getSizeAndPositionOfCell(columnCount - 1)
+    this._rowSizeAndPositionManager.getSizeAndPositionOfCell(rowCount - 1)
   }
 
   /**
@@ -482,48 +480,48 @@ export default class Grid extends React.PureComponent {
    * Since Grid only receives :columnCount and :rowCount it has no way of detecting when the underlying data changes.
    */
   recomputeGridSize({ columnIndex = 0, rowIndex = 0 }: CellPosition = {}) {
-    const { scrollToColumn, scrollToRow } = this.props;
+    const { scrollToColumn, scrollToRow } = this.props
 
-    this._columnSizeAndPositionManager.resetCell(columnIndex);
-    this._rowSizeAndPositionManager.resetCell(rowIndex);
+    this._columnSizeAndPositionManager.resetCell(columnIndex)
+    this._rowSizeAndPositionManager.resetCell(rowIndex)
 
     // Cell sizes may be determined by a function property.
     // In this case the cDU handler can't know if they changed.
     // Store this flag to let the next cDU pass know it needs to recompute the scroll offset.
     this._recomputeScrollLeftFlag =
-      scrollToColumn >= 0 && columnIndex <= scrollToColumn;
-    this._recomputeScrollTopFlag = scrollToRow >= 0 && rowIndex <= scrollToRow;
+      scrollToColumn >= 0 && columnIndex <= scrollToColumn
+    this._recomputeScrollTopFlag = scrollToRow >= 0 && rowIndex <= scrollToRow
 
     // Clear cell cache in case we are scrolling;
     // Invalid row heights likely mean invalid cached content as well.
-    this._cellCache = {};
-    this._styleCache = {};
+    this._cellCache = {}
+    this._styleCache = {}
 
-    this.forceUpdate();
+    this.forceUpdate()
   }
 
   /**
    * Ensure column and row are visible.
    */
   scrollToCell({ columnIndex, rowIndex }: CellPosition) {
-    const { columnCount } = this.props;
+    const { columnCount } = this.props
 
-    const props = this.props;
+    const props = this.props
 
     // Don't adjust scroll offset for single-column grids (eg List, Table).
     // This can cause a funky scroll offset because of the vertical scrollbar width.
     if (columnCount > 1 && columnIndex !== undefined) {
       this._updateScrollLeftForScrollToColumn({
         ...props,
-        scrollToColumn: columnIndex
-      });
+        scrollToColumn: columnIndex,
+      })
     }
 
     if (rowIndex !== undefined) {
       this._updateScrollTopForScrollToRow({
         ...props,
-        scrollToRow: rowIndex
-      });
+        scrollToRow: rowIndex,
+      })
     }
   }
 
@@ -535,50 +533,50 @@ export default class Grid extends React.PureComponent {
       scrollToColumn,
       scrollTop,
       scrollToRow,
-      width
-    } = this.props;
+      width,
+    } = this.props
 
     // If cell sizes have been invalidated (eg we are using CellMeasurer) then reset cached positions.
     // We must do this at the start of the method as we may calculate and update scroll position below.
-    this._handleInvalidatedGridSize();
+    this._handleInvalidatedGridSize()
 
     // If this component was first rendered server-side, scrollbar size will be undefined.
     // In that event we need to remeasure.
     if (!this._scrollbarSizeMeasured) {
-      this._scrollbarSize = getScrollbarSize();
-      this._scrollbarSizeMeasured = true;
-      this.setState({});
+      this._scrollbarSize = getScrollbarSize()
+      this._scrollbarSizeMeasured = true
+      this.setState({})
     }
 
     if (
-      (typeof scrollLeft === "number" && scrollLeft >= 0) ||
-      (typeof scrollTop === "number" && scrollTop >= 0)
+      (typeof scrollLeft === 'number' && scrollLeft >= 0) ||
+      (typeof scrollTop === 'number' && scrollTop >= 0)
     ) {
-      this.scrollToPosition({ scrollLeft, scrollTop });
+      this.scrollToPosition({ scrollLeft, scrollTop })
     }
 
     // Don't update scroll offset if the size is 0; we don't render any cells in this case.
     // Setting a state may cause us to later thing we've updated the offce when we haven't.
-    const sizeIsBiggerThanZero = height > 0 && width > 0;
+    const sizeIsBiggerThanZero = height > 0 && width > 0
     if (scrollToColumn >= 0 && sizeIsBiggerThanZero) {
-      this._updateScrollLeftForScrollToColumn();
+      this._updateScrollLeftForScrollToColumn()
     }
     if (scrollToRow >= 0 && sizeIsBiggerThanZero) {
-      this._updateScrollTopForScrollToRow();
+      this._updateScrollTopForScrollToRow()
     }
 
     // Update onRowsRendered callback
-    this._invokeOnGridRenderedHelper();
+    this._invokeOnGridRenderedHelper()
 
     // Initialize onScroll callback
     this._invokeOnScrollMemoizer({
       scrollLeft: scrollLeft || 0,
       scrollTop: scrollTop || 0,
       totalColumnsWidth: this._columnSizeAndPositionManager.getTotalSize(),
-      totalRowsHeight: this._rowSizeAndPositionManager.getTotalSize()
-    });
+      totalRowsHeight: this._rowSizeAndPositionManager.getTotalSize(),
+    })
 
-    this._maybeCallOnScrollbarPresenceChange();
+    this._maybeCallOnScrollbarPresenceChange()
   }
 
   /**
@@ -596,20 +594,20 @@ export default class Grid extends React.PureComponent {
       scrollToAlignment,
       scrollToColumn,
       scrollToRow,
-      width
-    } = this.props;
-    const { scrollLeft, scrollPositionChangeReason, scrollTop } = this.state;
+      width,
+    } = this.props
+    const { scrollLeft, scrollPositionChangeReason, scrollTop } = this.state
 
     // If cell sizes have been invalidated (eg we are using CellMeasurer) then reset cached positions.
     // We must do this at the start of the method as we may calculate and update scroll position below.
-    this._handleInvalidatedGridSize();
+    this._handleInvalidatedGridSize()
 
     // Handle edge case where column or row count has only just increased over 0.
     // In this case we may have to restore a previously-specified scroll offset.
     // For more info see bvaughn/react-virtualized/issues/218
     const columnOrRowCountJustIncreasedFromZero =
       (columnCount > 0 && prevProps.columnCount === 0) ||
-      (rowCount > 0 && prevProps.rowCount === 0);
+      (rowCount > 0 && prevProps.rowCount === 0)
 
     // Make sure requested changes to :scrollLeft or :scrollTop get applied.
     // Assigning to scrollLeft/scrollTop tells the browser to interrupt any running scroll animations,
@@ -628,7 +626,7 @@ export default class Grid extends React.PureComponent {
           scrollLeft !== this._scrollingContainer.scrollLeft) ||
           columnOrRowCountJustIncreasedFromZero)
       ) {
-        this._scrollingContainer.scrollLeft = scrollLeft;
+        this._scrollingContainer.scrollLeft = scrollLeft
       }
       if (
         !autoHeight &&
@@ -637,7 +635,7 @@ export default class Grid extends React.PureComponent {
           scrollTop !== this._scrollingContainer.scrollTop) ||
           columnOrRowCountJustIncreasedFromZero)
       ) {
-        this._scrollingContainer.scrollTop = scrollTop;
+        this._scrollingContainer.scrollTop = scrollTop
       }
     }
 
@@ -646,19 +644,19 @@ export default class Grid extends React.PureComponent {
     // So we should always recalculate offset afterwards.
     const sizeJustIncreasedFromZero =
       (prevProps.width === 0 || prevProps.height === 0) &&
-      (height > 0 && width > 0);
+      (height > 0 && width > 0)
 
     // Update scroll offsets if the current :scrollToColumn or :scrollToRow values requires it
     // @TODO Do we also need this check or can the one in componentWillUpdate() suffice?
     if (this._recomputeScrollLeftFlag) {
-      this._recomputeScrollLeftFlag = false;
-      this._updateScrollLeftForScrollToColumn(this.props);
+      this._recomputeScrollLeftFlag = false
+      this._updateScrollLeftForScrollToColumn(this.props)
     } else {
       updateScrollIndexHelper({
         cellSizeAndPositionManager: this._columnSizeAndPositionManager,
         previousCellsCount: prevProps.columnCount,
         previousCellSize:
-          typeof prevProps.columnWidth === "number"
+          typeof prevProps.columnWidth === 'number'
             ? prevProps.columnWidth
             : null,
         previousScrollToAlignment: prevProps.scrollToAlignment,
@@ -670,19 +668,19 @@ export default class Grid extends React.PureComponent {
         size: width,
         sizeJustIncreasedFromZero,
         updateScrollIndexCallback: () =>
-          this._updateScrollLeftForScrollToColumn(this.props)
-      });
+          this._updateScrollLeftForScrollToColumn(this.props),
+      })
     }
 
     if (this._recomputeScrollTopFlag) {
-      this._recomputeScrollTopFlag = false;
-      this._updateScrollTopForScrollToRow(this.props);
+      this._recomputeScrollTopFlag = false
+      this._updateScrollTopForScrollToRow(this.props)
     } else {
       updateScrollIndexHelper({
         cellSizeAndPositionManager: this._rowSizeAndPositionManager,
         previousCellsCount: prevProps.rowCount,
         previousCellSize:
-          typeof prevProps.rowHeight === "number" ? prevProps.rowHeight : null,
+          typeof prevProps.rowHeight === 'number' ? prevProps.rowHeight : null,
         previousScrollToAlignment: prevProps.scrollToAlignment,
         previousScrollToIndex: prevProps.scrollToRow,
         previousSize: prevProps.height,
@@ -692,51 +690,51 @@ export default class Grid extends React.PureComponent {
         size: height,
         sizeJustIncreasedFromZero,
         updateScrollIndexCallback: () =>
-          this._updateScrollTopForScrollToRow(this.props)
-      });
+          this._updateScrollTopForScrollToRow(this.props),
+      })
     }
 
     // Update onRowsRendered callback if start/stop indices have changed
-    this._invokeOnGridRenderedHelper();
+    this._invokeOnGridRenderedHelper()
 
     // Changes to :scrollLeft or :scrollTop should also notify :onScroll listeners
     if (
       scrollLeft !== prevState.scrollLeft ||
       scrollTop !== prevState.scrollTop
     ) {
-      const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize();
-      const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize();
+      const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize()
+      const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
 
       this._invokeOnScrollMemoizer({
         scrollLeft,
         scrollTop,
         totalColumnsWidth,
-        totalRowsHeight
-      });
+        totalRowsHeight,
+      })
     }
 
-    this._maybeCallOnScrollbarPresenceChange();
+    this._maybeCallOnScrollbarPresenceChange()
   }
 
   componentWillMount() {
-    const { getScrollbarSize } = this.props;
+    const { getScrollbarSize } = this.props
 
     // If this component is being rendered server-side, getScrollbarSize() will return undefined.
     // We handle this case in componentDidMount()
-    this._scrollbarSize = getScrollbarSize();
+    this._scrollbarSize = getScrollbarSize()
     if (this._scrollbarSize === undefined) {
-      this._scrollbarSizeMeasured = false;
-      this._scrollbarSize = 0;
+      this._scrollbarSizeMeasured = false
+      this._scrollbarSize = 0
     } else {
-      this._scrollbarSizeMeasured = true;
+      this._scrollbarSizeMeasured = true
     }
 
-    this._calculateChildrenToRender();
+    this._calculateChildrenToRender()
   }
 
   componentWillUnmount() {
     if (this._disablePointerEventsTimeoutId) {
-      cancelAnimationTimeout(this._disablePointerEventsTimeoutId);
+      cancelAnimationTimeout(this._disablePointerEventsTimeoutId)
     }
   }
 
@@ -748,7 +746,7 @@ export default class Grid extends React.PureComponent {
    * 3) Cells-count or cells-size has changed, making previous scroll offsets invalid
    */
   componentWillReceiveProps(nextProps: Props) {
-    const { scrollLeft, scrollTop } = this.state;
+    const { scrollLeft, scrollTop } = this.state
 
     if (
       (nextProps.columnCount === 0 && scrollLeft !== 0) ||
@@ -756,51 +754,51 @@ export default class Grid extends React.PureComponent {
     ) {
       this.scrollToPosition({
         scrollLeft: 0,
-        scrollTop: 0
-      });
+        scrollTop: 0,
+      })
     } else if (
       nextProps.scrollLeft !== this.props.scrollLeft ||
       nextProps.scrollTop !== this.props.scrollTop
     ) {
-      const newState = {};
+      const newState = {}
 
       if (nextProps.scrollLeft != null) {
-        newState.scrollLeft = nextProps.scrollLeft;
+        newState.scrollLeft = nextProps.scrollLeft
       }
       if (nextProps.scrollTop != null) {
-        newState.scrollTop = nextProps.scrollTop;
+        newState.scrollTop = nextProps.scrollTop
       }
 
-      this.scrollToPosition(newState);
+      this.scrollToPosition(newState)
     }
 
     if (
       nextProps.columnWidth !== this.props.columnWidth ||
       nextProps.rowHeight !== this.props.rowHeight
     ) {
-      this._styleCache = {};
+      this._styleCache = {}
     }
 
-    this._columnWidthGetter = this._wrapSizeGetter(nextProps.columnWidth);
-    this._rowHeightGetter = this._wrapSizeGetter(nextProps.rowHeight);
+    this._columnWidthGetter = this._wrapSizeGetter(nextProps.columnWidth)
+    this._rowHeightGetter = this._wrapSizeGetter(nextProps.rowHeight)
 
     this._columnSizeAndPositionManager.configure({
       cellCount: nextProps.columnCount,
-      estimatedCellSize: this._getEstimatedColumnSize(nextProps)
-    });
+      estimatedCellSize: this._getEstimatedColumnSize(nextProps),
+    })
     this._rowSizeAndPositionManager.configure({
       cellCount: nextProps.rowCount,
-      estimatedCellSize: this._getEstimatedRowSize(nextProps)
-    });
+      estimatedCellSize: this._getEstimatedRowSize(nextProps),
+    })
 
-    let { columnCount, rowCount } = this.props;
+    let { columnCount, rowCount } = this.props
 
     // Special case when either cols or rows were 0
     // This would prevent any cells from rendering
     // So we need to reset row scroll if cols changed from 0 (and vice versa)
     if (columnCount === 0 || rowCount === 0) {
-      columnCount = 0;
-      rowCount = 0;
+      columnCount = 0
+      rowCount = 0
     }
 
     // If scrolling is controlled outside this component, clear cache when scrolling stops
@@ -809,14 +807,14 @@ export default class Grid extends React.PureComponent {
       nextProps.isScrolling === false &&
       this.props.isScrolling === true
     ) {
-      this._resetStyleCache();
+      this._resetStyleCache()
     }
 
     // Update scroll offsets if the size or number of cells have changed, invalidating the previous value
     calculateSizeAndPositionDataAndUpdateScrollOffset({
       cellCount: columnCount,
       cellSize:
-        typeof this.props.columnWidth === "number"
+        typeof this.props.columnWidth === 'number'
           ? this.props.columnWidth
           : null,
       computeMetadataCallback: () =>
@@ -824,33 +822,33 @@ export default class Grid extends React.PureComponent {
       computeMetadataCallbackProps: nextProps,
       nextCellsCount: nextProps.columnCount,
       nextCellSize:
-        typeof nextProps.columnWidth === "number"
+        typeof nextProps.columnWidth === 'number'
           ? nextProps.columnWidth
           : null,
       nextScrollToIndex: nextProps.scrollToColumn,
       scrollToIndex: this.props.scrollToColumn,
       updateScrollOffsetForScrollToIndex: () =>
-        this._updateScrollLeftForScrollToColumn(nextProps, this.state)
-    });
+        this._updateScrollLeftForScrollToColumn(nextProps, this.state),
+    })
     calculateSizeAndPositionDataAndUpdateScrollOffset({
       cellCount: rowCount,
       cellSize:
-        typeof this.props.rowHeight === "number" ? this.props.rowHeight : null,
+        typeof this.props.rowHeight === 'number' ? this.props.rowHeight : null,
       computeMetadataCallback: () =>
         this._rowSizeAndPositionManager.resetCell(0),
       computeMetadataCallbackProps: nextProps,
       nextCellsCount: nextProps.rowCount,
       nextCellSize:
-        typeof nextProps.rowHeight === "number" ? nextProps.rowHeight : null,
+        typeof nextProps.rowHeight === 'number' ? nextProps.rowHeight : null,
       nextScrollToIndex: nextProps.scrollToRow,
       scrollToIndex: this.props.scrollToRow,
       updateScrollOffsetForScrollToIndex: () =>
-        this._updateScrollTopForScrollToRow(nextProps, this.state)
-    });
+        this._updateScrollTopForScrollToRow(nextProps, this.state),
+    })
   }
 
   componentWillUpdate(nextProps: Props, nextState: State) {
-    this._calculateChildrenToRender(nextProps, nextState);
+    this._calculateChildrenToRender(nextProps, nextState)
   }
 
   render() {
@@ -868,39 +866,39 @@ export default class Grid extends React.PureComponent {
       role,
       style,
       tabIndex,
-      width
-    } = this.props;
+      width,
+    } = this.props
 
-    const isScrolling = this._isScrolling();
+    const isScrolling = this._isScrolling()
 
     const gridStyle: Object = {
-      boxSizing: "border-box",
-      direction: "ltr",
-      height: autoHeight ? "auto" : height,
-      position: "relative",
-      width: autoWidth ? "auto" : width,
-      WebkitOverflowScrolling: "touch",
-      willChange: "transform"
-    };
+      boxSizing: 'border-box',
+      direction: 'ltr',
+      height: autoHeight ? 'auto' : height,
+      position: 'relative',
+      width: autoWidth ? 'auto' : width,
+      WebkitOverflowScrolling: 'touch',
+      willChange: 'transform',
+    }
 
-    const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize();
-    const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize();
+    const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
+    const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize()
 
     // Force browser to hide scrollbars when we know they aren't necessary.
     // Otherwise once scrollbars appear they may not disappear again.
     // For more info see issue #116
     const verticalScrollBarSize =
-      totalRowsHeight > height ? this._scrollbarSize : 0;
+      totalRowsHeight > height ? this._scrollbarSize : 0
     const horizontalScrollBarSize =
-      totalColumnsWidth > width ? this._scrollbarSize : 0;
+      totalColumnsWidth > width ? this._scrollbarSize : 0
 
     if (
       horizontalScrollBarSize !== this._horizontalScrollBarSize ||
       verticalScrollBarSize !== this._verticalScrollBarSize
     ) {
-      this._horizontalScrollBarSize = horizontalScrollBarSize;
-      this._verticalScrollBarSize = verticalScrollBarSize;
-      this._scrollbarPresenceChanged = true;
+      this._horizontalScrollBarSize = horizontalScrollBarSize
+      this._verticalScrollBarSize = verticalScrollBarSize
+      this._scrollbarPresenceChanged = true
     }
 
     // Also explicitly init styles to 'auto' if scrollbars are required.
@@ -909,28 +907,28 @@ export default class Grid extends React.PureComponent {
     // Without this style, Grid would render the correct range of cells but would NOT update its internal offset.
     // This was originally reported via clauderic/react-infinite-calendar/issues/23
     gridStyle.overflowX =
-      totalColumnsWidth + verticalScrollBarSize <= width ? "hidden" : "auto";
+      totalColumnsWidth + verticalScrollBarSize <= width ? 'hidden' : 'auto'
     gridStyle.overflowY =
-      totalRowsHeight + horizontalScrollBarSize <= height ? "hidden" : "auto";
+      totalRowsHeight + horizontalScrollBarSize <= height ? 'hidden' : 'auto'
 
-    const childrenToDisplay = this._childrenToDisplay;
+    const childrenToDisplay = this._childrenToDisplay
 
     const showNoContentRenderer =
-      childrenToDisplay.length === 0 && height > 0 && width > 0;
+      childrenToDisplay.length === 0 && height > 0 && width > 0
 
     return (
       <div
         ref={this._setScrollingContainerRef}
         {...containerProps}
-        aria-label={this.props["aria-label"]}
-        aria-readonly={this.props["aria-readonly"]}
-        className={cn("ReactVirtualized__Grid", className)}
+        aria-label={this.props['aria-label']}
+        aria-readonly={this.props['aria-readonly']}
+        className={cn('ReactVirtualized__Grid', className)}
         id={id}
         onScroll={this._onScroll}
         role={role}
         style={{
           ...gridStyle,
-          ...style
+          ...style,
         }}
         tabIndex={tabIndex}
       >
@@ -939,21 +937,21 @@ export default class Grid extends React.PureComponent {
             className="ReactVirtualized__Grid__innerScrollContainer"
             role={containerRole}
             style={{
-              width: autoContainerWidth ? "auto" : totalColumnsWidth,
+              width: autoContainerWidth ? 'auto' : totalColumnsWidth,
               height: totalRowsHeight,
               maxWidth: totalColumnsWidth,
               maxHeight: totalRowsHeight,
-              overflow: "hidden",
-              pointerEvents: isScrolling ? "none" : "",
-              position: "relative",
-              ...containerStyle
+              overflow: 'hidden',
+              pointerEvents: isScrolling ? 'none' : '',
+              position: 'relative',
+              ...containerStyle,
             }}
           >
             {childrenToDisplay}
           </div>}
         {showNoContentRenderer && noContentRenderer()}
       </div>
-    );
+    )
   }
 
   /* ---------------------------- Helper methods ---------------------------- */
@@ -972,90 +970,90 @@ export default class Grid extends React.PureComponent {
       overscanIndicesGetter,
       overscanRowCount,
       rowCount,
-      width
-    } = props;
+      width,
+    } = props
 
     const {
       scrollDirectionHorizontal,
       scrollDirectionVertical,
       scrollLeft,
-      scrollTop
-    } = state;
+      scrollTop,
+    } = state
 
-    const isScrolling = this._isScrolling(props, state);
+    const isScrolling = this._isScrolling(props, state)
 
-    this._childrenToDisplay = [];
+    this._childrenToDisplay = []
 
     // Render only enough columns and rows to cover the visible area of the grid.
     if (height > 0 && width > 0) {
       const visibleColumnIndices = this._columnSizeAndPositionManager.getVisibleCellRange(
         {
           containerSize: width,
-          offset: scrollLeft
+          offset: scrollLeft,
         }
-      );
+      )
       const visibleRowIndices = this._rowSizeAndPositionManager.getVisibleCellRange(
         {
           containerSize: height,
-          offset: scrollTop
+          offset: scrollTop,
         }
-      );
+      )
 
       const horizontalOffsetAdjustment = this._columnSizeAndPositionManager.getOffsetAdjustment(
         {
           containerSize: width,
-          offset: scrollLeft
+          offset: scrollLeft,
         }
-      );
+      )
       const verticalOffsetAdjustment = this._rowSizeAndPositionManager.getOffsetAdjustment(
         {
           containerSize: height,
-          offset: scrollTop
+          offset: scrollTop,
         }
-      );
+      )
 
       // Store for _invokeOnGridRenderedHelper()
-      this._renderedColumnStartIndex = visibleColumnIndices.start;
-      this._renderedColumnStopIndex = visibleColumnIndices.stop;
-      this._renderedRowStartIndex = visibleRowIndices.start;
-      this._renderedRowStopIndex = visibleRowIndices.stop;
+      this._renderedColumnStartIndex = visibleColumnIndices.start
+      this._renderedColumnStopIndex = visibleColumnIndices.stop
+      this._renderedRowStartIndex = visibleRowIndices.start
+      this._renderedRowStopIndex = visibleRowIndices.stop
 
       const overscanColumnIndices = overscanIndicesGetter({
-        direction: "horizontal",
+        direction: 'horizontal',
         cellCount: columnCount,
         overscanCellsCount: overscanColumnCount,
         scrollDirection: scrollDirectionHorizontal,
         startIndex:
-          typeof this._renderedColumnStartIndex === "number"
+          typeof this._renderedColumnStartIndex === 'number'
             ? this._renderedColumnStartIndex
             : 0,
         stopIndex:
-          typeof this._renderedColumnStopIndex === "number"
+          typeof this._renderedColumnStopIndex === 'number'
             ? this._renderedColumnStopIndex
-            : -1
-      });
+            : -1,
+      })
 
       const overscanRowIndices = overscanIndicesGetter({
-        direction: "vertical",
+        direction: 'vertical',
         cellCount: rowCount,
         overscanCellsCount: overscanRowCount,
         scrollDirection: scrollDirectionVertical,
         startIndex:
-          typeof this._renderedRowStartIndex === "number"
+          typeof this._renderedRowStartIndex === 'number'
             ? this._renderedRowStartIndex
             : 0,
         stopIndex:
-          typeof this._renderedRowStopIndex === "number"
+          typeof this._renderedRowStopIndex === 'number'
             ? this._renderedRowStopIndex
-            : -1
+            : -1,
         // stopIndex: this._renderedRowStopIndex
-      });
+      })
 
       // Store for _invokeOnGridRenderedHelper()
-      this._columnStartIndex = overscanColumnIndices.overscanStartIndex;
-      this._columnStopIndex = overscanColumnIndices.overscanStopIndex;
-      this._rowStartIndex = overscanRowIndices.overscanStartIndex;
-      this._rowStopIndex = overscanRowIndices.overscanStopIndex;
+      this._columnStartIndex = overscanColumnIndices.overscanStartIndex
+      this._columnStopIndex = overscanColumnIndices.overscanStopIndex
+      this._rowStartIndex = overscanRowIndices.overscanStartIndex
+      this._rowStopIndex = overscanRowIndices.overscanStopIndex
 
       this._childrenToDisplay = cellRangeRenderer({
         cellCache: this._cellCache,
@@ -1075,8 +1073,8 @@ export default class Grid extends React.PureComponent {
         styleCache: this._styleCache,
         verticalOffsetAdjustment,
         visibleColumnIndices,
-        visibleRowIndices
-      });
+        visibleRowIndices,
+      })
     }
   }
 
@@ -1086,33 +1084,33 @@ export default class Grid extends React.PureComponent {
    * This prevents jerky/stuttery mouse-wheel scrolling.
    */
   _debounceScrollEnded() {
-    const { scrollingResetTimeInterval } = this.props;
+    const { scrollingResetTimeInterval } = this.props
 
     if (this._disablePointerEventsTimeoutId) {
-      cancelAnimationTimeout(this._disablePointerEventsTimeoutId);
+      cancelAnimationTimeout(this._disablePointerEventsTimeoutId)
     }
 
     this._disablePointerEventsTimeoutId = requestAnimationTimeout(
       this._debounceScrollEndedCallback,
       scrollingResetTimeInterval
-    );
+    )
   }
 
   _debounceScrollEndedCallback = () => {
-    this._disablePointerEventsTimeoutId = null;
-    this._resetStyleCache();
-  };
+    this._disablePointerEventsTimeoutId = null
+    this._resetStyleCache()
+  }
 
   _getEstimatedColumnSize(props: Props) {
-    return typeof props.columnWidth === "number"
+    return typeof props.columnWidth === 'number'
       ? props.columnWidth
-      : props.estimatedColumnSize;
+      : props.estimatedColumnSize
   }
 
   _getEstimatedRowSize(props: Props) {
-    return typeof props.rowHeight === "number"
+    return typeof props.rowHeight === 'number'
       ? props.rowHeight
-      : props.estimatedRowSize;
+      : props.estimatedRowSize
   }
 
   /**
@@ -1121,21 +1119,21 @@ export default class Grid extends React.PureComponent {
    */
   _handleInvalidatedGridSize() {
     if (
-      typeof this._deferredInvalidateColumnIndex === "number" &&
-      typeof this._deferredInvalidateRowIndex === "number"
+      typeof this._deferredInvalidateColumnIndex === 'number' &&
+      typeof this._deferredInvalidateRowIndex === 'number'
     ) {
-      const columnIndex = this._deferredInvalidateColumnIndex;
-      const rowIndex = this._deferredInvalidateRowIndex;
+      const columnIndex = this._deferredInvalidateColumnIndex
+      const rowIndex = this._deferredInvalidateRowIndex
 
-      this._deferredInvalidateColumnIndex = null;
-      this._deferredInvalidateRowIndex = null;
+      this._deferredInvalidateColumnIndex = null
+      this._deferredInvalidateRowIndex = null
 
-      this.recomputeGridSize({ columnIndex, rowIndex });
+      this.recomputeGridSize({ columnIndex, rowIndex })
     }
   }
 
   _invokeOnGridRenderedHelper = () => {
-    const { onSectionRendered } = this.props;
+    const { onSectionRendered } = this.props
 
     this._onGridRenderedMemoizer({
       callback: onSectionRendered,
@@ -1147,25 +1145,25 @@ export default class Grid extends React.PureComponent {
         rowOverscanStartIndex: this._rowStartIndex,
         rowOverscanStopIndex: this._rowStopIndex,
         rowStartIndex: this._renderedRowStartIndex,
-        rowStopIndex: this._renderedRowStopIndex
-      }
-    });
-  };
+        rowStopIndex: this._renderedRowStopIndex,
+      },
+    })
+  }
 
   _invokeOnScrollMemoizer({
     scrollLeft,
     scrollTop,
     totalColumnsWidth,
-    totalRowsHeight
+    totalRowsHeight,
   }: {
     scrollLeft: number,
     scrollTop: number,
     totalColumnsWidth: number,
-    totalRowsHeight: number
+    totalRowsHeight: number,
   }) {
     this._onScrollMemoizer({
       callback: ({ scrollLeft, scrollTop }) => {
-        const { height, onScroll, width } = this.props;
+        const { height, onScroll, width } = this.props
 
         onScroll({
           clientHeight: height,
@@ -1173,41 +1171,41 @@ export default class Grid extends React.PureComponent {
           scrollHeight: totalRowsHeight,
           scrollLeft,
           scrollTop,
-          scrollWidth: totalColumnsWidth
-        });
+          scrollWidth: totalColumnsWidth,
+        })
       },
       indices: {
         scrollLeft,
-        scrollTop
-      }
-    });
+        scrollTop,
+      },
+    })
   }
 
   _isScrolling(props: Props = this.props, state: State = this.state): boolean {
     // If isScrolling is defined in props, use it to override the value in state
     // This is a performance optimization for WindowScroller + Grid
-    return Object.hasOwnProperty.call(props, "isScrolling")
+    return Object.hasOwnProperty.call(props, 'isScrolling')
       ? Boolean(props.isScrolling)
-      : Boolean(state.isScrolling);
+      : Boolean(state.isScrolling)
   }
 
   _maybeCallOnScrollbarPresenceChange() {
     if (this._scrollbarPresenceChanged) {
-      const { onScrollbarPresenceChange } = this.props;
+      const { onScrollbarPresenceChange } = this.props
 
-      this._scrollbarPresenceChanged = false;
+      this._scrollbarPresenceChanged = false
 
       onScrollbarPresenceChange({
         horizontal: this._horizontalScrollBarSize > 0,
         size: this._scrollbarSize,
-        vertical: this._verticalScrollBarSize > 0
-      });
+        vertical: this._verticalScrollBarSize > 0,
+      })
     }
   }
 
   _setScrollingContainerRef = (ref: Element) => {
-    this._scrollingContainer = ref;
-  };
+    this._scrollingContainer = ref
+  }
 
   /**
    * Scroll to the specified offset(s).
@@ -1215,39 +1213,39 @@ export default class Grid extends React.PureComponent {
    */
   scrollToPosition({ scrollLeft, scrollTop }: ScrollPosition) {
     const newState: Object = {
-      scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.REQUESTED
-    };
+      scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.REQUESTED,
+    }
 
-    if (typeof scrollLeft === "number" && scrollLeft >= 0) {
+    if (typeof scrollLeft === 'number' && scrollLeft >= 0) {
       newState.scrollDirectionHorizontal =
         scrollLeft > this.state.scrollLeft
           ? SCROLL_DIRECTION_FORWARD
-          : SCROLL_DIRECTION_BACKWARD;
-      newState.scrollLeft = scrollLeft;
+          : SCROLL_DIRECTION_BACKWARD
+      newState.scrollLeft = scrollLeft
     }
 
-    if (typeof scrollTop === "number" && scrollTop >= 0) {
+    if (typeof scrollTop === 'number' && scrollTop >= 0) {
       newState.scrollDirectionVertical =
         scrollTop > this.state.scrollTop
           ? SCROLL_DIRECTION_FORWARD
-          : SCROLL_DIRECTION_BACKWARD;
-      newState.scrollTop = scrollTop;
+          : SCROLL_DIRECTION_BACKWARD
+      newState.scrollTop = scrollTop
     }
 
     if (
-      (typeof scrollLeft === "number" &&
+      (typeof scrollLeft === 'number' &&
         scrollLeft >= 0 &&
         scrollLeft !== this.state.scrollLeft) ||
-      (typeof scrollTop === "number" &&
+      (typeof scrollTop === 'number' &&
         scrollTop >= 0 &&
         scrollTop !== this.state.scrollTop)
     ) {
-      this.setState(newState);
+      this.setState(newState)
     }
   }
 
   _wrapSizeGetter(value: CellSize): CellSizeGetter {
-    return typeof value === "function" ? value : () => (value: any);
+    return typeof value === 'function' ? value : () => (value: any)
   }
 
   _getCalculatedScrollLeft(
@@ -1259,25 +1257,23 @@ export default class Grid extends React.PureComponent {
       height,
       scrollToAlignment,
       scrollToColumn,
-      width
-    } = props;
-    const { scrollLeft } = state;
+      width,
+    } = props
+    const { scrollLeft } = state
 
     if (columnCount > 0) {
-      const finalColumn = columnCount - 1;
+      const finalColumn = columnCount - 1
       const targetIndex =
-        scrollToColumn < 0
-          ? finalColumn
-          : Math.min(finalColumn, scrollToColumn);
-      const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize();
-      const scrollBarSize = totalRowsHeight > height ? this._scrollbarSize : 0;
+        scrollToColumn < 0 ? finalColumn : Math.min(finalColumn, scrollToColumn)
+      const totalRowsHeight = this._rowSizeAndPositionManager.getTotalSize()
+      const scrollBarSize = totalRowsHeight > height ? this._scrollbarSize : 0
 
       return this._columnSizeAndPositionManager.getUpdatedOffsetForIndex({
         align: scrollToAlignment,
         containerSize: width - scrollBarSize,
         currentOffset: scrollLeft,
-        targetIndex
-      });
+        targetIndex,
+      })
     }
   }
 
@@ -1285,18 +1281,18 @@ export default class Grid extends React.PureComponent {
     props: Props = this.props,
     state: State = this.state
   ) {
-    const { scrollLeft } = state;
-    const calculatedScrollLeft = this._getCalculatedScrollLeft(props, state);
+    const { scrollLeft } = state
+    const calculatedScrollLeft = this._getCalculatedScrollLeft(props, state)
 
     if (
-      typeof calculatedScrollLeft === "number" &&
+      typeof calculatedScrollLeft === 'number' &&
       calculatedScrollLeft >= 0 &&
       scrollLeft !== calculatedScrollLeft
     ) {
       this.scrollToPosition({
         scrollLeft: calculatedScrollLeft,
-        scrollTop: -1
-      });
+        scrollTop: -1,
+      })
     }
   }
 
@@ -1304,34 +1300,34 @@ export default class Grid extends React.PureComponent {
     props: Props = this.props,
     state: State = this.state
   ) {
-    const { height, rowCount, scrollToAlignment, scrollToRow, width } = props;
-    const { scrollTop } = state;
+    const { height, rowCount, scrollToAlignment, scrollToRow, width } = props
+    const { scrollTop } = state
 
     if (rowCount > 0) {
-      const finalRow = rowCount - 1;
+      const finalRow = rowCount - 1
       const targetIndex =
-        scrollToRow < 0 ? finalRow : Math.min(finalRow, scrollToRow);
-      const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize();
-      const scrollBarSize = totalColumnsWidth > width ? this._scrollbarSize : 0;
+        scrollToRow < 0 ? finalRow : Math.min(finalRow, scrollToRow)
+      const totalColumnsWidth = this._columnSizeAndPositionManager.getTotalSize()
+      const scrollBarSize = totalColumnsWidth > width ? this._scrollbarSize : 0
 
       return this._rowSizeAndPositionManager.getUpdatedOffsetForIndex({
         align: scrollToAlignment,
         containerSize: height - scrollBarSize,
         currentOffset: scrollTop,
-        targetIndex
-      });
+        targetIndex,
+      })
     }
   }
 
   _resetStyleCache() {
-    const styleCache = this._styleCache;
+    const styleCache = this._styleCache
 
     // Reset cell and style caches once scrolling stops.
     // This makes Grid simpler to use (since cells commonly change).
     // And it keeps the caches from growing too large.
     // Performance is most sensitive when a user is scrolling.
-    this._cellCache = {};
-    this._styleCache = {};
+    this._cellCache = {}
+    this._styleCache = {}
 
     // Copy over the visible cell styles so avoid unnecessary re-render.
     for (
@@ -1344,32 +1340,32 @@ export default class Grid extends React.PureComponent {
         columnIndex <= this._columnStopIndex;
         columnIndex++
       ) {
-        let key = `${rowIndex}-${columnIndex}`;
-        this._styleCache[key] = styleCache[key];
+        let key = `${rowIndex}-${columnIndex}`
+        this._styleCache[key] = styleCache[key]
       }
     }
 
     this.setState({
-      isScrolling: false
-    });
+      isScrolling: false,
+    })
   }
 
   _updateScrollTopForScrollToRow(
     props: Props = this.props,
     state: State = this.state
   ) {
-    const { scrollTop } = state;
-    const calculatedScrollTop = this._getCalculatedScrollTop(props, state);
+    const { scrollTop } = state
+    const calculatedScrollTop = this._getCalculatedScrollTop(props, state)
 
     if (
-      typeof calculatedScrollTop === "number" &&
+      typeof calculatedScrollTop === 'number' &&
       calculatedScrollTop >= 0 &&
       scrollTop !== calculatedScrollTop
     ) {
       this.scrollToPosition({
         scrollLeft: -1,
-        scrollTop: calculatedScrollTop
-      });
+        scrollTop: calculatedScrollTop,
+      })
     }
   }
 
@@ -1378,7 +1374,7 @@ export default class Grid extends React.PureComponent {
     // This invalid event can be detected by comparing event.target to this component's scrollable DOM element.
     // See issue #404 for more information.
     if (event.target === this._scrollingContainer) {
-      this.handleScrollEvent((event.target: any));
+      this.handleScrollEvent((event.target: any))
     }
-  };
+  }
 }

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -208,7 +208,7 @@ type Props = {
   style: Object,
 
   /** Tab index for focus */
-  tabIndex: number,
+  tabIndex: number | null,
 
   /** Width of Grid; this property determines the number of visible (vs virtualized) columns.  */
   width: number


### PR DESCRIPTION
Fixes: https://github.com/bvaughn/react-virtualized/issues/815

Since `MultiGrid` sends `null` for `tabIndex`, this just adds it as a possible value in the flow props, which get compiled into `propTypes` for distribution.

Note: Reverted my previous update since it seems we just don't want focus on those grids at all.