### PR TITLE
reverse using fixed option of cellMeasureCache

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -2328,6 +2328,62 @@ describe('Grid', () => {
     expect(keys).toEqual(['0-0', '1-1']);
   });
 
+  describe('getVisibleCellRange', () => {
+    it('should return all cell-range of row when a :deferredMeasurementCache is provided without fixedHeight', () => {
+      const cache = new CellMeasurerCache({
+        fixedWidth: true,
+      });
+      const grid = render(
+        getMarkup({
+          deferredMeasurementCache: cache,
+        }),
+      );
+
+      expect(grid._columnSizeAndPositionManager.batchAllCells).not.toBe(true);
+      const columnRange = grid._columnSizeAndPositionManager.getVisibleCellRange({
+        containerSize: DEFAULT_WIDTH,
+        offset: 500,
+      });
+      expect(columnRange.start).not.toEqual(0);
+      expect(columnRange.stop).not.toEqual(NUM_COLUMNS - 1);
+
+      expect(grid._rowSizeAndPositionManager.batchAllCells).not.toBe(false);
+      const rowRange = grid._rowSizeAndPositionManager.getVisibleCellRange({
+        containerSize: DEFAULT_HEIGHT,
+        offset: 1000,
+      });
+      expect(rowRange.start).toEqual(0);
+      expect(rowRange.stop).toEqual(NUM_ROWS - 1);
+    });
+
+    it('should return all cell-range of column when a :deferredMeasurementCache is provided without fixedWidth', () => {
+      const cache = new CellMeasurerCache({
+        fixedHeight: true,
+      });
+      const grid = render(
+        getMarkup({
+          deferredMeasurementCache: cache,
+        }),
+      );
+
+      expect(grid._columnSizeAndPositionManager.batchAllCells).not.toBe(false);
+      const columnRange = grid._columnSizeAndPositionManager.getVisibleCellRange({
+        containerSize: DEFAULT_WIDTH,
+        offset: 500,
+      });
+      expect(columnRange.start).toEqual(0);
+      expect(columnRange.stop).toEqual(NUM_COLUMNS - 1);
+
+      expect(grid._rowSizeAndPositionManager.batchAllCells).not.toBe(true);
+      const rowRange = grid._rowSizeAndPositionManager.getVisibleCellRange({
+        containerSize: DEFAULT_HEIGHT,
+        offset: 1000,
+      });
+      expect(rowRange.start).not.toEqual(0);
+      expect(rowRange.stop).not.toEqual(NUM_ROWS - 1);
+    });
+  });
+
   describe('DEV warnings', () => {
     it('should warn about cells that forget to include the :style property', () => {
       spyOn(console, 'warn');

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -318,7 +318,7 @@ export default class Grid extends React.PureComponent {
     this._columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       batchAllCells:
         deferredMeasurementCache !== undefined &&
-        !deferredMeasurementCache.hasFixedHeight(),
+        !deferredMeasurementCache.hasFixedWidth(),
       cellCount: props.columnCount,
       cellSizeGetter: params => this._columnWidthGetter(params),
       estimatedCellSize: this._getEstimatedColumnSize(props),
@@ -326,7 +326,7 @@ export default class Grid extends React.PureComponent {
     this._rowSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       batchAllCells:
         deferredMeasurementCache !== undefined &&
-        !deferredMeasurementCache.hasFixedWidth(),
+        !deferredMeasurementCache.hasFixedHeight(),
       cellCount: props.rowCount,
       cellSizeGetter: params => this._rowHeightGetter(params),
       estimatedCellSize: this._getEstimatedRowSize(props),


### PR DESCRIPTION
I have performance issue of MultiGrid with CellMeasure.

I believe the [comment](https://github.com/bvaughn/react-virtualized/blob/656033edec3e33c89a468643ca861625fc5ade6f/source/Grid/utils/CellSizeAndPositionManager.js#L211-L213). But the grid behavior is different from my wish. 
> // eg we can't know a row's height without measuring the height of all columns within that row.

I am thinking Grid can know row's height without measuring for cellMeasureCache with fixedHeight.


I think bug is [here](https://github.com/bvaughn/react-virtualized/blob/656033edec3e33c89a468643ca861625fc5ade6f/source/Grid/Grid.js#L318-L334).
Here is [sample](https://plnkr.co/edit/rypMdjS44EzEsxp6il1D?p=preview) 

I fixed the issue by this PR.