### PR TITLE
Add "react-vtree" link to "Friends" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Here are some great components built on top of react-virtualized:
 * [react-sortable-tree](https://github.com/fritz-c/react-sortable-tree): Drag-and-drop sortable representation of hierarchical data
 * [react-virtualized-checkbox](https://github.com/emilebres/react-virtualized-checkbox): Checkbox group component with virtualization for large number of options
 * [react-virtualized-select](https://github.com/bvaughn/react-virtualized-select): Drop-down menu for React with windowing to support large numbers of options.
+* [react-vtree](https://github.com/Lodin/react-vtree): Low-level tree component for React with virtualization to support large number of elements.
 
 Contributions
 ------------


### PR DESCRIPTION
This PR adds a link to an implementation of virtual tree component previously presented in #882.

I have tried to consider all notes mentioned in #882. `react-vtree` is still in alpha, but I suppose it is pretty ready for playing with. 

There is also [storybook site](https://lodin.github.io/react-vtree) to see it working. 