### PR TITLE
[Masonry] estimate at least one column

### DIFF
--- a/source/Masonry/Masonry.js
+++ b/source/Masonry/Masonry.js
@@ -319,9 +319,10 @@ export default class Masonry extends PureComponent {
   _getEstimatedTotalHeight() {
     const {cellCount, cellMeasurerCache, width} = this.props;
 
-    const estimatedColumnCount = Math.floor(
-      width / cellMeasurerCache.defaultWidth,
-    ) || 1;
+    const estimatedColumnCount = Math.max(
+      1,
+      Math.floor(width / cellMeasurerCache.defaultWidth)
+    );
 
     return this._positionCache.estimateTotalHeight(
       cellCount,

--- a/source/Masonry/Masonry.js
+++ b/source/Masonry/Masonry.js
@@ -321,7 +321,7 @@ export default class Masonry extends PureComponent {
 
     const estimatedColumnCount = Math.floor(
       width / cellMeasurerCache.defaultWidth,
-    );
+    ) || 1;
 
     return this._positionCache.estimateTotalHeight(
       cellCount,


### PR DESCRIPTION
I have a situation with a responsive layout recalculation, where the width ends up being ever so slightly less than defaultWidth, eg 312 / 318

Which then gets floored to 0
https://github.com/bvaughn/react-virtualized/blob/master/source/Masonry/Masonry.js#L319-L331
Which cascades into an invalid css error, assigning Infinity to a div height.

Thoughts on always estimating a least one column?
