### PR TITLE
Resolves #898 - Allow Table to accept children other than Column type

### DIFF
--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -95,34 +95,6 @@ describe('Table', () => {
 
   beforeEach(() => jest.resetModules());
 
-  describe('children', () => {
-    it('should accept Column children', () => {
-      const children = [<Column dataKey="foo" width={100} />];
-      const result = Table.propTypes.children({children}, 'children', 'Table');
-      expect(result instanceof Error).toEqual(false);
-    });
-
-    it('should accept subclasses of Column as children', () => {
-      class AnotherColumn extends Column {}
-
-      const children = [<AnotherColumn dataKey="foo" width={100} />];
-      const result = Table.propTypes.children({children}, 'children', 'Table');
-      expect(result instanceof Error).toEqual(false);
-    });
-
-    it('should not accept non-Column children', () => {
-      const children = [<div />];
-      const result = Table.propTypes.children({children}, 'children', 'Table');
-      expect(result instanceof Error).toEqual(true);
-    });
-
-    it('should accept falsy children to allow easier dynamic showing/hiding of columns', () => {
-      const children = [false, <Column dataKey="foo" width={100} />, null];
-      const result = Table.propTypes.children({children}, 'children', 'Table');
-      expect(result instanceof Error).toEqual(false);
-    });
-  });
-
   describe('height', () => {
     it('should subtract header row height from the inner Grid height if headers are enabled', () => {
       const rendered = findDOMNode(

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -26,16 +26,10 @@ export default class Table extends PureComponent {
      */
     autoHeight: PropTypes.bool,
 
-    /** One or more Columns describing the data displayed in this row */
-    children: props => {
-      const children = React.Children.toArray(props.children);
-      for (let i = 0; i < children.length; i++) {
-        const childType = children[i].type;
-        if (childType !== Column && !(childType.prototype instanceof Column)) {
-          return new Error('Table only accepts children of type Column');
-        }
-      }
-    },
+    /** One or more Columns describing the data displayed in this row
+     * Reason for PropTypes.any vs PropTypes.node, is to support falsy columns 
+     */
+    children: PropTypes.any,
 
     /** Optional CSS class name */
     className: PropTypes.string,


### PR DESCRIPTION
Changed the propType validation for children in Table to accept other types, not just Column.

My reasoning:

I wanted to create some custom columns for Table and I was getting an error unless I used Column or a class that extended Column.  This allows for using composition to create customized Columns.
