### PR TITLE
Add ScrollTo props to fixed grid elements in MultiGrid

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -279,17 +279,25 @@ export default class MultiGrid extends React.PureComponent {
     return (
       <div style={this._containerOuterStyle}>
         <div style={this._containerTopStyle}>
-          {this._renderTopLeftGrid(rest)}
+          {this._renderTopLeftGrid({
+            ...rest,
+            scrollToColumn,
+            scrollToRow,
+          })}
           {this._renderTopRightGrid({
             ...rest,
             onScroll,
             scrollLeft,
+            scrollToColumn,
+            scrollToRow,
           })}
         </div>
         <div style={this._containerBottomStyle}>
           {this._renderBottomLeftGrid({
             ...rest,
             onScroll,
+            scrollToColumn,
+            scrollToRow,
             scrollTop,
           })}
           {this._renderBottomRightGrid({
@@ -622,6 +630,8 @@ export default class MultiGrid extends React.PureComponent {
       fixedColumnCount,
       fixedRowCount,
       rowCount,
+      scrollToColumn,
+      scrollToRow,
       scrollTop,
     } = props;
     const {showVerticalScrollbar} = this.state;
@@ -644,6 +654,8 @@ export default class MultiGrid extends React.PureComponent {
         ref={this._bottomLeftGridRef}
         rowCount={Math.max(0, rowCount - fixedRowCount) + additionalRowCount}
         rowHeight={this._rowHeightBottomGrid}
+        scrollToColumn={scrollToColumn}
+        scrollToRow={scrollToRow - fixedRowCount}
         scrollTop={scrollTop}
         style={this._bottomLeftGridStyle}
         tabIndex={null}
@@ -685,7 +697,12 @@ export default class MultiGrid extends React.PureComponent {
   }
 
   _renderTopLeftGrid(props) {
-    const {fixedColumnCount, fixedRowCount} = props;
+    const {
+      fixedColumnCount,
+      fixedRowCount,
+      scrollToColumn,
+      scrollToRow,
+    } = props;
 
     if (!fixedColumnCount || !fixedRowCount) {
       return null;
@@ -699,6 +716,8 @@ export default class MultiGrid extends React.PureComponent {
         height={this._getTopGridHeight(props)}
         ref={this._topLeftGridRef}
         rowCount={fixedRowCount}
+        scrollToColumn={scrollToColumn}
+        scrollToRow={scrollToRow}
         style={this._topLeftGridStyle}
         tabIndex={null}
         width={this._getLeftGridWidth(props)}
@@ -713,6 +732,8 @@ export default class MultiGrid extends React.PureComponent {
       fixedColumnCount,
       fixedRowCount,
       scrollLeft,
+      scrollToColumn,
+      scrollToRow,
     } = props;
     const {showHorizontalScrollbar} = this.state;
 
@@ -737,6 +758,8 @@ export default class MultiGrid extends React.PureComponent {
         ref={this._topRightGridRef}
         rowCount={fixedRowCount}
         scrollLeft={scrollLeft}
+        scrollToColumn={scrollToColumn - fixedColumnCount}
+        scrollToRow={scrollToRow}
         style={this._topRightGridStyle}
         tabIndex={null}
         width={this._getRightGridWidth(props)}


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Run tests locally (`npm test`) to ensure that your change did not break linting or functionality.
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)

---

Hi,  I'm using MultiGrid wrapped in an ArrowKeyStepper element (in 'cells' mode).  This is working well but currently only the bottom right grid receives scrollToColumn & scrollToRow props from the parent MultiGrid.  Therefore, if navigating with ArrowKeyStepper in the TopLeft/BottomLeft/TopRight grids they do not receive render events and it is not possible to manage focus.

I've run npm test against this and it's all good.  Thanks

