### PR TITLE
Added missing documentation, Lists do support overscanIndicesGetter

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -16,6 +16,7 @@ That means that `List` also accepts [`Grid` props](Grid.md) in addition to the p
 | noRowsRenderer | Function |  | Callback used to render placeholder content when `rowCount` is 0 |
 | onRowsRendered | Function |  | Callback invoked with information about the slice of rows that were just rendered: `({ overscanStartIndex: number, overscanStopIndex: number, startIndex: number, stopIndex: number }): void` |
 | onScroll | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number, scrollTop: number }): void` |
+| overscanIndicesGetter | Function |  | Responsible for calculating the number of cells to overscan before and after a specified range [Learn more](Grid.md#overscanindicesgetter) |
 | overscanRowCount | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browsers/devices. See [here](overscanUsage.md) for an important note about this property. |
 | rowCount | Number | ✓ | Number of rows in list. |
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |


### PR DESCRIPTION
Hopefully the title explains all, I was looking to override the List components overscanIndicesGetter behaviour as documented by the grid, as a new user to this, it looked like it wasn't possible. After looking at the code and trying it though it worked.. So hopefully this helps people in the future!