### PR TITLE
Adding note on `forceUpdateGrids` for `MultiGrid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For example:
 ###### Public methods
 
 `Grid` and `Collection` components can be forcefully re-rendered using [`forceUpdate`](https://facebook.github.io/react/docs/component-api.html#forceupdate).
-For `Table` and `List`, you'll need to call [`forceUpdateGrid`](https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md#forceupdategrid) to ensure that the inner `Grid` is also updated.
+For `Table` and `List`, you'll need to call [`forceUpdateGrid`](https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md#forceupdategrid) to ensure that the inner `Grid` is also updated. For `MultiGrid`, you'll need to call [`forceUpdateGrids`](https://github.com/bvaughn/react-virtualized/blob/master/docs/MultiGrid.md#forceupdategrids) to ensure that the inner `Grid`s are updated.
 
 Documentation
 ---------------


### PR DESCRIPTION
In the Pure Components section of the README (https://github.com/bvaughn/react-virtualized#pure-components). There isn't info on the `MultiGrid`. Got confused when `forceUpdate` didn't work.