### PR TITLE
Change `import` to `import type` to fix circular dependency

### DIFF
--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -4,7 +4,7 @@ import {
   requestAnimationTimeout,
   cancelAnimationTimeout,
 } from '../../utils/requestAnimationTimeout';
-import WindowScroller from '../WindowScroller.js';
+import type WindowScroller from '../WindowScroller.js';
 
 let mountedInstances = [];
 let originalBodyPointerEvents = null;


### PR DESCRIPTION
This fixes a circular dependency warning when bundling react-virtualized with rollup.

```
(!) Circular dependency: node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js -> node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js -> node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js
```