### PR TITLE
Fix create multi sort bug

### DIFF
--- a/source/Table/createMultiSort.jest.js
+++ b/source/Table/createMultiSort.jest.js
@@ -86,6 +86,29 @@ describe('createMultiSort', () => {
       simulate(multiSort.sort, 'a');
       expect(multiSort.sortBy).toEqual(['a']);
     });
+
+    it('resets sort-direction fields', () => {
+      const multiSort = createMultiSort(jest.fn(), {
+        defaultSortBy: ['a', 'b'],
+        defaultSortDirection: {
+          a: 'DESC',
+          b: 'ASC',
+        },
+      });
+      expect(multiSort.sortBy).toEqual(['a', 'b']);
+      expect(multiSort.sortDirection.a).toEqual('DESC');
+      expect(multiSort.sortDirection.b).toEqual('ASC');
+
+      simulate(multiSort.sort, 'a');
+      expect(multiSort.sortBy).toEqual(['a']);
+      expect(multiSort.sortDirection.a).toEqual('ASC');
+      expect(multiSort.sortDirection.b).toEqual(undefined);
+
+      simulate(multiSort.sort, 'b');
+      expect(multiSort.sortBy).toEqual(['b']);
+      expect(multiSort.sortDirection.a).toEqual(undefined);
+      expect(multiSort.sortDirection.b).toEqual('ASC');
+    });
   });
 
   describe('on shift click', () => {

--- a/source/Table/createMultiSort.jest.js
+++ b/source/Table/createMultiSort.jest.js
@@ -147,6 +147,28 @@ describe('createMultiSort', () => {
       expect(multiSort.sortDirection.a).toBe('ASC');
       expect(multiSort.sortDirection.b).toBe('ASC');
     });
+
+    it('able to shift+click more than once', () => {
+      const multiSort = createMultiSort(jest.fn());
+
+      simulate(multiSort.sort, 'a');
+      expect(multiSort.sortBy).toEqual(['a']);
+      expect(multiSort.sortDirection.a).toBe('ASC');
+
+      simulate(multiSort.sort, 'b', 'shift');
+      expect(multiSort.sortBy).toEqual(['a', 'b']);
+      expect(multiSort.sortDirection.a).toBe('ASC');
+      expect(multiSort.sortDirection.b).toBe('ASC');
+
+      simulate(multiSort.sort, 'b');
+      expect(multiSort.sortBy).toEqual(['b']);
+      expect(multiSort.sortDirection.b).toBe('DESC');
+
+      simulate(multiSort.sort, 'a', 'shift');
+      expect(multiSort.sortBy).toEqual(['b', 'a']);
+      expect(multiSort.sortDirection.a).toBe('ASC');
+      expect(multiSort.sortDirection.b).toBe('DESC');
+    });
   });
 
   ['control', 'meta'].forEach(modifier => {

--- a/source/Table/createMultiSort.js
+++ b/source/Table/createMultiSort.js
@@ -73,9 +73,18 @@ export default function createMultiSort(
         delete sortDirection[dataKey];
       }
     } else {
+      // Clear sortBy array of all non-selected keys
       sortBy.length = 0;
       sortBy.push(dataKey);
 
+      // Clear sortDirection object of all non-selected keys
+      const sortDirectionKeys = Object.keys(sortDirection);
+      sortDirectionKeys.forEach(key => {
+        if (key !== dataKey) delete sortDirection[key];
+      });
+
+      // If key is already selected, reverse sort direction.
+      // Else, set sort direction to default direction.
       if (sortDirection.hasOwnProperty(dataKey)) {
         sortDirection[dataKey] =
           sortDirection[dataKey] === 'ASC' ? 'DESC' : 'ASC';


### PR DESCRIPTION
This PR fixes a bug found in the `createMultiSort` function. When selecting a new column to sort, the original code clears the `sortBy` array of all non-selected keys, however, fails to clear the `sortDirection` object. By failing to do so, multi-select will not work on any future shift+clicks. Let me explain: in the `event.shiftClick` if-statement block starting on line 59, since the old keys remain in the `sortDirection` object, it will never push the new column value to the `sortBy` array, and thus only ever returning one key in `sortBy`. In my PR, I make sure the `sortDirection` object is cleared of all the non-selected key-values. 