### PR TITLE
Fixed instanceOf HTMLElement to work across contexts

### DIFF
--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -53,7 +53,12 @@ export default class CellMeasurer extends React.PureComponent<Props> {
 
     // TODO Check for a bad combination of fixedWidth and missing numeric width or vice versa with height
 
-    if (node instanceof HTMLElement) {
+    if (
+      node &&
+      node.ownerDocument &&
+      node.ownerDocument.defaultView &&
+      node instanceof node.ownerDocument.defaultView.HTMLElement
+    ) {
       const styleWidth = node.style.width;
       const styleHeight = node.style.height;
 


### PR DESCRIPTION
https://github.com/bvaughn/react-virtualized/pull/900 fixed an issue with iframes/child windows.

One important change was to update the HTMLElement instance check to work across contexts in AutoSizer.js.

There's still one other HTML instance check in CellMeasurer.js which was not updated to work across contexts.

This PR fixes this.