### PR TITLE
Add class to AutoSizer's wrapping div.

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -122,7 +122,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
     */
 
     return (
-      <div ref={this._setRef} style={outerStyle}>
+      <div ref={this._setRef} style={outerStyle} className={'ReactVirtualized__AutoSizer'}>
         {children(childParams)}
       </div>
     );


### PR DESCRIPTION
AutoSizer is wrapped in a `div` that has inline styles, but no className. That makes targetting it in css cumbersome.

I am creating a table with lots of columns, so being able to scroll horizontally is necessary. I am using a `WindowScroller` wrapped around `<Autosizer disableHeight>`, which as of now prevents horizontal scrolling due to the wrapping div having inline style:
```
overflow: visible;
width: 0px;
```

By targetting this div, I can change it's effective style to:
```
overflow-x: auto;
width: unset;
```

This enables horizontal scrolling.