### PR TITLE
Fix #986: call requestAnimationFrame on `window`

### DIFF
--- a/source/utils/animationFrame.js
+++ b/source/utils/animationFrame.js
@@ -5,7 +5,7 @@ type CancelAnimationFrame = (requestId: number) => void;
 type RequestAnimationFrame = (callback: Callback) => number;
 
 // Properly handle server-side rendering.
-export let win;
+let win;
 if (typeof window !== 'undefined') {
   win = window;
 } else if (typeof self !== 'undefined') {
@@ -36,5 +36,5 @@ const cancel =
     (win: any).clearTimeout(id);
   };
 
-export const raf: RequestAnimationFrame = (request: any);
-export const caf: CancelAnimationFrame = (cancel: any);
+export const raf: RequestAnimationFrame = (request: any).bind(win);
+export const caf: CancelAnimationFrame = (cancel: any).bind(win);

--- a/source/utils/animationFrame.js
+++ b/source/utils/animationFrame.js
@@ -5,7 +5,7 @@ type CancelAnimationFrame = (requestId: number) => void;
 type RequestAnimationFrame = (callback: Callback) => number;
 
 // Properly handle server-side rendering.
-let win;
+export let win;
 if (typeof window !== 'undefined') {
   win = window;
 } else if (typeof self !== 'undefined') {

--- a/source/utils/requestAnimationTimeout.js
+++ b/source/utils/requestAnimationTimeout.js
@@ -1,13 +1,13 @@
 /** @flow */
 
-import {caf, raf} from './animationFrame';
+import {caf, raf, win} from './animationFrame';
 
 export type AnimationTimeoutId = {
   id: number,
 };
 
 export const cancelAnimationTimeout = (frame: AnimationTimeoutId) =>
-  caf(frame.id);
+  caf.call(win, frame.id);
 
 /**
  * Recursively calls requestAnimationFrame until a specified delay has been met or exceeded.
@@ -25,12 +25,12 @@ export const requestAnimationTimeout = (
     if (Date.now() - start >= delay) {
       callback.call();
     } else {
-      frame.id = raf(timeout);
+      frame.id = raf.call(win, timeout);
     }
   };
 
   const frame: AnimationTimeoutId = {
-    id: raf(timeout),
+    id: raf.call(win, timeout),
   };
 
   return frame;

--- a/source/utils/requestAnimationTimeout.js
+++ b/source/utils/requestAnimationTimeout.js
@@ -1,13 +1,13 @@
 /** @flow */
 
-import {caf, raf, win} from './animationFrame';
+import {caf, raf} from './animationFrame';
 
 export type AnimationTimeoutId = {
   id: number,
 };
 
 export const cancelAnimationTimeout = (frame: AnimationTimeoutId) =>
-  caf.call(win, frame.id);
+  caf(frame.id);
 
 /**
  * Recursively calls requestAnimationFrame until a specified delay has been met or exceeded.
@@ -25,12 +25,12 @@ export const requestAnimationTimeout = (
     if (Date.now() - start >= delay) {
       callback.call();
     } else {
-      frame.id = raf.call(win, timeout);
+      frame.id = raf(timeout);
     }
   };
 
   const frame: AnimationTimeoutId = {
-    id: raf.call(win, timeout),
+    id: raf(timeout),
   };
 
   return frame;


### PR DESCRIPTION
Currently `requestAnimationFrame`/`cancelAnimationFrame` are getting called in another context besides `window` (or `self`). This throws an error as an illegal operation, so this just calls the function with the explicit context of whatever `win` is.

I'm happy to write tests for this, but I just don't really know _how_ to test this sort of thing. If anyone has ideas, let me know and I'll add them to this PR.
