### PR TITLE
add get size helpers

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -49,6 +49,14 @@ A windowed grid of elements. `Grid` only renders cells necessary to fill itself 
 
 Gets offsets for a given cell and alignment.
 
+##### getTotalRowsHeight
+
+Gets estimated total rows' height.
+
+##### getTotalColumnsWidth
+
+Gets estimated total columns' width.
+
 ##### handleScrollEvent ({ scrollLeft, scrollTop })
 
 This method handles a scroll event originating from an external scroll control.

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -613,6 +613,22 @@ describe('Grid', () => {
       expect(scrollTop).toEqual(900);
     });
 
+    it('should support getTotalRowsHeight() public method', () => {
+      const grid = render(getMarkup());
+      grid.recomputeGridSize();
+      const totalHeight = grid.getTotalRowsHeight();
+      // 100 rows * 20 item height = 2,000 total item height
+      expect(totalHeight).toEqual(2000);
+    });
+
+    it('should support getTotalColumnsWidth() public method', () => {
+      const grid = render(getMarkup());
+      grid.recomputeGridSize();
+      const totalWidth = grid.getTotalColumnsWidth();
+      // 50 columns * 50 item width = 2,500 total item width
+      expect(totalWidth).toEqual(2500);
+    });
+
     // See issue #565
     it('should update scroll position to account for changed cell sizes within a function prop wrapper', () => {
       let rowHeight = 20;

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -387,6 +387,20 @@ class Grid extends React.PureComponent<Props, State> {
   }
 
   /**
+   * Gets estimated total rows' height.
+   */
+  getTotalRowsHeight() {
+    return this.state.instanceProps.rowSizeAndPositionManager.getTotalSize();
+  }
+
+  /**
+   * Gets estimated total columns' width.
+   */
+  getTotalColumnsWidth() {
+    return this.state.instanceProps.columnSizeAndPositionManager.getTotalSize();
+  }
+
+  /**
    * This method handles a scroll event originating from an external scroll control.
    * It's an advanced method and should probably not be used unless you're implementing a custom scroll-bar solution.
    */


### PR DESCRIPTION
I'm creating a `Table` based on `Grid`, it supports tree data and auto growable height, I need to get the total rows' height after expanding/adding/removing or I have to calculate every time it changes manually, right now I have to access the private `_rowSizeAndPositionManager` to get the total height