### PR TITLE
Optimize webpack by setting sideEffects to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer'
 import List from 'react-virtualized/dist/commonjs/List'
 ```
 
+Note webpack 4 makes this optimization itself, see the [documentation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).
+
 If the above syntax looks too cumbersome, or you import react-virtualized components from a lot of places, you can also configure a Webpack alias. For example:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
   "jsnext:main": "dist/es/index.js",
+  "sideEffects": false,
   "license": "MIT",
   "scripts": {
     "build:types": "flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/WindowScroller dist/es/WindowScroller && flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/AutoSizer dist/es/AutoSizer ",


### PR DESCRIPTION
This allows webpack 4 to optimize the bundle by only importing the used modules instead of everything.

(Admittedly I didn't read all of the source code so I don't know whether there is some module which does have side effects)

[Webpack documentation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)
[Webpack example](https://github.com/webpack/webpack/tree/master/examples/side-effects)