### PR TITLE
Fix List with CellMeasurer on first paint

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -212,9 +212,6 @@ type Props = {
 
   /** Width of Grid; this property determines the number of visible (vs virtualized) columns.  */
   width: number,
-
-  /** Callback that's called with a ref to the current instance of the Grid before the actual mount has happened */
-  preMountRef: Grid => void,
 };
 
 type State = {
@@ -257,7 +254,6 @@ export default class Grid extends React.PureComponent<Props, State> {
     scrollToRow: -1,
     style: {},
     tabIndex: 0,
-    preMountRef: () => {},
   };
 
   state = {
@@ -716,7 +712,7 @@ export default class Grid extends React.PureComponent<Props, State> {
   }
 
   componentWillMount() {
-    const {getScrollbarSize, preMountRef} = this.props;
+    const {getScrollbarSize} = this.props;
 
     // If this component is being rendered server-side, getScrollbarSize() will return undefined.
     // We handle this case in componentDidMount()
@@ -729,7 +725,6 @@ export default class Grid extends React.PureComponent<Props, State> {
     }
 
     this._calculateChildrenToRender();
-    preMountRef(this);
   }
 
   componentWillUnmount() {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -212,6 +212,9 @@ type Props = {
 
   /** Width of Grid; this property determines the number of visible (vs virtualized) columns.  */
   width: number,
+
+  /** Callback that's called with a ref to the current instance of the Grid before the actual mount has happened */
+  preMountRef: Grid => void,
 };
 
 type State = {
@@ -254,6 +257,7 @@ export default class Grid extends React.PureComponent<Props, State> {
     scrollToRow: -1,
     style: {},
     tabIndex: 0,
+    preMountRef: () => {},
   };
 
   state = {
@@ -712,7 +716,7 @@ export default class Grid extends React.PureComponent<Props, State> {
   }
 
   componentWillMount() {
-    const {getScrollbarSize} = this.props;
+    const {getScrollbarSize, preMountRef} = this.props;
 
     // If this component is being rendered server-side, getScrollbarSize() will return undefined.
     // We handle this case in componentDidMount()
@@ -725,6 +729,7 @@ export default class Grid extends React.PureComponent<Props, State> {
     }
 
     this._calculateChildrenToRender();
+    preMountRef(this);
   }
 
   componentWillUnmount() {

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -203,13 +203,13 @@ export default class List extends React.PureComponent<Props> {
         onScroll={this._onScroll}
         onSectionRendered={this._onSectionRendered}
         ref={this._setRef}
-        preMountRef={this._setRef}
         scrollToRow={scrollToIndex}
       />
     );
   }
 
   _cellRenderer = ({
+    parent,
     rowIndex,
     style,
     isScrolling,
@@ -236,7 +236,7 @@ export default class List extends React.PureComponent<Props> {
       isScrolling,
       isVisible,
       key,
-      parent: this,
+      parent,
     });
   };
 

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -214,6 +214,7 @@ export default class List extends React.PureComponent<Props> {
     isScrolling,
     isVisible,
     key,
+    parent,
   }: CellRendererParams) => {
     const {rowRenderer} = this.props;
 
@@ -228,6 +229,8 @@ export default class List extends React.PureComponent<Props> {
       // This prevents them from flowing under a scrollbar (if present).
       style.width = '100%';
     }
+
+    this.Grid = this.Grid || parent;
 
     return rowRenderer({
       index: rowIndex,


### PR DESCRIPTION
fix #866 

## The Problem
Going back to the original issue -  the problem was that `List` with `CellMeasurer` rendered the children incorrectly but after the first scroll - everything went back to normal.

After the initial findings coming from @steinso, which turned out to be true I wanted to dig a bit deeper into why the `Grid` ref in `List` wasn't initialized when calling `invalidateCellSizeAfterRender` on the `List` but only on the first render (after mount).
I realized that the `List._setRef` is being called after `List.invalidateCellSizeAfterRender` which is called (indirectly) in `CellMeasurer.componentDidMount`.

So I looked at reacts [source code and figured out that this is by design](https://github.com/facebook/react/blob/37e4329bc81def4695211d6e3795a654ef4d84f5/packages/react-reconciler/src/ReactFiberScheduler.js#L317-L325), component lifecycle hooks are being triggered before attaching refs.
![image](https://user-images.githubusercontent.com/2384068/34693494-6d785d80-f4cc-11e7-9077-14923e273988.png)
(notice `commitLifeCycles` react-dom.development.js:11505)
![image](https://user-images.githubusercontent.com/2384068/34693504-85a96304-f4cc-11e7-988a-6a643a3c3753.png)
(notice `commitAttachRef` react-dom.development.js:11579)

Plus, `CellMeasurer` is returned through `rowRenderer` which in turn, is returned to `cellRenderer` and is then rendered by `Grid`, so the component hierarchy is something like this:
```
List
|___ Grid
     |___CellMeasurer
     |___CellMeasurer
     |___CellMeasurer
     ...
```
This means that `Grid.componentDidMount` will only be called when all of `componentDidMount` of all of his children have been executed, and since attaching refs only happens after life cycle hooks, it means that react will attach the `Grid` ref to the `List` only after all the `CellMeasurer` children have been mounted.
To conclude, this is the call order (of the calls we care about):
1. `Grid.props.cellRenderer` (for each cell)
2. `List.props.rowRenderer` (for each cell)
3. `CellMeasurer.componentDidMount` (for each `CellMeasurer`)
4. `List.invalidateCellSizeAfterRender` (for each `CellMeasurer`)
5. `Grid.ComponentDidMount`
6. `List._setRef` (for getting the `Grid`s ref)

## The solutions
I thought of several solutions to solve this but couldn't decide which is better so I did all of them, each in its own commit.

### Simple solution
This one is the easiest to understand, since the first call in the call chain is `Grid.props.cellRenderer` which calls `List._cellRenderer`, we can use that.
`Grid` invokes to `cellRenderer` with a `parent` parameter, we can use that in `List._cellRenderer` to do this simple check:
```js
this.Grid = this.Grid || parent;
```
This way we're setting the "ref" for the `Grid` a lot sooner, thus ensuring `Grid.invalidateCellSizeAfterRender` will be called, even during `CellMeasurer.componentDidMount`.

### Deferred solution
Instead of trying to set the ref every time on `List._cellRenderer`, we can do everything regularly, except that if we find that `this.Grid` is not initialized we add a desired callback (basically calling `Grid.invalidateCellSizeAfterRender`) to a deferred callback list that will be invoked once we actually set `this.Grid`.
The only problem is that now the `Grid.componentDidMount` is being called before all of our deferred callbacks (they're invoked in `List._setRef`) which means it'll miss the call to `Grid._handleInvalidatedGridSize` in `Grid.componentDidMount`, so we also add a call to `List.forceUpdateGrid` in `List._setRef`, that will cause a render but also invoke `Grid._handleInvalidatedGridSize` in `Grid.componentDidUpdate`.

### Premount solution
This solution tries another approach, setting the `Grid`s ref really early, even before the life cycle hooks. It does that by adding a new prop to `Grid` that's called `preMountRef` and it's invoked in `Grid.componentWillMount` with `this` as the `Grid` ref. That way the `List` will have the ref before the first `CellMeasurer` is being rendered - which is what we want.
To me it feels like a dirty trick, but maybe that's just me 🤷‍♂️ 

### Testing each solution
I couldn't easily reproduce this issue with the local examples, so what I did was to edit `source/demo/Application.js` and replace everything there with:
```js
import React, {PureComponent} from 'react';
import CellMeasurer, {CellMeasurerCache} from '../CellMeasurer';
import List from '../List';
const numberList = Array.from(new Array(500)).map((_, i) => i + '');

export default class DynamicHeightList extends PureComponent {
  constructor() {
    super();
    this.cellMeasurerCache = new CellMeasurerCache({
      fixedWidth: true,
    });
  }

  renderItem({index, key, style, parent}) {
    return (
      <CellMeasurer
        cache={this.cellMeasurerCache}
        key={key}
        parent={parent}
        rowIndex={index}
        columnIndex={0}>
        <div style={style} key={key}>
          {numberList[index]}
        </div>
      </CellMeasurer>
    );
  }
  render() {
    return (
      <List
        rowRenderer={this.renderItem.bind(this)}
        width={200}
        height={300}
        deferredMeasurementCache={this.cellMeasurerCache}
        rowHeight={this.cellMeasurerCache.rowHeight}
        rowCount={numberList.length}
        overscanRowCount={10}
      />
    );
  }
}
```
(This is the code from the plunker in the original issue)

Update: I managed to figure out why I couldn't reproduce the issue with the original `CellMeasurer` examples. That's because the examples use `AutoSizer` which transfer the width to each example, and on `AutoSizer.componentDidMount` it calls `setState` with the new dimensions, this triggers another render cycle so now all the refs exist so everything appears to be working.
So a side note here - I'd make each example page as isolated as possible to avoid example specific quirks like these.

</br>
I'll update the tests/examples/docs once I'll know which solution to use 😉 

</br></br>
P.S.
I did `nvm use` once I saw there's `.nvmrc`, but `yarn install` resulted in a segmentation fault when running `npm run lint` 😳 
So I deleted `node_modules` and ran `nvm use 8` and later everything was fine.
I don't know if it's my machine or not but it's worth upgrading `.nvmrc` to `8.x.x`.
  