### PR TITLE
Adding in the defaultSortOrder for the column. Currently only SortDirection.ASC is the uneditable default.

### DIFF
--- a/docs/Column.md
+++ b/docs/Column.md
@@ -11,6 +11,7 @@ Describes the header and cell contents of a table column.
 | className | String |  | CSS class to apply to rendered cell container |
 | columnData | Object |  | Additional data passed to this column's `cellDataGetter`. Use this object to relay action-creators or relational data. |
 | dataKey | any | ✓ | Uniquely identifies the row-data attribute corresponding to this cell (eg this might be "name" in an array of user objects). |
+| defaultSortOrder| [SortDirection](SortDirection.md) |  | Default sort order when clicked for the first time. Defaults to Asc |
 | disableSort | Boolean |  | If sort is enabled for the table at large, disable it for this column |
 | flexGrow | Number |  | Flex grow style; defaults to 0 |
 | flexShrink | Number |  | Flex shrink style; defaults to 1 |

--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -4,6 +4,7 @@ import { Component } from "react";
 import defaultHeaderRenderer from "./defaultHeaderRenderer";
 import defaultCellRenderer from "./defaultCellRenderer";
 import defaultCellDataGetter from "./defaultCellDataGetter";
+import SortDirection from "./SortDirection";
 
 /**
  * Describes the header and cell contents of a table column.
@@ -33,6 +34,9 @@ export default class Column extends Component {
 
     /** Uniquely identifies the row-data attribute corresponding to this cell */
     dataKey: PropTypes.any.isRequired,
+
+    /** Optional direction to be used when clicked the first time */
+    defaultSortDirection: PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC]),
 
     /** If sort is enabled for the table at large, disable it for this column */
     disableSort: PropTypes.bool,

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -48,6 +48,7 @@ describe("Table", () => {
       headerRenderer,
       maxWidth,
       minWidth,
+      defaultSortOrder,
       ...flexTableProps
     } = {}
   ) {
@@ -72,6 +73,7 @@ describe("Table", () => {
           cellDataGetter={cellDataGetter}
           headerRenderer={headerRenderer}
           disableSort={disableSort}
+          defaultSortOrder={defaultSortOrder}
           style={columnStyle}
           id={columnID}
         />
@@ -560,6 +562,32 @@ describe("Table", () => {
       expect(sortCalls.length).toEqual(2);
       Simulate.keyDown(nameColumn, { key: "F" });
       expect(sortCalls.length).toEqual(2);
+    });
+
+    it("should honor the default sort order on first click of the column", () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              sort: ({ sortBy, sortDirection }) =>
+                sortCalls.push({ sortBy, sortDirection }),
+              defaultSortOrder: sortDirection
+            })
+          )
+        );
+        const nameColumn = rendered.querySelector(
+          ".ReactVirtualized__Table__headerColumn:first-of-type"
+        );
+
+        Simulate.click(nameColumn);
+        expect(sortCalls.length).toEqual(1);
+
+        const { sortBy, sortDirection: newSortDirection } = sortCalls[0];
+        expect(sortBy).toEqual("name");
+        expect(newSortDirection).toEqual(sortDirection);
+      });
     });
   });
 

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -489,7 +489,8 @@ export default class Table extends PureComponent {
       headerRenderer,
       id,
       label,
-      columnData
+      columnData,
+      defaultSortOrder
     } = column.props;
     const sortEnabled = !disableSort && sort;
 
@@ -518,10 +519,13 @@ export default class Table extends PureComponent {
 
     if (sortEnabled || onHeaderClick) {
       // If this is a sortable header, clicking it should update the table data's sorting.
-      const newSortDirection =
-        sortBy !== dataKey || sortDirection === SortDirection.DESC
-          ? SortDirection.ASC
-          : SortDirection.DESC;
+      const isFirstTimeSort = sortBy !== dataKey;
+
+      // If this is the firstTime sort of this column, use the column default sort order OR the default, asc.
+      // Otherwise, invert the direction of the sort.
+      const newSortDirection = (isFirstTimeSort ?
+      				(defaultSortOrder || SortDirection.ASC) :
+      				(sortDirection === SortDirection.DESC ? SortDirection.ASC : SortDirection.DESC))
 
       const onClick = event => {
         sortEnabled &&


### PR DESCRIPTION
**Motivation**
Currently, when a user selects a column to sort, the default direction is hard coded to `SortDirection.ASC`. It would be great to have this as a configurable option so that each column can have their own default sorting direction.

**Implementation** 
I added a prop to the `Column` object and updated the `_createHeader` function to use the column's information to handle the sorting click.

Side Note: I added a test to ensure that it works and also added the new prop to the docs also.

Let me know what you think and thanks for the awesome library!