### PR TITLE
Updating CONTRIBUTING.md: Project uses Slack instead of Gitter now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ In return, they should reciprocate that respect in addressing your issue or asse
 
 The issue tracker is the preferred channel for bug reports but please respect the following restrictions:
 
-* Please **do not** use the issue tracker for personal support requests (use [Gitter](https://gitter.im/bvaughn/react-virtualized)).
+* Please **do not** use the issue tracker for personal support requests (use [Slack](http://slack.reactvirtualized.com)).
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
 <a name="bugs"></a>


### PR DESCRIPTION
I was reading the contributing guidelines, tried to connect via Gitter - but it seems that the project has moved to Slack - this update reflects that change.