### PR TITLE
Allow custom WindowScroller child with childRef in children function

### DIFF
--- a/source/WindowScroller/WindowScroller.example.js
+++ b/source/WindowScroller/WindowScroller.example.js
@@ -82,35 +82,38 @@ export default class WindowScrollerExample extends PureComponent<{}, State> {
             value={scrollToIndex || ''}
           />
         </InputRow>
-        <div className={styles.WindowScrollerWrapper}>
-          <WindowScroller
-            ref={this._setRef}
-            scrollElement={isScrollingCustomElement ? customElement : window}>
-            {({height, isScrolling, onChildScroll, scrollTop}) => (
+
+        <WindowScroller
+          ref={this._setRef}
+          scrollElement={isScrollingCustomElement ? customElement : window}>
+          {({height, isScrolling, childRef, onChildScroll, scrollTop}) => (
+            <div className={styles.WindowScrollerWrapper}>
               <AutoSizer disableHeight>
                 {({width}) => (
-                  <List
-                    ref={el => {
-                      window.listEl = el;
-                    }}
-                    autoHeight
-                    className={styles.List}
-                    height={height}
-                    isScrolling={isScrolling}
-                    onScroll={onChildScroll}
-                    overscanRowCount={2}
-                    rowCount={list.size}
-                    rowHeight={30}
-                    rowRenderer={this._rowRenderer}
-                    scrollToIndex={scrollToIndex}
-                    scrollTop={scrollTop}
-                    width={width}
-                  />
+                  <div ref={childRef}>
+                    <List
+                      ref={el => {
+                        window.listEl = el;
+                      }}
+                      autoHeight
+                      className={styles.List}
+                      height={height}
+                      isScrolling={isScrolling}
+                      onScroll={onChildScroll}
+                      overscanRowCount={2}
+                      rowCount={list.size}
+                      rowHeight={30}
+                      rowRenderer={this._rowRenderer}
+                      scrollToIndex={scrollToIndex}
+                      scrollTop={scrollTop}
+                      width={width}
+                    />
+                  </div>
                 )}
               </AutoSizer>
-            )}
-          </WindowScroller>
-        </div>
+            </div>
+          )}
+        </WindowScroller>
       </ContentBox>
     );
   }

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -21,7 +21,8 @@ type Props = {
    * ({ height, isScrolling, scrollLeft, scrollTop, width }) => PropTypes.element
    */
   children: (params: {
-    onChildScroll: (params: {scrollTop: number}) => void,
+    onChildScroll: ({scrollTop: number}) => void,
+    childRef: (?Element) => void,
     height: number,
     isScrolling: boolean,
     scrollLeft: number,
@@ -36,7 +37,8 @@ type Props = {
   onScroll: (params: {scrollLeft: number, scrollTop: number}) => void,
 
   /** Element to attach scroll event listeners. Defaults to window. */
-  scrollElement: ?(typeof window | Element),
+  scrollElement: ?Element,
+
   /**
    * Wait this amount of time after the last scroll event before resetting child `pointer-events`.
    */
@@ -87,6 +89,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
   _positionFromTop = 0;
   _positionFromLeft = 0;
   _detectElementResize: DetectElementResize = createDetectElementResize();
+  _child: ?Element;
 
   state = {
     ...getDimensions(this.props.scrollElement, this.props),
@@ -102,7 +105,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
     const {onResize} = this.props;
     const {height, width} = this.state;
 
-    const thisNode = ReactDOM.findDOMNode(this);
+    const thisNode = this._child || ReactDOM.findDOMNode(this);
     if (thisNode instanceof Element && scrollElement) {
       const offset = getPositionOffset(thisNode, scrollElement);
       this._positionFromTop = offset.top;
@@ -170,6 +173,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
 
     return children({
       onChildScroll: this._onChildScroll,
+      childRef: this._childRef,
       height,
       isScrolling,
       scrollLeft,
@@ -177,6 +181,11 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
       width,
     });
   }
+
+  _childRef = element => {
+    this._child = element;
+    this.updatePosition();
+  };
 
   _onChildScroll = ({scrollTop}) => {
     if (this.state.scrollTop === scrollTop) {


### PR DESCRIPTION
`findDOMNode` is not quite flexible with complex layouts. This PR introduces childRef to improve this. Current behavior uses `findDOMNode` result until `childRef` is called
```js
<WindowScroller>
{({ childRef }) => <div ref={childRef} />}
</WindowScroller>
```
Also bit refactored WindowScroller tests with jest mocks.