### PR TITLE
Support iframes with WindowScroller

### DIFF
--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -429,6 +429,31 @@ describe('WindowScroller', () => {
       expect(window.scrollY).toEqual(200 + windowScroller._positionFromTop);
     });
 
+    it('should scroll the scrollElement (when it is an iframe) the desired amount', (done) => {
+      let windowScroller;
+      const renderFn = jest.fn();
+      const iframe = document.createElement('iframe');
+      iframe.addEventListener('load', handleLoad, true);
+      document.body.appendChild(iframe);
+      function handleLoad(){
+        const {contentWindow} = iframe;
+        render(
+          getMarkup({
+            ref: ref => {
+              windowScroller = ref;
+            },
+            renderFn,
+            scrollElement: contentWindow,
+          }),
+        );
+
+        renderFn.mock.calls[0][0].onChildScroll({scrollTop: 200});
+        console.log('here', contentWindow.scrollY)
+        expect(contentWindow.scrollY).toEqual(200 + windowScroller._positionFromTop);
+        done()
+      }
+    });
+
     it('should not scroll the scrollElement if trying to scroll to where we already are', () => {
       const renderFn = jest.fn();
 

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -7,6 +7,7 @@ import {
   unregisterScrollListener,
 } from './utils/onScroll';
 import {
+  isWindow,
   getDimensions,
   getPositionOffset,
   getScrollOffset,
@@ -96,12 +97,15 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
     scrollTop: 0,
   };
 
-  updatePosition(scrollElement: ?Element = this.props.scrollElement) {
+  updatePosition(scrollElement: ?any = this.props.scrollElement) {
     const {onResize} = this.props;
     const {height, width} = this.state;
 
     const thisNode = this._child || ReactDOM.findDOMNode(this);
-    if (thisNode instanceof Element && scrollElement) {
+    if (
+      scrollElement &&
+      (thisNode instanceof Element || thisNode instanceof scrollElement.Element)
+    ) {
       const offset = getPositionOffset(thisNode, scrollElement);
       this._positionFromTop = offset.top;
       this._positionFromLeft = offset.left;
@@ -205,16 +209,16 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
   };
 
   _registerResizeListener = element => {
-    if (element === window) {
-      window.addEventListener('resize', this._onResize, false);
+    if (isWindow(element)) {
+      element.addEventListener('resize', this._onResize, false);
     } else {
       this._detectElementResize.addResizeListener(element, this._onResize);
     }
   };
 
   _unregisterResizeListener = element => {
-    if (element === window) {
-      window.removeEventListener('resize', this._onResize, false);
+    if (isWindow(element)) {
+      element.removeEventListener('resize', this._onResize, false);
     } else if (element) {
       this._detectElementResize.removeResizeListener(element, this._onResize);
     }

--- a/source/WindowScroller/utils/dimensions.js
+++ b/source/WindowScroller/utils/dimensions.js
@@ -16,12 +16,14 @@ type WindowScrollerProps = {
   serverWidth: number,
 };
 
-const isWindow = element => element === window;
+export const isWindow = (element: ?any) =>
+  element === window ||
+  (element && element.location && element.document && element.frameElement);
 
 const getBoundingBox = element => element.getBoundingClientRect();
 
 export function getDimensions(
-  scrollElement: ?Element,
+  scrollElement: ?any,
   props: WindowScrollerProps,
 ): Dimensions {
   if (!scrollElement) {
@@ -30,7 +32,7 @@ export function getDimensions(
       width: props.serverWidth,
     };
   } else if (isWindow(scrollElement)) {
-    const {innerHeight, innerWidth} = window;
+    const {innerWidth, innerHeight} = scrollElement;
     return {
       height: typeof innerHeight === 'number' ? innerHeight : 0,
       width: typeof innerWidth === 'number' ? innerWidth : 0,
@@ -46,9 +48,9 @@ export function getDimensions(
  * Handles edge-case where a user is navigating back (history) from an already-scrolled page.
  * In this case the body’s top or left position will be a negative number and this element’s top or left will be increased (by that amount).
  */
-export function getPositionOffset(element: Element, container: Element) {
-  if (isWindow(container) && document.documentElement) {
-    const containerElement = document.documentElement;
+export function getPositionOffset(element: Element, container: any) {
+  if (isWindow(container) && container.document.documentElement) {
+    const containerElement = container.document.documentElement;
     const elementRect = getBoundingBox(element);
     const containerRect = getBoundingBox(containerElement);
     return {
@@ -70,17 +72,17 @@ export function getPositionOffset(element: Element, container: Element) {
  * Gets the vertical and horizontal scroll amount of the element, accounting for IE compatibility
  * and API differences between `window` and other DOM elements.
  */
-export function getScrollOffset(element: Element) {
-  if (isWindow(element) && document.documentElement) {
+export function getScrollOffset(element: any) {
+  if (isWindow(element) && element.document.documentElement) {
     return {
       top:
-        'scrollY' in window
-          ? window.scrollY
-          : document.documentElement.scrollTop,
+        'scrollY' in element
+          ? element.scrollY
+          : element.document.documentElement.scrollTop,
       left:
-        'scrollX' in window
-          ? window.scrollX
-          : document.documentElement.scrollLeft,
+        'scrollX' in element
+          ? element.scrollX
+          : element.document.documentElement.scrollLeft,
     };
   } else {
     return {


### PR DESCRIPTION
The WindowScroller should also be functional for use with iframes. Things to note:

- [x] given a scrollElement of contentWindow provided by an iframe, container.document.documentElement, and element.document is used in place of the applicable document, respectively. 
- [x] Linter is 👍 
- [ ] The needed changes cause tests to fail, and I have not found the appropriate fixes to address them. Any help would be thoroughly appreciated.
- [ ] I satisfied the flow checker in a very naive way for a few cases, using `any` instead of the appropriate type because I couldn't find the correct types in the flow docs for documentElement and contentWindow (I apologize for this, I'm not a flow expert by any means).
- Finally, I had to create a closure [here](https://github.com/bvaughn/react-virtualized/compare/master...mkralla11:iframe?expand=1#diff-781ced233be16fea033614f03e3054f2R25) to allow the document to be available for the given scope due to the way this module has been implemented already (not a huge issue, but I want to make sure it was known.)


solves issue https://github.com/bvaughn/react-virtualized/issues/1088


