### PR TITLE
Reduce unnecessary renders for CellMeasurer in Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ##### 9.17.1
 * 🐛 `CellMeasurer` works properly in iframes and popup windows. ([dfdeagle47](https://github.com/dfdeagle47) - [#968](https://github.com/bvaughn/react-virtualized/pull/968))
+* ✨ Eliminate unnecessary renders for `CellMeasurer` and `Grid`. ([bvaughn](https://github.com/bvaughn) - [#969](https://github.com/bvaughn/react-virtualized/pull/969))
 
 ##### 9.17.0
 

--- a/source/Grid/utils/CellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.jest.js
@@ -2,13 +2,11 @@ import CellSizeAndPositionManager from './CellSizeAndPositionManager';
 
 describe('CellSizeAndPositionManager', () => {
   function getCellSizeAndPositionManager({
-    batchAllCells,
     cellCount = 100,
     estimatedCellSize = 15,
   } = {}) {
     const cellSizeGetterCalls = [];
     const cellSizeAndPositionManager = new CellSizeAndPositionManager({
-      batchAllCells,
       cellCount,
       cellSizeGetter: ({index}) => {
         cellSizeGetterCalls.push(index);
@@ -380,19 +378,6 @@ describe('CellSizeAndPositionManager', () => {
         offset: 950,
       });
       expect(start).toEqual(95);
-      expect(stop).toEqual(99);
-    });
-
-    it('should return all cells if :batchAllCells param was used (for CellMeasurer support)', () => {
-      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
-        batchAllCells: true,
-        cellCount: 100,
-      });
-      const {start, stop} = cellSizeAndPositionManager.getVisibleCellRange({
-        containerSize: 50,
-        offset: 950,
-      });
-      expect(start).toEqual(0);
       expect(stop).toEqual(99);
     });
   });

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -3,7 +3,6 @@
 import type {Alignment, CellSizeGetter, VisibleCellRange} from '../types';
 
 type CellSizeAndPositionManagerParams = {
-  batchAllCells: boolean,
   cellCount: number,
   cellSizeGetter: CellSizeGetter,
   estimatedCellSize: number,
@@ -46,18 +45,15 @@ export default class CellSizeAndPositionManager {
   // Used in deferred mode to track which cells have been queued for measurement.
   _lastBatchedIndex = -1;
 
-  _batchAllCells: boolean;
   _cellCount: number;
   _cellSizeGetter: CellSizeGetter;
   _estimatedCellSize: number;
 
   constructor({
-    batchAllCells = false,
     cellCount,
     cellSizeGetter,
     estimatedCellSize,
   }: CellSizeAndPositionManagerParams) {
-    this._batchAllCells = batchAllCells;
     this._cellSizeGetter = cellSizeGetter;
     this._cellCount = cellCount;
     this._estimatedCellSize = estimatedCellSize;
@@ -208,15 +204,6 @@ export default class CellSizeAndPositionManager {
   }
 
   getVisibleCellRange(params: GetVisibleCellRangeParams): VisibleCellRange {
-    // Advanced use-cases (eg CellMeasurer) require batched measurements to determine accurate sizes.
-    // eg we can't know a row's height without measuring the height of all columns within that row.
-    if (this._batchAllCells) {
-      return {
-        start: 0,
-        stop: this._cellCount - 1,
-      };
-    }
-
     let {containerSize, offset} = params;
 
     const totalSize = this.getTotalSize();

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -18,7 +18,6 @@ type ContainerSizeAndOffset = {
 
 type Params = {
   maxScrollSize?: number,
-  batchAllCells: boolean,
   cellCount: number,
   cellSizeGetter: CellSizeGetter,
   estimatedCellSize: number,


### PR DESCRIPTION
I realized this morning that when `CellMeasurer` is used, it causes `CellSizeAndPositionManager` to [always render every cell in a given column or row](https://github.com/bvaughn/react-virtualized/blob/04de423e9fe9db5f896add1aadc722c82bbc94ce/source/Grid/utils/CellSizeAndPositionManager.js#L210-L218) regardless of whether measurements have already been collected for those cells. This was not the intent of that code.

I believe I've fixed this to only render all cells initially (per the need explained via the inline comments). Local smoke testing seems good. Automated tests pass.