### PR TITLE
add defaultHeight, defaultWidth props on WindowScroller

### DIFF
--- a/docs/WindowScroller.md
+++ b/docs/WindowScroller.md
@@ -11,6 +11,8 @@ This may change with a future release but for the time being this HOC is should 
 | Property | Type | Required? | Description |
 |:---|:---|:---:|:---|
 | children | Function | ✓ | Function responsible for rendering children. This function should implement the following signature: `({ height: number, width: number, isScrolling: boolean, scrollTop: number, onChildScroll: function }) => PropTypes.element` |
+| defaultHeight | Number |  | Height passed to child for initial render; useful for server-side rendering. This value will be overridden with an accurate height after mounting. |
+| defaultWidth | Number |  | Width passed to child for initial render; useful for server-side rendering. This value will be overridden with an accurate width after mounting. |
 | onResize | Function |  | Callback to be invoked on-resize; it is passed the following named parameters: `({ height: number, width: number })`. |
 | onScroll | Function |  | Callback to be invoked on-scroll; it is passed the following named parameters: `({ scrollTop: number, scrollLeft: number })`. |
 | scrollElement | any |  | Element to attach scroll event listeners. Defaults to `window`. |

--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -2,15 +2,16 @@
 
 import React from 'react';
 import {findDOMNode} from 'react-dom';
+import ReactDOMServer from 'react-dom/server';
 import {render} from '../TestUtils';
 import WindowScroller, {IS_SCROLLING_TIMEOUT} from './WindowScroller';
 
 class ChildComponent extends React.Component {
   render() {
-    const {scrollTop, isScrolling, height} = this.props;
+    const {scrollTop, isScrolling, height, width} = this.props;
 
     return (
-      <div>{`scrollTop:${scrollTop}, isScrolling:${isScrolling}, height:${height}`}</div>
+      <div>{`scrollTop:${scrollTop}, isScrolling:${isScrolling}, height:${height}, width:${width}`}</div>
     );
   }
 }
@@ -35,10 +36,11 @@ function mockGetBoundingClientRectForHeader({
 function getMarkup({headerElements, documentOffset, childRef, ...props} = {}) {
   const windowScroller = (
     <WindowScroller {...props}>
-      {({height, isScrolling, onChildScroll, scrollTop}) => (
+      {({width, height, isScrolling, onChildScroll, scrollTop}) => (
         <ChildComponent
           ref={childRef}
           height={height}
+          width={width}
           isScrolling={isScrolling}
           onScroll={onChildScroll}
           scrollTop={scrollTop}
@@ -438,6 +440,19 @@ describe('WindowScroller', () => {
       childComponent.props.onScroll({scrollTop: 200});
 
       expect(windowScroller.state.scrollTop).toEqual(200);
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('should render content with default widths and heights initially', () => {
+      const rendered = ReactDOMServer.renderToString(
+        getMarkup({
+          defaultHeight: 100,
+          defaultWidth: 200,
+        }),
+      );
+      expect(rendered).toContain('height:100');
+      expect(rendered).toContain('width:200');
     });
   });
 });

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -58,7 +58,7 @@ export default class WindowScroller extends PureComponent {
     super(props);
 
     const {width, height} =
-      typeof window !== "undefined"
+      typeof window !== 'undefined'
         ? getDimensions(props.scrollElement || window)
         : {
             width: props.defaultWidth || 0,

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -58,9 +58,12 @@ export default class WindowScroller extends PureComponent {
     super(props);
 
     const {width, height} =
-      props.defaultWidth || props.defaultHeight
-        ? {width: props.defaultWidth, height: props.defaultHeight}
-        : getDimensions(props.scrollElement || window);
+      typeof window !== "undefined"
+        ? getDimensions(props.scrollElement || window)
+        : {
+            width: props.defaultWidth || 0,
+            height: props.defaultHeight || 0
+          };
 
     this.state = {
       height,

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -40,6 +40,12 @@ export default class WindowScroller extends PureComponent {
      * Wait this amount of time after the last scroll event before resetting child `pointer-events`.
      */
     scrollingResetTimeInterval: PropTypes.number.isRequired,
+
+    /** Default height to use for initial render; useful for SSR */
+    defaultHeight: PropTypes.number,
+
+    /** Default width to use for initial render; useful for SSR */
+    defaultWidth: PropTypes.number,
   };
 
   static defaultProps = {
@@ -51,11 +57,10 @@ export default class WindowScroller extends PureComponent {
   constructor(props) {
     super(props);
 
-    // Handle server-side rendering case
     const {width, height} =
-      typeof window !== 'undefined'
-        ? getDimensions(props.scrollElement || window)
-        : {width: 0, height: 0};
+      props.defaultWidth || props.defaultHeight
+        ? {width: props.defaultWidth, height: props.defaultHeight}
+        : getDimensions(props.scrollElement || window);
 
     this.state = {
       height,


### PR DESCRIPTION
Fixed: #891 

When I run server-side rendering, browser prints below warning and fail initial rendering.
`Warning: Expected server HTML to contain a matching <div> in <div>`
I added defaultHeight and defaultWidth props like AutoSizer.
I checked There is no warning with the props.