### PR TITLE
Multi column sort support

### DIFF
--- a/source/Table/MultiTable.js
+++ b/source/Table/MultiTable.js
@@ -1,0 +1,367 @@
+/** @flow */
+
+import type {CellPosition} from '../Grid';
+
+import cn from 'classnames';
+import Column from './Column';
+import PropTypes from 'prop-types';
+import React, {PureComponent} from 'react';
+import {findDOMNode} from 'react-dom';
+import Grid, {accessibilityOverscanIndicesGetter} from '../Grid';
+import defaultRowRenderer from './defaultRowRenderer';
+import defaultHeaderRowRenderer from './defaultHeaderRowRenderer';
+import Table from './Table';
+import SortDirection from './SortDirection';
+
+export default class MultiTable extends PureComponent {
+  static propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Removes fixed height from the scrollingContainer so that the total height
+     * of rows can stretch the window. Intended for use with WindowScroller
+     */
+    autoHeight: PropTypes.bool,
+
+    /** One or more Columns describing the data displayed in this row */
+    children: props => {
+      const children = React.Children.toArray(props.children);
+      for (let i = 0; i < children.length; i++) {
+        const childType = children[i].type;
+        if (childType !== Column && !(childType.prototype instanceof Column)) {
+          return new Error('Table only accepts children of type Column');
+        }
+      }
+    },
+
+    /** Optional CSS class name */
+    className: PropTypes.string,
+
+    /** Disable rendering the header at all */
+    disableHeader: PropTypes.bool,
+
+    /**
+     * Used to estimate the total height of a Table before all of its rows have actually been measured.
+     * The estimated total height is adjusted as rows are rendered.
+     */
+    estimatedRowSize: PropTypes.number.isRequired,
+
+    /** Optional custom CSS class name to attach to inner Grid element. */
+    gridClassName: PropTypes.string,
+
+    /** Optional inline style to attach to inner Grid element. */
+    gridStyle: PropTypes.object,
+
+    /** Optional CSS class to apply to all column headers */
+    headerClassName: PropTypes.string,
+
+    /** Fixed height of header row */
+    headerHeight: PropTypes.number.isRequired,
+
+    /**
+     * Responsible for rendering a table row given an array of columns:
+     * Should implement the following interface: ({
+     *   className: string,
+     *   columns: any[],
+     *   style: any
+     * }): PropTypes.node
+     */
+    headerRowRenderer: PropTypes.func,
+
+    /** Optional custom inline style to attach to table header columns. */
+    headerStyle: PropTypes.object,
+
+    /** Fixed/available height for out DOM element */
+    height: PropTypes.number.isRequired,
+
+    /** Optional id */
+    id: PropTypes.string,
+
+    /** Optional renderer to be used in place of table body rows when rowCount is 0 */
+    noRowsRenderer: PropTypes.func,
+
+    /**
+     * Optional callback when a column's header is clicked.
+     * ({ columnData: any, dataKey: string }): void
+     */
+    onHeaderClick: PropTypes.func,
+
+    /**
+     * Callback invoked when a user clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowClick: PropTypes.func,
+
+    /**
+     * Callback invoked when a user double-clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowDoubleClick: PropTypes.func,
+
+    /**
+     * Callback invoked when the mouse leaves a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOut: PropTypes.func,
+
+    /**
+     * Callback invoked when a user moves the mouse over a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOver: PropTypes.func,
+
+    /**
+     * Callback invoked when a user right-clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowRightClick: PropTypes.func,
+
+    /**
+     * Callback invoked with information about the slice of rows that were just rendered.
+     * ({ startIndex, stopIndex }): void
+     */
+    onRowsRendered: PropTypes.func,
+
+    /**
+     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
+     * This callback can be used to sync scrolling between lists, tables, or grids.
+     * ({ clientHeight, scrollHeight, scrollTop }): void
+     */
+    onScroll: PropTypes.func.isRequired,
+
+    /** See Grid#overscanIndicesGetter */
+    overscanIndicesGetter: PropTypes.func.isRequired,
+
+    /**
+     * Number of rows to render above/below the visible bounds of the list.
+     * These rows can help for smoother scrolling on touch devices.
+     */
+    overscanRowCount: PropTypes.number.isRequired,
+
+    /**
+     * Optional CSS class to apply to all table rows (including the header row).
+     * This property can be a CSS class name (string) or a function that returns a class name.
+     * If a function is provided its signature should be: ({ index: number }): string
+     */
+    rowClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+    /**
+     * Callback responsible for returning a data row given an index.
+     * ({ index: number }): any
+     */
+    rowGetter: PropTypes.func.isRequired,
+
+    /**
+     * Either a fixed row height (number) or a function that returns the height of a row given its index.
+     * ({ index: number }): number
+     */
+    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
+      .isRequired,
+
+    /** Number of rows in table. */
+    rowCount: PropTypes.number.isRequired,
+
+    /**
+     * Responsible for rendering a table row given an array of columns:
+     * Should implement the following interface: ({
+     *   className: string,
+     *   columns: Array,
+     *   index: number,
+     *   isScrolling: boolean,
+     *   onRowClick: ?Function,
+     *   onRowDoubleClick: ?Function,
+     *   onRowMouseOver: ?Function,
+     *   onRowMouseOut: ?Function,
+     *   rowData: any,
+     *   style: any
+     * }): PropTypes.node
+     */
+    rowRenderer: PropTypes.func,
+
+    /** Optional custom inline style to attach to table rows. */
+    rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func])
+      .isRequired,
+
+    /** See Grid#scrollToAlignment */
+    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center'])
+      .isRequired,
+
+    /** Row index to ensure visible (by forcefully scrolling if necessary) */
+    scrollToIndex: PropTypes.number.isRequired,
+
+    /** Vertical offset. */
+    scrollTop: PropTypes.number,
+
+    /**
+     * Sort function to be called if a sortable header is clicked.
+     * ({ sortBy: string[], sortDirection: SortDirection[] }): void
+     */
+    sort: PropTypes.func,
+
+    /** Table data is currently sorted by these :dataKey (if it is sorted at all) */
+    sortBy: PropTypes.arrayOf(PropTypes.string),
+
+    /** Table data is currently sorted in these directions (if it is sorted at all) */
+    sortDirection: PropTypes.arrayOf(
+      PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC]),
+    ),
+
+    /** Optional inline style */
+    style: PropTypes.object,
+
+    /** Tab index for focus */
+    tabIndex: PropTypes.number,
+
+    /** Width of list */
+    width: PropTypes.number.isRequired,
+  };
+
+  static defaultProps = {
+    disableHeader: false,
+    estimatedRowSize: 30,
+    headerHeight: 0,
+    headerStyle: {},
+    noRowsRenderer: () => null,
+    onRowsRendered: () => null,
+    onScroll: () => null,
+    overscanIndicesGetter: accessibilityOverscanIndicesGetter,
+    overscanRowCount: 10,
+    rowRenderer: defaultRowRenderer,
+    headerRowRenderer: defaultHeaderRowRenderer,
+    rowStyle: {},
+    scrollToAlignment: 'auto',
+    scrollToIndex: -1,
+    sortBy: [],
+    sortDirection: [],
+    style: {},
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      scrollbarWidth: 0,
+    };
+
+    this._calcNewSort = this._calcNewSort.bind(this);
+    this._sortState = this._sortState.bind(this);
+    this._setRef = this._setRef.bind(this);
+  }
+
+  forceUpdateGrid() {
+    this.Table.forceUpdateGrid();
+  }
+
+  /** See Grid#getOffsetForCell */
+  getOffsetForRow({alignment, index}) {
+    return this.Table.getOffsetForRow({alignment, index});
+  }
+
+  /** CellMeasurer compatibility */
+  invalidateCellSizeAfterRender({columnIndex, rowIndex}: CellPosition) {
+    this.Table.invalidateCellSizeAfterRender({columnIndex, rowIndex});
+  }
+
+  /** See Grid#measureAllCells */
+  measureAllRows() {
+    this.Table.measureAllRows();
+  }
+
+  /** CellMeasurer compatibility */
+  recomputeGridSize({columnIndex = 0, rowIndex = 0}: CellPosition = {}) {
+    this.Table.recomputeGridSize({columnIndex, rowIndex});
+  }
+
+  /** See Grid#recomputeGridSize */
+  recomputeRowHeights(index = 0) {
+    this.Table.recomputeRowHeights(index);
+  }
+
+  /** See Grid#scrollToPosition */
+  scrollToPosition(scrollTop = 0) {
+    this.Table.scrollToPosition(scrollTop);
+  }
+
+  /** See Grid#scrollToCell */
+  scrollToRow(index = 0) {
+    this.Table.scrollToRow(index);
+  }
+
+  render() {
+    const {sortBy, sortDirection, ...props} = this.props;
+    return (
+      <Table
+        ref={this._setRef}
+        {...props}
+        calcNewSort={this._calcNewSort}
+        sortState={this._sortState}
+      />
+    );
+  }
+
+  get Grid() {
+    return this.Table.Grid;
+  }
+
+  _calcNewSort({dataKey, defaultSortDirection, event}) {
+    let {sortBy, sortDirection} = this.props;
+    const index = sortBy.findIndex(o => o === dataKey);
+    if (event.shiftKey) {
+      // If this is the firstTime sort of this column, add column default sort
+      // order to sort info. Otherwise, invert the direction of the sort.
+      if (index === -1) {
+        sortBy = sortBy.slice();
+        sortDirection = sortDirection.slice();
+
+        sortBy.push(dataKey);
+        sortDirection.push(defaultSortDirection);
+      } else {
+        // no need to slice sortBy
+        sortDirection = sortDirection.slice();
+        sortDirection[index] =
+          sortDirection[index] === SortDirection.DESC
+            ? SortDirection.ASC
+            : SortDirection.DESC;
+      }
+    } else if (event.ctrlKey) {
+      // If this column is sorted by, removed it from sort.
+      if (index !== -1) {
+        sortBy = sortBy.slice();
+        sortDirection = sortDirection.slice();
+
+        sortBy.splice(index, 1);
+        sortDirection.splice(index, 1);
+      }
+    } else {
+      // If this is the firstTime sort of this column, use the column default
+      // sort order. Otherwise, invert the direction of the sort.
+      sortBy = [dataKey];
+      sortDirection = [
+        index === -1
+          ? defaultSortDirection
+          : sortDirection[index] === SortDirection.DESC
+            ? SortDirection.ASC
+            : SortDirection.DESC,
+      ];
+    }
+
+    return {
+      sortBy,
+      sortDirection,
+    };
+  }
+
+  _sortState({dataKey}) {
+    const {sortBy, sortDirection} = this.props;
+    const index = sortBy.findIndex(o => o === dataKey);
+    if (index !== -1) {
+      return {sortDirection: sortDirection[index]};
+    }
+
+    return {};
+  }
+
+  _setRef(ref) {
+    this.Table = ref;
+  }
+}

--- a/source/Table/SimpleTable.js
+++ b/source/Table/SimpleTable.js
@@ -1,0 +1,335 @@
+/** @flow */
+
+import type {CellPosition} from '../Grid';
+
+import cn from 'classnames';
+import Column from './Column';
+import PropTypes from 'prop-types';
+import React, {PureComponent} from 'react';
+import {findDOMNode} from 'react-dom';
+import Grid, {accessibilityOverscanIndicesGetter} from '../Grid';
+import defaultRowRenderer from './defaultRowRenderer';
+import defaultHeaderRowRenderer from './defaultHeaderRowRenderer';
+import Table from './Table';
+import SortDirection from './SortDirection';
+
+export default class SimpleTable extends PureComponent {
+  static propTypes = {
+    'aria-label': PropTypes.string,
+
+    /**
+     * Removes fixed height from the scrollingContainer so that the total height
+     * of rows can stretch the window. Intended for use with WindowScroller
+     */
+    autoHeight: PropTypes.bool,
+
+    /** One or more Columns describing the data displayed in this row */
+    children: props => {
+      const children = React.Children.toArray(props.children);
+      for (let i = 0; i < children.length; i++) {
+        const childType = children[i].type;
+        if (childType !== Column && !(childType.prototype instanceof Column)) {
+          return new Error('Table only accepts children of type Column');
+        }
+      }
+    },
+
+    /** Optional CSS class name */
+    className: PropTypes.string,
+
+    /** Disable rendering the header at all */
+    disableHeader: PropTypes.bool,
+
+    /**
+     * Used to estimate the total height of a Table before all of its rows have actually been measured.
+     * The estimated total height is adjusted as rows are rendered.
+     */
+    estimatedRowSize: PropTypes.number.isRequired,
+
+    /** Optional custom CSS class name to attach to inner Grid element. */
+    gridClassName: PropTypes.string,
+
+    /** Optional inline style to attach to inner Grid element. */
+    gridStyle: PropTypes.object,
+
+    /** Optional CSS class to apply to all column headers */
+    headerClassName: PropTypes.string,
+
+    /** Fixed height of header row */
+    headerHeight: PropTypes.number.isRequired,
+
+    /**
+     * Responsible for rendering a table row given an array of columns:
+     * Should implement the following interface: ({
+     *   className: string,
+     *   columns: any[],
+     *   style: any
+     * }): PropTypes.node
+     */
+    headerRowRenderer: PropTypes.func,
+
+    /** Optional custom inline style to attach to table header columns. */
+    headerStyle: PropTypes.object,
+
+    /** Fixed/available height for out DOM element */
+    height: PropTypes.number.isRequired,
+
+    /** Optional id */
+    id: PropTypes.string,
+
+    /** Optional renderer to be used in place of table body rows when rowCount is 0 */
+    noRowsRenderer: PropTypes.func,
+
+    /**
+     * Optional callback when a column's header is clicked.
+     * ({ columnData: any, dataKey: string }): void
+     */
+    onHeaderClick: PropTypes.func,
+
+    /**
+     * Callback invoked when a user clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowClick: PropTypes.func,
+
+    /**
+     * Callback invoked when a user double-clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowDoubleClick: PropTypes.func,
+
+    /**
+     * Callback invoked when the mouse leaves a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOut: PropTypes.func,
+
+    /**
+     * Callback invoked when a user moves the mouse over a table row.
+     * ({ index: number }): void
+     */
+    onRowMouseOver: PropTypes.func,
+
+    /**
+     * Callback invoked when a user right-clicks on a table row.
+     * ({ index: number }): void
+     */
+    onRowRightClick: PropTypes.func,
+
+    /**
+     * Callback invoked with information about the slice of rows that were just rendered.
+     * ({ startIndex, stopIndex }): void
+     */
+    onRowsRendered: PropTypes.func,
+
+    /**
+     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
+     * This callback can be used to sync scrolling between lists, tables, or grids.
+     * ({ clientHeight, scrollHeight, scrollTop }): void
+     */
+    onScroll: PropTypes.func.isRequired,
+
+    /** See Grid#overscanIndicesGetter */
+    overscanIndicesGetter: PropTypes.func.isRequired,
+
+    /**
+     * Number of rows to render above/below the visible bounds of the list.
+     * These rows can help for smoother scrolling on touch devices.
+     */
+    overscanRowCount: PropTypes.number.isRequired,
+
+    /**
+     * Optional CSS class to apply to all table rows (including the header row).
+     * This property can be a CSS class name (string) or a function that returns a class name.
+     * If a function is provided its signature should be: ({ index: number }): string
+     */
+    rowClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+    /**
+     * Callback responsible for returning a data row given an index.
+     * ({ index: number }): any
+     */
+    rowGetter: PropTypes.func.isRequired,
+
+    /**
+     * Either a fixed row height (number) or a function that returns the height of a row given its index.
+     * ({ index: number }): number
+     */
+    rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
+      .isRequired,
+
+    /** Number of rows in table. */
+    rowCount: PropTypes.number.isRequired,
+
+    /**
+     * Responsible for rendering a table row given an array of columns:
+     * Should implement the following interface: ({
+     *   className: string,
+     *   columns: Array,
+     *   index: number,
+     *   isScrolling: boolean,
+     *   onRowClick: ?Function,
+     *   onRowDoubleClick: ?Function,
+     *   onRowMouseOver: ?Function,
+     *   onRowMouseOut: ?Function,
+     *   rowData: any,
+     *   style: any
+     * }): PropTypes.node
+     */
+    rowRenderer: PropTypes.func,
+
+    /** Optional custom inline style to attach to table rows. */
+    rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func])
+      .isRequired,
+
+    /** See Grid#scrollToAlignment */
+    scrollToAlignment: PropTypes.oneOf(['auto', 'end', 'start', 'center'])
+      .isRequired,
+
+    /** Row index to ensure visible (by forcefully scrolling if necessary) */
+    scrollToIndex: PropTypes.number.isRequired,
+
+    /** Vertical offset. */
+    scrollTop: PropTypes.number,
+
+    /**
+     * Sort function to be called if a sortable header is clicked.
+     * ({ sortBy: string, sortDirection: SortDirection }): void
+     */
+    sort: PropTypes.func,
+
+    /** Table data is currently sorted by this :dataKey (if it is sorted at all) */
+    sortBy: PropTypes.string,
+
+    /** Table data is currently sorted in this direction (if it is sorted at all) */
+    sortDirection: PropTypes.oneOf([SortDirection.ASC, SortDirection.DESC]),
+
+    /** Optional inline style */
+    style: PropTypes.object,
+
+    /** Tab index for focus */
+    tabIndex: PropTypes.number,
+
+    /** Width of list */
+    width: PropTypes.number.isRequired,
+  };
+
+  static defaultProps = {
+    disableHeader: false,
+    estimatedRowSize: 30,
+    headerHeight: 0,
+    headerStyle: {},
+    noRowsRenderer: () => null,
+    onRowsRendered: () => null,
+    onScroll: () => null,
+    overscanIndicesGetter: accessibilityOverscanIndicesGetter,
+    overscanRowCount: 10,
+    rowRenderer: defaultRowRenderer,
+    headerRowRenderer: defaultHeaderRowRenderer,
+    rowStyle: {},
+    scrollToAlignment: 'auto',
+    scrollToIndex: -1,
+    style: {},
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      scrollbarWidth: 0,
+    };
+
+    this._calcNewSort = this._calcNewSort.bind(this);
+    this._sortState = this._sortState.bind(this);
+    this._setRef = this._setRef.bind(this);
+  }
+
+  forceUpdateGrid() {
+    this.Table.forceUpdateGrid();
+  }
+
+  /** See Grid#getOffsetForCell */
+  getOffsetForRow({alignment, index}) {
+    return this.Table.getOffsetForRow({alignment, index});
+  }
+
+  /** CellMeasurer compatibility */
+  invalidateCellSizeAfterRender({columnIndex, rowIndex}: CellPosition) {
+    this.Table.invalidateCellSizeAfterRender({columnIndex, rowIndex});
+  }
+
+  /** See Grid#measureAllCells */
+  measureAllRows() {
+    this.Table.measureAllRows();
+  }
+
+  /** CellMeasurer compatibility */
+  recomputeGridSize({columnIndex = 0, rowIndex = 0}: CellPosition = {}) {
+    this.Table.recomputeGridSize({columnIndex, rowIndex});
+  }
+
+  /** See Grid#recomputeGridSize */
+  recomputeRowHeights(index = 0) {
+    this.Table.recomputeRowHeights(index);
+  }
+
+  /** See Grid#scrollToPosition */
+  scrollToPosition(scrollTop = 0) {
+    this.Table.scrollToPosition(scrollTop);
+  }
+
+  /** See Grid#scrollToCell */
+  scrollToRow(index = 0) {
+    this.Table.scrollToRow(index);
+  }
+
+  render() {
+    const {sortBy, sortDirection, ...props} = this.props;
+    return (
+      <Table
+        ref={this._setRef}
+        {...props}
+        calcNewSort={this._calcNewSort}
+        sortState={this._sortState}
+      />
+    );
+  }
+
+  get Grid() {
+    return this.Table.Grid;
+  }
+
+  _calcNewSort({dataKey, defaultSortDirection, event}) {
+    const {sortBy, sortDirection} = this.props;
+
+    // If this is a sortable header, clicking it should update the table
+    // data's sorting.
+    const isFirstTimeSort = sortBy !== dataKey;
+
+    // If this is the firstTime sort of this column, use the column default
+    // sort order. Otherwise, invert the direction of the sort.
+    const newSortDirection = isFirstTimeSort
+      ? defaultSortDirection
+      : sortDirection === SortDirection.DESC
+        ? SortDirection.ASC
+        : SortDirection.DESC;
+
+    return {
+      sortBy: dataKey,
+      sortDirection: newSortDirection,
+    };
+  }
+
+  _sortState({dataKey}) {
+    const {sortBy, sortDirection} = this.props;
+    if (sortBy === dataKey) {
+      return {sortDirection};
+    }
+
+    return {};
+  }
+
+  _setRef(ref) {
+    this.Table = ref;
+  }
+}

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -4,7 +4,8 @@ import {render} from '../TestUtils';
 import {Simulate} from 'react-dom/test-utils';
 import Immutable from 'immutable';
 import Column from './Column';
-import Table from './Table';
+import Table from './SimpleTable';
+import MultiTable from './MultiTable';
 import SortDirection from './SortDirection';
 
 describe('Table', () => {
@@ -49,10 +50,12 @@ describe('Table', () => {
     maxWidth,
     minWidth,
     defaultSortDirection,
+    extendedSort,
     ...flexTableProps
   } = {}) {
+    const TableComponent = extendedSort ? MultiTable : Table;
     return (
-      <Table
+      <TableComponent
         headerHeight={20}
         height={100}
         overscanRowCount={0}
@@ -83,11 +86,12 @@ describe('Table', () => {
           minWidth={minWidth}
           width={50}
         />
+        {extendedSort && <Column label="Id" dataKey="id" width={50} />}
         {false}
         {true}
         {null}
         {undefined}
-      </Table>
+      </TableComponent>
     );
   }
 
@@ -570,6 +574,209 @@ describe('Table', () => {
         const {sortBy, sortDirection: newSortDirection} = sortCalls[0];
         expect(sortBy).toEqual('name');
         expect(newSortDirection).toEqual(sortDirection);
+      });
+    });
+  });
+
+  describe('multi-sort', () => {
+    it('should render the correct sort indicators', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: () => {},
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+
+        [1, 2].forEach(index => {
+          const column = rendered.querySelector(
+            '.ReactVirtualized__Table__headerColumn:nth-of-type(' + index + ')',
+          );
+
+          expect(
+            column.querySelector(
+              '.ReactVirtualized__Table__sortableHeaderIcon',
+            ),
+          ).not.toEqual(null);
+          expect(
+            column.querySelector(
+              `.ReactVirtualized__Table__sortableHeaderIcon--${sortDirection}`,
+            ),
+          ).not.toEqual(null);
+        });
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when the current sort-by column header is clicked', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: info => sortCalls.push(info),
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+        const nameColumn = rendered.querySelector(
+          '.ReactVirtualized__Table__headerColumn:first-of-type',
+        );
+
+        Simulate.click(nameColumn);
+        expect(sortCalls.length).toEqual(1);
+        expect(sortCalls[0]).toEqual({
+          sortBy: ['name'],
+          sortDirection: [
+            sortDirection === SortDirection.ASC
+              ? SortDirection.DESC
+              : SortDirection.ASC,
+          ],
+        });
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when the current sort-by column header is shift+clicked', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: info => sortCalls.push(info),
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+        const nameColumn = rendered.querySelector(
+          '.ReactVirtualized__Table__headerColumn:first-of-type',
+        );
+
+        Simulate.click(nameColumn, {shiftKey: true});
+        expect(sortCalls.length).toEqual(1);
+        expect(sortCalls[0]).toEqual({
+          sortBy: ['name', 'email'],
+          sortDirection: [
+            sortDirection === SortDirection.ASC
+              ? SortDirection.DESC
+              : SortDirection.ASC,
+            sortDirection,
+          ],
+        });
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when the current sort-by column header is ctrl+clicked', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: info => sortCalls.push(info),
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+        const nameColumn = rendered.querySelector(
+          '.ReactVirtualized__Table__headerColumn:first-of-type',
+        );
+
+        Simulate.click(nameColumn, {ctrlKey: true});
+        expect(sortCalls.length).toEqual(1);
+        expect(sortCalls[0]).toEqual({
+          sortBy: ['email'],
+          sortDirection: [sortDirection],
+        });
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when a new sort-by column header is clicked', () => {
+      const sortCalls = [];
+      const rendered = findDOMNode(
+        render(
+          getMarkup({
+            extendedSort: true,
+            sort: info => sortCalls.push(info),
+            sortBy: ['name', 'email'],
+            sortDirection: [SortDirection.ASC, SortDirection.ASC],
+          }),
+        ),
+      );
+      const idColumn = rendered.querySelector(
+        '.ReactVirtualized__Table__headerColumn:nth-of-type(3)',
+      );
+
+      Simulate.click(idColumn);
+      expect(sortCalls.length).toEqual(1);
+      expect(sortCalls[0]).toEqual({
+        sortBy: ['id'],
+        sortDirection: [SortDirection.ASC],
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when a new sort-by column header is shift+clicked', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: info => sortCalls.push(info),
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+        const idColumn = rendered.querySelector(
+          '.ReactVirtualized__Table__headerColumn:nth-of-type(3)',
+        );
+
+        Simulate.click(idColumn, {shiftKey: true});
+        expect(sortCalls.length).toEqual(1);
+        expect(sortCalls[0]).toEqual({
+          sortBy: ['name', 'email', 'id'],
+          sortDirection: [sortDirection, sortDirection, SortDirection.ASC],
+        });
+      });
+    });
+
+    it('should call multi-sort with the correct arguments when a new sort-by column header is ctrl+clicked', () => {
+      const sortDirections = [SortDirection.ASC, SortDirection.DESC];
+      sortDirections.forEach(sortDirection => {
+        const sortCalls = [];
+        const rendered = findDOMNode(
+          render(
+            getMarkup({
+              extendedSort: true,
+              sort: info => sortCalls.push(info),
+              sortBy: ['name', 'email'],
+              sortDirection: [sortDirection, sortDirection],
+            }),
+          ),
+        );
+        const idColumn = rendered.querySelector(
+          '.ReactVirtualized__Table__headerColumn:nth-of-type(3)',
+        );
+
+        Simulate.click(idColumn, {ctrlKey: true});
+        expect(sortCalls.length).toEqual(1);
+        expect(sortCalls[0]).toEqual({
+          sortBy: ['name', 'email'],
+          sortDirection: [sortDirection, sortDirection],
+        });
       });
     });
   });

--- a/source/Table/index.js
+++ b/source/Table/index.js
@@ -7,7 +7,8 @@ import defaultRowRenderer from './defaultRowRenderer';
 import Column from './Column';
 import SortDirection from './SortDirection';
 import SortIndicator from './SortIndicator';
-import Table from './Table';
+import Table from './SimpleTable';
+import MultiTable from './MultiTable';
 
 export default Table;
 export {
@@ -20,4 +21,5 @@ export {
   SortDirection,
   SortIndicator,
   Table,
+  MultiTable,
 };

--- a/source/demo/utils.js
+++ b/source/demo/utils.js
@@ -4,7 +4,7 @@
 export function generateRandomList() {
   const list = [];
 
-  for (var i = 0; i < 1000; i++) {
+  for (var i = 0; i < 1000; i += 3) {
     const random = loremIpsum[i % loremIpsum.length];
     const randoms = [random];
 
@@ -12,14 +12,18 @@ export function generateRandomList() {
       randoms.push(loremIpsum[(i * j) % loremIpsum.length]);
     }
 
-    list.push({
-      color: BADGE_COLORS[i % BADGE_COLORS.length],
-      index: i,
-      name: NAMES[i % NAMES.length],
-      random,
-      randomLong: randoms.join(' '),
-      size: ROW_HEIGHTS[Math.floor(Math.random() * ROW_HEIGHTS.length)],
-    });
+    const name = NAMES[i % NAMES.length];
+
+    for (var j = 0; j < 3; ++j) {
+      list.push({
+        color: BADGE_COLORS[j % BADGE_COLORS.length],
+        index: i + j,
+        name,
+        random,
+        randomLong: randoms.join(' '),
+        size: ROW_HEIGHTS[Math.floor(Math.random() * ROW_HEIGHTS.length)],
+      });
+    }
   }
 
   return list;


### PR DESCRIPTION
original PR: #946 

- splitted simple and multi-sort into separate components, which internally render original table component.
- original table no longer gets sortBy and sortDirection via props (using internal fn for that)
- original table no longer calculate arguments for sort function (again delegated to internal fn)

