### PR TITLE
Add table rowkey

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -37,6 +37,7 @@ This component expects explicit `width` and `height` parameters.
 | rowHeight | Number or Function | ✓ | Either a fixed row height (number) or a function that returns the height of a row given its index: `({ index: number }): number` |
 | rowRenderer | Function |  | Responsible for rendering a table row given an array of columns. [Learn more](#rowrenderer) |
 | rowStyle | Object or Function |  | Optional custom inline style to attach to table rows. This value may be either a style object or a function with the signature `({ index: number }): Object`. Note that for the header row an index of `-1` is provided. |
+| rowKey | String or Function |  | Either the `dataKey` to use as a unique identifier or a function with the signature `({ rowData: any }): String. When no `rowKey` is provided, a row identifier is generated from its index. |
 | scrollToAlignment | String |  | Controls the alignment scrolled-to-rows. The default ("_auto_") scrolls the least amount possible to ensure that the specified row is fully visible. Use "_start_" to always align rows to the top of the list and "_end_" to align them bottom. Use "_center_" to align them in the middle of container. |
 | scrollToIndex | Number |  | Row index to ensure visible (by forcefully scrolling if necessary) |
 | scrollTop | Number |  | Vertical offset |

--- a/source/Table/Table.example.js
+++ b/source/Table/Table.example.js
@@ -196,6 +196,7 @@ export default class TableExample extends React.PureComponent {
                 rowHeight={useDynamicRowHeight ? this._getRowHeight : rowHeight}
                 rowGetter={rowGetter}
                 rowCount={rowCount}
+                rowKey="index"
                 scrollToIndex={scrollToIndex}
                 sort={this._sort}
                 sortBy={sortBy}

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -381,6 +381,17 @@ describe('Table', () => {
       );
       expect(nameColumn.getAttribute('title')).toEqual(null);
     });
+
+    it('should use rowKey to generate keys when its a string', () => {
+      const {Grid} = render(
+        getMarkup({
+          rowKey: 'email',
+        }),
+      );
+      Grid._childrenToDisplay.forEach((row, index) => {
+        expect(row.key).toEqual(array[index].email);
+      });
+    });
   });
 
   describe('sorting', () => {

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -425,7 +425,15 @@ export default class Table extends React.PureComponent {
     );
   }
 
-  _createColumn({column, columnIndex, isScrolling, parent, rowData, rowIndex}) {
+  _createColumn({
+    column,
+    columnIndex,
+    customKey,
+    isScrolling,
+    parent,
+    rowData,
+    rowIndex,
+  }) {
     const {
       cellDataGetter,
       cellRenderer,
@@ -451,6 +459,10 @@ export default class Table extends React.PureComponent {
 
     const title = typeof renderedCell === 'string' ? renderedCell : null;
 
+    const key = customKey
+      ? customKey + '-' + dataKey
+      : 'Row' + rowIndex + '-' + 'Col' + columnIndex;
+
     // Avoid using object-spread syntax with multiple objects here,
     // Since it results in an extra method call to 'babel-runtime/helpers/extends'
     // See PR https://github.com/bvaughn/react-virtualized/pull/942
@@ -458,7 +470,7 @@ export default class Table extends React.PureComponent {
       <div
         aria-describedby={id}
         className={cn('ReactVirtualized__Table__rowColumn', className)}
-        key={'Row' + rowIndex + '-' + 'Col' + columnIndex}
+        key={key}
         role="gridcell"
         style={style}
         title={title}>
@@ -584,6 +596,7 @@ export default class Table extends React.PureComponent {
       onRowMouseOver,
       onRowMouseOut,
       rowClassName,
+      rowKey,
       rowGetter,
       rowRenderer,
       rowStyle,
@@ -597,9 +610,18 @@ export default class Table extends React.PureComponent {
       typeof rowStyle === 'function' ? rowStyle({index}) : rowStyle;
     const rowData = rowGetter({index});
 
+    const customKey =
+      rowKey &&
+      (typeof rowKey === 'function'
+        ? rowKey(rowData)
+        : typeof rowData.get === 'function'
+          ? String(rowData.get(rowKey))
+          : String(rowData[rowKey]));
+
     const columns = React.Children.toArray(children).map(
       (column, columnIndex) =>
         this._createColumn({
+          customKey,
           column,
           columnIndex,
           isScrolling,
@@ -624,7 +646,7 @@ export default class Table extends React.PureComponent {
       columns,
       index,
       isScrolling,
-      key,
+      key: customKey || key,
       onRowClick,
       onRowDoubleClick,
       onRowRightClick,


### PR DESCRIPTION
This PR adds a new property to the `Table` element, namely `rowKey`.

As its name implied, it allows to customize React `key` for each row.

The obvious reason is to leverage existing identifiers in the users data, instead of relying on indexes. More practically, this also solves the bug described below (which might be of interest on its own).

---

The bug this solves.

I have have dynamic data in my table, with rows frequently inserted and deleted. Using event delegation on the whole table element, I determine which cell was clicked. Cells have a custom rendered which sets `data-something="whatever"`, that's how I extract my data the event's target element.

After removing a few rows, I discover the target elements had `data-something` pointing to the wrong data: that of the cell that was previously at the same location. Suspecting some optimization-related-code reusing the same DOM element because it has the same key and type, I tried this quick fix that got it worked.

I'm beginner-level with React, so unsure if that might point out to a deeper issuer.

Anyways, as I read about it, it seems like the bug I have is identical to what is described here: [using indexes as keys is an anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).

> Let me explain, a key is the only thing React uses to identify DOM elements. What happens if you push an item to the list or remove something in the middle? If the key is same as before React assumes that the DOM element represents the same component as before. But that is no longer true.

So, using smarter row keys seems to be the answer to such bugs.