### PR TITLE
docs/multiColumnSortTable.md: fix function references.

### DIFF
--- a/docs/Column.md
+++ b/docs/Column.md
@@ -38,7 +38,7 @@ function ({
 }): any
 ```
 
-A [default `cellDataGetter`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultCellDataGetter.js) is provided that simply returns the attribute as a String.
+A [default `cellDataGetter`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultTableCellDataGetter.js) is provided that simply returns the attribute as a String.
 This function expects to operate on either a vanilla Object or a Map-like object with a get method.
 You should override this default method if your data is calculated or requires any custom processing.
 
@@ -59,7 +59,7 @@ function ({
 }): node
 ```
 
-A [default `cellRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultCellRenderer.js) is provided that displays an attribute as a simple string
+A [default `cellRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultTableCellRenderer.js) is provided that displays an attribute as a simple string
 You should override this default method if your data is some other type of object or requires custom formatting.
 
 #### headerRenderer
@@ -78,5 +78,5 @@ function ({
 }): element
 ```
 
-A [default `headerRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultHeaderRenderer.js) is provided that displays the column `label` along with a sort indicator if the column is sort-enabled and active.
+A [default `headerRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultTableHeaderRenderer.js) is provided that displays the column `label` along with a sort indicator if the column is sort-enabled and active.
 You should override this default method if you want to customize the appearance of table columns.

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -103,7 +103,7 @@ The Table component supports the following static class names
 
 This is an advanced property.
 It is useful for situations where you require additional hooks into `Table` to render additional custom UI elements.
-You may want to start by forking the [`defaultTableHeaderRowRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultHeaderRowRenderer.js) function.
+You may want to start by forking the [`defaultTableHeaderRowRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultTableHeaderRowRenderer.js) function.
 
 This function accepts the following named parameters:
 
@@ -140,7 +140,7 @@ function CustomizedTable (props) {
 }
 ```
 
-If you require greater customization, you may want to fork the [`defaultTableRowRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultRowRenderer.js) function.
+If you require greater customization, you may want to fork the [`defaultTableRowRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultTableRowRenderer.js) function.
 
 This function accepts the following named parameters:
 

--- a/docs/multiColumnSortTable.md
+++ b/docs/multiColumnSortTable.md
@@ -1,6 +1,6 @@
 By default, `Table` assumes that its data will be sorted by single attribute, in either ascending or descending order.
 For advanced use cases, you may want to sort by multiple fields.
-This can be accomplished using the `createMultiSort` utility.
+This can be accomplished using the `createTableMultiSort` utility.
 
 ```jsx
 import {
@@ -19,7 +19,7 @@ function sort({
   // When you're done, setState() or update your Flux store, etc.
 }
 
-const sortState = createMultiSort(sort);
+const sortState = createTableMultiSort(sort);
 
 // When rendering your header columns,
 // Use the sort state exposed by sortState:
@@ -49,9 +49,9 @@ const headerRenderer = ({ dataKey, label }) => {
 </Table>
 ```
 
-The `createMultiSort` utility also accepts default sort-by values:
+The `createTableMultiSort` utility also accepts default sort-by values:
 ```js
-const sortState = createMultiSort(sort, {
+const sortState = createTableMultiSort(sort, {
   defaultSortBy: ['firstName', 'lastName'],
   defaultSortDirection: {
     firstName: 'ASC',

--- a/source/Collection/Collection.jest.js
+++ b/source/Collection/Collection.jest.js
@@ -11,7 +11,7 @@ import Collection from './Collection';
 import {CELLS, SECTION_SIZE} from './TestData';
 
 describe('Collection', () => {
-  function defaultCellRenderer({index, key, style}) {
+  function defaultTableCellRenderer({index, key, style}) {
     return (
       <div className="cell" key={key} style={style}>
         cell:{index}
@@ -31,7 +31,7 @@ describe('Collection', () => {
     return (
       <Collection
         cellCount={cellCount}
-        cellRenderer={defaultCellRenderer}
+        cellRenderer={defaultTableCellRenderer}
         cellSizeAndPositionGetter={defaultCellSizeAndPositionGetter}
         height={SECTION_SIZE}
         sectionSize={SECTION_SIZE}
@@ -636,7 +636,7 @@ describe('Collection', () => {
     const cellRendererCalls = [];
     function cellRenderer({index, isScrolling, key, style}) {
       cellRendererCalls.push(isScrolling);
-      return defaultCellRenderer({index, key, style});
+      return defaultTableCellRenderer({index, key, style});
     }
 
     const collection = render(
@@ -723,7 +723,7 @@ describe('Collection', () => {
       const cellRendererCalls = [];
       function cellRenderer({isScrolling, index, key, style}) {
         cellRendererCalls.push({isScrolling, index});
-        return defaultCellRenderer({index, key, style});
+        return defaultTableCellRenderer({index, key, style});
       }
 
       const props = {
@@ -756,7 +756,7 @@ describe('Collection', () => {
       const cellRendererCalls = [];
       function cellRenderer({isScrolling, index, key, style}) {
         cellRendererCalls.push({isScrolling, index});
-        return defaultCellRenderer({index, key, style});
+        return defaultTableCellRenderer({index, key, style});
       }
 
       const props = {
@@ -793,7 +793,7 @@ describe('Collection', () => {
       const cellRendererCalls = [];
       function cellRenderer({isScrolling, index, key, style}) {
         cellRendererCalls.push({isScrolling, index});
-        return defaultCellRenderer({isScrolling, index, key, style});
+        return defaultTableCellRenderer({isScrolling, index, key, style});
       }
 
       const props = {

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -26,7 +26,7 @@ function getScrollbarSize20() {
 }
 
 describe('Grid', () => {
-  function defaultCellRenderer({columnIndex, key, rowIndex, style}) {
+  function defaultTableCellRenderer({columnIndex, key, rowIndex, style}) {
     return (
       <div className="gridItem" key={key} style={style}>
         {`row:${rowIndex}, column:${columnIndex}`}
@@ -43,7 +43,7 @@ describe('Grid', () => {
   function getMarkup(props = {}) {
     return (
       <Grid
-        cellRenderer={defaultCellRenderer}
+        cellRenderer={defaultTableCellRenderer}
         columnCount={NUM_COLUMNS}
         columnWidth={DEFAULT_COLUMN_WIDTH}
         getScrollbarSize={getScrollbarSize0}
@@ -1583,7 +1583,7 @@ describe('Grid', () => {
     const cellRendererCalls = [];
     function cellRenderer({columnIndex, isScrolling, key, rowIndex, style}) {
       cellRendererCalls.push(isScrolling);
-      return defaultCellRenderer({columnIndex, key, rowIndex, style});
+      return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
     }
     const grid = render(
       getMarkup({
@@ -1631,7 +1631,7 @@ describe('Grid', () => {
     const cellRendererCalls = [];
     function cellRenderer(props) {
       cellRendererCalls.push(props);
-      return defaultCellRenderer(props);
+      return defaultTableCellRenderer(props);
     }
     render(
       getMarkup({
@@ -1654,7 +1654,7 @@ describe('Grid', () => {
       const cellRendererCalls = [];
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,
@@ -1694,7 +1694,7 @@ describe('Grid', () => {
       const cellRendererCalls = [];
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,
@@ -1735,7 +1735,7 @@ describe('Grid', () => {
       const cellRendererCalls = [];
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,
@@ -1776,7 +1776,7 @@ describe('Grid', () => {
       const cellRendererCalls = [];
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,
@@ -1862,7 +1862,7 @@ describe('Grid', () => {
       const cellRendererCalls = [];
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,
@@ -1894,7 +1894,7 @@ describe('Grid', () => {
         DEFAULT_SCROLLING_RESET_TIME_INTERVAL * 2;
       function cellRenderer({columnIndex, key, rowIndex, style}) {
         cellRendererCalls.push({columnIndex, rowIndex});
-        return defaultCellRenderer({columnIndex, key, rowIndex, style});
+        return defaultTableCellRenderer({columnIndex, key, rowIndex, style});
       }
       const props = {
         cellRenderer,

--- a/source/MultiGrid/MultiGrid.jest.js
+++ b/source/MultiGrid/MultiGrid.jest.js
@@ -7,7 +7,7 @@ import {CellMeasurerCache} from '../CellMeasurer';
 // These tests only focus on what MultiGrid does specifically.
 // The inner Grid component is tested in depth elsewhere.
 describe('MultiGrid', () => {
-  function defaultCellRenderer({columnIndex, key, rowIndex, style}) {
+  function defaultTableCellRenderer({columnIndex, key, rowIndex, style}) {
     return (
       <div className="gridItem" key={key} style={style}>
         {`row:${rowIndex}, column:${columnIndex}`}
@@ -18,7 +18,7 @@ describe('MultiGrid', () => {
   function getMarkup(props = {}) {
     return (
       <MultiGrid
-        cellRenderer={defaultCellRenderer}
+        cellRenderer={defaultTableCellRenderer}
         columnCount={50}
         columnWidth={50}
         fixedColumnCount={2}

--- a/source/Table/Column.jest.js
+++ b/source/Table/Column.jest.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Immutable from 'immutable';
-import defaultCellDataGetter from './defaultCellDataGetter';
-import defaultCellRenderer from './defaultCellRenderer';
-import defaultHeaderRenderer from './defaultHeaderRenderer';
+import defaultTableCellDataGetter from './defaultTableCellDataGetter';
+import defaultTableCellRenderer from './defaultTableCellRenderer';
+import defaultTableHeaderRenderer from './defaultTableHeaderRenderer';
 
 describe('Column', () => {
   const rowData = Immutable.Map({
@@ -10,16 +10,16 @@ describe('Column', () => {
     bar: 1,
   });
 
-  describe('defaultCellDataGetter', () => {
+  describe('defaultTableCellDataGetter', () => {
     it('should return a value for specified attributes', () => {
       expect(
-        defaultCellDataGetter({
+        defaultTableCellDataGetter({
           dataKey: 'foo',
           rowData,
         }),
       ).toEqual('Foo');
       expect(
-        defaultCellDataGetter({
+        defaultTableCellDataGetter({
           dataKey: 'bar',
           rowData,
         }),
@@ -28,7 +28,7 @@ describe('Column', () => {
 
     it('should return undefined for missing attributes', () => {
       expect(
-        defaultCellDataGetter({
+        defaultTableCellDataGetter({
           dataKey: 'baz',
           rowData,
         }),
@@ -36,10 +36,10 @@ describe('Column', () => {
     });
   });
 
-  describe('defaultCellRenderer', () => {
+  describe('defaultTableCellRenderer', () => {
     it('should render a value for specified attributes', () => {
       expect(
-        defaultCellRenderer({
+        defaultTableCellRenderer({
           cellData: 'Foo',
           dataKey: 'foo',
           rowData,
@@ -47,7 +47,7 @@ describe('Column', () => {
         }),
       ).toEqual('Foo');
       expect(
-        defaultCellRenderer({
+        defaultTableCellRenderer({
           cellData: 1,
           dataKey: 'bar',
           rowData,
@@ -58,7 +58,7 @@ describe('Column', () => {
 
     it('should render empty string for null or missing attributes', () => {
       expect(
-        defaultCellRenderer({
+        defaultTableCellRenderer({
           cellData: null,
           dataKey: 'baz',
           rowData,
@@ -66,7 +66,7 @@ describe('Column', () => {
         }),
       ).toEqual('');
       expect(
-        defaultCellRenderer({
+        defaultTableCellRenderer({
           cellData: undefined,
           dataKey: 'baz',
           rowData,
@@ -76,10 +76,10 @@ describe('Column', () => {
     });
   });
 
-  describe('defaultHeaderRenderer', () => {
+  describe('defaultTableHeaderRenderer', () => {
     it('should render a value for specified attributes', () => {
       expect(
-        defaultHeaderRenderer({
+        defaultTableHeaderRenderer({
           dataKey: 'foo',
           label: 'squirrel',
         })[0].props.children,
@@ -87,7 +87,7 @@ describe('Column', () => {
 
       const label = <div className="rabbit">Rabbit</div>;
       expect(
-        defaultHeaderRenderer({
+        defaultTableHeaderRenderer({
           dataKey: 'bar',
           label: label,
         })[0].props.children,
@@ -96,13 +96,13 @@ describe('Column', () => {
 
     it('should render empty string for null or missing attributes', () => {
       expect(
-        defaultHeaderRenderer({
+        defaultTableHeaderRenderer({
           dataKey: 'foo',
           label: null,
         })[0].props.children,
       ).toBeNull();
       expect(
-        defaultHeaderRenderer({
+        defaultTableHeaderRenderer({
           dataKey: 'bar',
           label: undefined,
         })[0].props.children,

--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -1,9 +1,9 @@
 /** @flow */
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import defaultHeaderRenderer from './defaultHeaderRenderer';
-import defaultCellRenderer from './defaultCellRenderer';
-import defaultCellDataGetter from './defaultCellDataGetter';
+import defaultTableHeaderRenderer from './defaultTableHeaderRenderer';
+import defaultTableCellRenderer from './defaultTableCellRenderer';
+import defaultTableCellDataGetter from './defaultTableCellDataGetter';
 import SortDirection from './SortDirection';
 
 /**
@@ -82,12 +82,12 @@ export default class Column extends React.Component {
   };
 
   static defaultProps = {
-    cellDataGetter: defaultCellDataGetter,
-    cellRenderer: defaultCellRenderer,
+    cellDataGetter: defaultTableCellDataGetter,
+    cellRenderer: defaultTableCellRenderer,
     defaultSortDirection: SortDirection.ASC,
     flexGrow: 0,
     flexShrink: 1,
-    headerRenderer: defaultHeaderRenderer,
+    headerRenderer: defaultTableHeaderRenderer,
     style: {},
   };
 }

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -9,8 +9,8 @@ import * as React from 'react';
 import {findDOMNode} from 'react-dom';
 import Grid, {accessibilityOverscanIndicesGetter} from '../Grid';
 
-import defaultRowRenderer from './defaultRowRenderer';
-import defaultHeaderRowRenderer from './defaultHeaderRowRenderer';
+import defaultTableRowRenderer from './defaultTableRowRenderer';
+import defaultTableHeaderRowRenderer from './defaultTableHeaderRowRenderer';
 import SortDirection from './SortDirection';
 
 /**
@@ -233,8 +233,8 @@ export default class Table extends React.PureComponent {
     onScroll: () => null,
     overscanIndicesGetter: accessibilityOverscanIndicesGetter,
     overscanRowCount: 10,
-    rowRenderer: defaultRowRenderer,
-    headerRowRenderer: defaultHeaderRowRenderer,
+    rowRenderer: defaultTableRowRenderer,
+    headerRowRenderer: defaultTableHeaderRowRenderer,
     rowStyle: {},
     scrollToAlignment: 'auto',
     scrollToIndex: -1,

--- a/source/Table/createTableMultiSort.jest.js
+++ b/source/Table/createTableMultiSort.jest.js
@@ -1,6 +1,6 @@
-import createMultiSort from './createMultiSort';
+import createTableMultiSort from './createTableMultiSort';
 
-describe('createMultiSort', () => {
+describe('createTableMultiSort', () => {
   function simulate(
     sort,
     dataKey,
@@ -19,11 +19,11 @@ describe('createMultiSort', () => {
   }
 
   it('errors if the user did not specify a sort callback', () => {
-    expect(createMultiSort).toThrow();
+    expect(createTableMultiSort).toThrow();
   });
 
   it('sets the correct default values', () => {
-    const multiSort = createMultiSort(jest.fn(), {
+    const multiSort = createTableMultiSort(jest.fn(), {
       defaultSortBy: ['a', 'b'],
       defaultSortDirection: {
         a: 'ASC',
@@ -36,7 +36,7 @@ describe('createMultiSort', () => {
   });
 
   it('sets the correct default sparse values', () => {
-    const multiSort = createMultiSort(jest.fn(), {
+    const multiSort = createTableMultiSort(jest.fn(), {
       defaultSortBy: ['a', 'b'],
     });
     expect(multiSort.sortBy).toEqual(['a', 'b']);
@@ -46,7 +46,7 @@ describe('createMultiSort', () => {
 
   describe('on click', () => {
     it('sets the correct default value for a field', () => {
-      const multiSort = createMultiSort(jest.fn());
+      const multiSort = createTableMultiSort(jest.fn());
 
       simulate(multiSort.sort, 'a');
       expect(multiSort.sortBy).toEqual(['a']);
@@ -58,7 +58,7 @@ describe('createMultiSort', () => {
     });
 
     it('toggles a field value', () => {
-      const multiSort = createMultiSort(jest.fn());
+      const multiSort = createTableMultiSort(jest.fn());
 
       simulate(multiSort.sort, 'a');
       expect(multiSort.sortBy).toEqual(['a']);
@@ -78,7 +78,7 @@ describe('createMultiSort', () => {
     });
 
     it('resets sort-by fields', () => {
-      const multiSort = createMultiSort(jest.fn(), {
+      const multiSort = createTableMultiSort(jest.fn(), {
         defaultSortBy: ['a', 'b'],
       });
       expect(multiSort.sortBy).toEqual(['a', 'b']);
@@ -90,7 +90,7 @@ describe('createMultiSort', () => {
 
   describe('on shift click', () => {
     it('appends a field to the sort by list', () => {
-      const multiSort = createMultiSort(jest.fn());
+      const multiSort = createTableMultiSort(jest.fn());
 
       simulate(multiSort.sort, 'a');
       expect(multiSort.sortBy).toEqual(['a']);
@@ -103,7 +103,7 @@ describe('createMultiSort', () => {
     });
 
     it('toggles an appended field value', () => {
-      const multiSort = createMultiSort(jest.fn());
+      const multiSort = createTableMultiSort(jest.fn());
 
       simulate(multiSort.sort, 'a');
       expect(multiSort.sortBy).toEqual(['a']);
@@ -129,7 +129,7 @@ describe('createMultiSort', () => {
   ['control', 'meta'].forEach(modifier => {
     describe(`${modifier} click`, () => {
       it('removes a field from the sort by list', () => {
-        const multiSort = createMultiSort(jest.fn(), {
+        const multiSort = createTableMultiSort(jest.fn(), {
           defaultSortBy: ['a', 'b'],
         });
         expect(multiSort.sortBy).toEqual(['a', 'b']);
@@ -142,7 +142,7 @@ describe('createMultiSort', () => {
       });
 
       it('ignores fields not in the list on control click', () => {
-        const multiSort = createMultiSort(jest.fn(), {
+        const multiSort = createTableMultiSort(jest.fn(), {
           defaultSortBy: ['a', 'b'],
         });
         expect(multiSort.sortBy).toEqual(['a', 'b']);

--- a/source/Table/createTableMultiSort.js
+++ b/source/Table/createTableMultiSort.js
@@ -34,7 +34,7 @@ type MultiSortReturn = {
   sortDirection: SortDirectionMap,
 };
 
-export default function createMultiSort(
+export default function createTableMultiSort(
   sortCallback: Function,
   {defaultSortBy, defaultSortDirection = {}}: MultiSortOptions = {},
 ): MultiSortReturn {

--- a/source/Table/defaultTableCellDataGetter.js
+++ b/source/Table/defaultTableCellDataGetter.js
@@ -6,7 +6,7 @@ import type {CellDataGetterParams} from './types';
  * This function expects to operate on either a vanilla Object or an Immutable Map.
  * You should override the column's cellDataGetter if your data is some other type of object.
  */
-export default function defaultCellDataGetter({
+export default function defaultTableCellDataGetter({
   dataKey,
   rowData,
 }: CellDataGetterParams) {

--- a/source/Table/defaultTableCellRenderer.js
+++ b/source/Table/defaultTableCellRenderer.js
@@ -5,7 +5,7 @@ import type {CellRendererParams} from './types';
  * Default cell renderer that displays an attribute as a simple string
  * You should override the column's cellRenderer if your data is some other type of object.
  */
-export default function defaultCellRenderer({
+export default function defaultTableCellRenderer({
   cellData,
 }: CellRendererParams): string {
   if (cellData == null) {

--- a/source/Table/defaultTableHeaderRenderer.js
+++ b/source/Table/defaultTableHeaderRenderer.js
@@ -6,7 +6,7 @@ import type {HeaderRendererParams} from './types';
 /**
  * Default table header renderer.
  */
-export default function defaultHeaderRenderer({
+export default function defaultTableHeaderRenderer({
   dataKey,
   label,
   sortBy,

--- a/source/Table/defaultTableHeaderRowRenderer.js
+++ b/source/Table/defaultTableHeaderRowRenderer.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import type {HeaderRowRendererParams} from './types';
 
-export default function defaultHeaderRowRenderer({
+export default function defaultTableHeaderRowRenderer({
   className,
   columns,
   style,

--- a/source/Table/defaultTableRowRenderer.js
+++ b/source/Table/defaultTableRowRenderer.js
@@ -5,7 +5,7 @@ import type {RowRendererParams} from './types';
 /**
  * Default row renderer for Table.
  */
-export default function defaultRowRenderer({
+export default function defaultTableRowRenderer({
   className,
   columns,
   index,

--- a/source/Table/index.js
+++ b/source/Table/index.js
@@ -1,23 +1,30 @@
 /* @flow */
-import createMultiSort from './createMultiSort';
-import defaultCellDataGetter from './defaultCellDataGetter';
-import defaultCellRenderer from './defaultCellRenderer';
-import defaultHeaderRowRenderer from './defaultHeaderRowRenderer.js';
-import defaultHeaderRenderer from './defaultHeaderRenderer';
-import defaultRowRenderer from './defaultRowRenderer';
+import createTableMultiSort from './createTableMultiSort';
+import defaultTableCellDataGetter from './defaultTableCellDataGetter';
+import defaultTableCellRenderer from './defaultTableCellRenderer';
+import defaultTableHeaderRowRenderer from './defaultTableHeaderRowRenderer.js';
+import defaultTableHeaderRenderer from './defaultTableHeaderRenderer';
+import defaultTableRowRenderer from './defaultTableRowRenderer';
 import Column from './Column';
 import SortDirection from './SortDirection';
 import SortIndicator from './SortIndicator';
 import Table from './Table';
 
 export default Table;
+// TODO Remove export aliases without -Table- in version 10
 export {
-  createMultiSort,
-  defaultCellDataGetter,
-  defaultCellRenderer,
-  defaultHeaderRowRenderer,
-  defaultHeaderRenderer,
-  defaultRowRenderer,
+  createTableMultiSort,
+  createTableMultiSort as createMultiSort,
+  defaultTableCellDataGetter,
+  defaultTableCellDataGetter as defaultCellDataGetter,
+  defaultTableCellRenderer,
+  defaultTableCellRenderer as defaultCellRenderer,
+  defaultTableHeaderRowRenderer,
+  defaultTableHeaderRowRenderer as defaultHeaderRowRenderer,
+  defaultTableHeaderRenderer,
+  defaultTableHeaderRenderer as defaultHeaderRenderer,
+  defaultTableRowRenderer,
+  defaultTableRowRenderer as defaultRowRenderer,
   Column,
   SortDirection,
   SortIndicator,

--- a/source/index.js
+++ b/source/index.js
@@ -18,12 +18,12 @@ export {
 export {MultiGrid} from './MultiGrid';
 export {ScrollSync} from './ScrollSync';
 export {
-  createMultiSort as createTableMultiSort,
-  defaultCellDataGetter as defaultTableCellDataGetter,
-  defaultCellRenderer as defaultTableCellRenderer,
-  defaultHeaderRenderer as defaultTableHeaderRenderer,
-  defaultHeaderRowRenderer as defaultTableHeaderRowRenderer,
-  defaultRowRenderer as defaultTableRowRenderer,
+  createTableMultiSort,
+  defaultTableCellDataGetter,
+  defaultTableCellRenderer,
+  defaultTableHeaderRenderer,
+  defaultTableHeaderRowRenderer,
+  defaultTableRowRenderer,
   Table,
   Column,
   SortDirection,


### PR DESCRIPTION
+ fix function references so they match the initial imported function name (`createMultiSort` -> `createTableMultiSort`).

For exported function name from source/index.js, see:
https://github.com/bvaughn/react-virtualized/blob/de107e81f6d412d3561b169f7fdbfdbe25dd7b00/source/index.js#L21