### PR TITLE
Introduce Column headerStyle

### DIFF
--- a/docs/Column.md
+++ b/docs/Column.md
@@ -17,6 +17,7 @@ Describes the header and cell contents of a table column.
 | flexShrink | Number |  | Flex shrink style; defaults to 1 |
 | headerClassName | String |  | CSS class to apply to this column's header |
 | headerRenderer | Function |  | Optional callback responsible for rendering a column's header column. [Learn more](#headerrenderer) |
+| headerStyle | Object |  | Optional inline style to apply to this column's header |
 | id | String |  | Optional id to set on the column header; used for [`aria-describedby`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby) |
 | label | Node |  | Header label for this column |
 | maxWidth | Number |  | Maximum width of column; this property will only be used if :flexGrow is greater than 0 |

--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -59,6 +59,9 @@ export default class Column extends Component {
      */
     headerRenderer: PropTypes.func.isRequired,
 
+    /** Optional inline style to apply to this column's header */
+    headerStyle: PropTypes.object,
+
     /** Optional id to set on the column header */
     id: PropTypes.string,
 

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -44,6 +44,7 @@ describe('Table', () => {
       columnData = {data: 123},
       columnID,
       columnStyle,
+      columnHeaderStyle,
       disableSort = false,
       headerRenderer,
       maxWidth,
@@ -74,6 +75,7 @@ describe('Table', () => {
           disableSort={disableSort}
           defaultSortDirection={defaultSortDirection}
           style={columnStyle}
+          headerStyle={columnHeaderStyle}
           id={columnID}
         />
         <Column
@@ -1048,6 +1050,7 @@ describe('Table', () => {
     it('should use custom :styles if specified', () => {
       const columnStyle = {backgroundColor: 'red'};
       const headerStyle = {backgroundColor: 'blue'};
+      const columnHeaderStyle = {color: 'yellow'};
       const rowStyle = {backgroundColor: 'green'};
       const style = {backgroundColor: 'orange'};
       const node = findDOMNode(
@@ -1055,6 +1058,7 @@ describe('Table', () => {
           getMarkup({
             columnStyle,
             headerStyle,
+            columnHeaderStyle,
             rowStyle,
             style,
           }),
@@ -1068,6 +1072,10 @@ describe('Table', () => {
         node.querySelector('.ReactVirtualized__Table__headerColumn').style
           .backgroundColor,
       ).toEqual('blue');
+      expect(
+        node.querySelector('.ReactVirtualized__Table__headerColumn').style
+          .color,
+      ).toEqual('yellow');
       expect(
         node.querySelector('.ReactVirtualized__Table__row').style
           .backgroundColor,

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -493,7 +493,10 @@ export default class Table extends PureComponent {
         ReactVirtualized__Table__sortableHeaderColumn: sortEnabled,
       },
     );
-    const style = this._getFlexStyleForColumn(column, headerStyle);
+    const style = this._getFlexStyleForColumn(column, {
+      ...headerStyle,
+      ...column.props.headerStyle,
+    });
 
     const renderedHeader = headerRenderer({
       columnData,


### PR DESCRIPTION
Hello this is my first contribution in this repo! 🎉 

I miss the ability to provide extra styles for each column header.
Currently it is possible to provide only extra className for each column header.

I need this for adding IE support for react-virtualized where I pass the width for every column and its header as fallback solution for flex-box.

I am open to submit a PR with IE support for Table if you wish later.
