### PR TITLE
Fix ArrowKeyStepper example

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -174,7 +174,8 @@ export default class ArrowKeyStepperExample extends React.PureComponent<
     });
 
     return (
-      <button
+      <span
+        role="none"
         className={className}
         key={key}
         onClick={
@@ -187,7 +188,7 @@ export default class ArrowKeyStepperExample extends React.PureComponent<
         }
         style={style}>
         {`r:${rowIndex}, c:${columnIndex}`}
-      </button>
+      </span>
     );
   };
 


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Run tests locally (`npm test`) to ensure that your change did not break linting or functionality.
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)

## Action explanation 
The bug was introduced [at this commit](https://github.com/bvaughn/react-virtualized/commit/343a0afdb274874e3079ebcf2d93bf53039c7447#diff-3c77e6d5cb59e393955e89d1cc2220f0L177) and it's part of a bigger issue.

There was an old issue reported that mentioned a problem with focusable elements inside the grid cells (https://github.com/bvaughn/react-virtualized/issues/776), what is happens it that when navigating with arrows to the boundaries of the grid it ends up losing focus from the grid element, and, as a consequence the keydown event at (https://github.com/bvaughn/react-virtualized/blob/master/source/ArrowKeyStepper/ArrowKeyStepper.js#L106) doesn't get executed.

Changing the example to have a span without a role (it wouldn't make much sense to have a role in the first place as all the functionality is handled programmatically) fixes the example issue.

A hider fix may need to be discussed
