### PR TITLE
Fix WindowScroller scrollElement prop types for window

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -38,7 +38,6 @@ type Props = {
 
   /** Element to attach scroll event listeners. Defaults to window. */
   scrollElement: ?(typeof window | Element),
-
   /**
    * Wait this amount of time after the last scroll event before resetting child `pointer-events`.
    */

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -37,7 +37,7 @@ type Props = {
   onScroll: ({scrollLeft: number, scrollTop: number}) => void,
 
   /** Element to attach scroll event listeners. Defaults to window. */
-  scrollElement: ?Element,
+  scrollElement: ?(typeof window | Element),
 
   /**
    * Wait this amount of time after the last scroll event before resetting child `pointer-events`.


### PR DESCRIPTION
Seems like I accidentally overrided [#939](https://github.com/bvaughn/react-virtualized/pull/939) with latter merge.