### PR TITLE
vendor/detectElementResize: fix window check for SSR

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -18,7 +18,7 @@ export default function createDetectElementResize(nonce) {
   } else if (typeof self !== 'undefined') {
     _window = self;
   } else {
-    _window = this;
+    _window = global;
   }
 
   var attachEvent = typeof document !== 'undefined' && document.attachEvent;


### PR DESCRIPTION
'this' is undefined at this point, so you will get errors like `Cannot read
property 'requestAnimationFrame' of undefined` when assigning to variable `raf`
on the server.

`global` is the analogous `window` object on the server.