### PR TITLE
Make tabIndex maybe number

### DIFF
--- a/source/List/List.js
+++ b/source/List/List.js
@@ -90,7 +90,7 @@ type Props = {
   style: Object,
 
   /** Tab index for focus */
-  tabIndex?: number,
+  tabIndex?: ?number,
 
   /** Width of list */
   width: number,


### PR DESCRIPTION
Currently grid can take `null` as tabIndex, but using list forces to set tabIndex as non-null.

