### PR TITLE
Fix #1015 Set scrollLeft and scrollTop in state object to match the actual values

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -618,6 +618,7 @@ export default class Grid extends React.PureComponent<Props, State> {
           columnOrRowCountJustIncreasedFromZero)
       ) {
         this._scrollingContainer.scrollLeft = scrollLeft;
+        this.state.scrollLeft = this._scrollingContainer.scrollLeft;
       }
       if (
         !autoHeight &&
@@ -627,6 +628,7 @@ export default class Grid extends React.PureComponent<Props, State> {
           columnOrRowCountJustIncreasedFromZero)
       ) {
         this._scrollingContainer.scrollTop = scrollTop;
+        this.state.scrollTop = this._scrollingContainer.scrollTop;
       }
     }
 


### PR DESCRIPTION
I'm trying to fix https://github.com/bvaughn/react-virtualized/issues/1015.
Since it requires browser zoom or high-DPI screen to reproduce, I'm not sure how to create a test.

More detail about the issue [here](https://github.com/bvaughn/react-virtualized/issues/1015#issuecomment-369495037)

This PR will make the scrollLeft and scrollTop in the state have the same values as the actual scrollLeft and scrollTop.