### PR TITLE
Add back coverage reporting, update coverage denominator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           key: dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Test
-          command: yarn test
+          command: yarn run test:ci
       - store_artifacts:
           path: coverage
           prefix: coverage

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev.js",
     "test": "npm run test:jest",
     "test:jest": "jest --no-watchman --runInBand",
+    "test:ci": "jest --no-watchman --runInBand --coverage",
     "watch": "watch 'clear && npm run test -s' source",
     "watch:jest": "jest --no-watchman --watch"
   },
@@ -72,6 +73,15 @@
     ],
     "testPathDirs": [
       "./source"
+    ],
+    "coverageReporters": ["lcov"],
+    "collectCoverageFrom": [
+      "source/**/*.js",
+      "!source/vendor/**",
+      "!source/demo/**",
+      "!source/jest-setup.js",
+      "!source/TestUtils.js",
+      "!**/*.example.js"
     ],
     "testRegex": ".jest.js",
     "verbose": true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev.js",
     "test": "npm run test:jest",
     "test:jest": "jest --no-watchman --runInBand",
-    "test:ci": "jest --no-watchman --runInBand --coverage",
+    "test:ci": "jest --no-watchman --maxWorkers 2 --coverage",
     "watch": "watch 'clear && npm run test -s' source",
     "watch:jest": "jest --no-watchman --watch"
   },


### PR DESCRIPTION
## Overview

This PR adds back coverage reporting to CodeCov 

It also sets the correct denominator when computing coverage 🤓 

Update: also sets maxWorkers in Circle to 2 to parallelize a bit

### Details

It looks like coverage broke when migrating to Jest so the coverage badge is out of date and not included on PRs (last commit with coverage [here](https://codecov.io/gh/bvaughn/react-virtualized/commit/2c92cb092c60729964bc6b3d12bc394b1962e25b)). To fix, I added a new script command `test:ci` which includes coverage.

While I was there I noticed that there were at least a couple files that don't have any tests at all. That means those files were not included in the denominator when computing coverage, which would make it appear that there's better coverage than there is

#### Coverage Before
![](http://dp.hanlon.io/3i2D0y2J331a/Image%202017-11-25%20at%209.34.33%20PM.png)
#### Coverage After
Note: I'm excluding /vendor now, which is why the lines when down
![](http://dp.hanlon.io/3C3t021A0r2k/Image%202017-11-25%20at%209.33.07%20PM.png)

