### PR TITLE
No `setState(null)`

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -1440,7 +1440,6 @@ class Grid extends React.PureComponent<Props, State> {
       stateUpdate.needToResetStyleCache = false;
       this.setState(stateUpdate);
     }
-    return null;
   }
 
   static _wrapSizeGetter(value: CellSize): CellSizeGetter {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -459,7 +459,7 @@ class Grid extends React.PureComponent<Props, State> {
             : SCROLL_DIRECTION_BACKWARD
           : this.state.scrollDirectionVertical;
 
-      const newState: Object = {
+      const newState: $Shape<State> = {
         isScrolling: true,
         scrollDirectionHorizontal,
         scrollDirectionVertical,
@@ -597,10 +597,10 @@ class Grid extends React.PureComponent<Props, State> {
     // In that event we need to remeasure.
     if (!instanceProps.scrollbarSizeMeasured) {
       this.setState(prevState => {
-        prevState.instanceProps.scrollbarSize = getScrollbarSize();
-        prevState.instanceProps.scrollbarSizeMeasured = true;
-        prevState.needToResetStyleCache = false;
-        return prevState;
+        const stateUpdate = {...prevState, needToResetStyleCache: false};
+        stateUpdate.instanceProps.scrollbarSize = getScrollbarSize();
+        stateUpdate.instanceProps.scrollbarSizeMeasured = true;
+        return stateUpdate;
       });
     }
 
@@ -608,18 +608,15 @@ class Grid extends React.PureComponent<Props, State> {
       (typeof scrollLeft === 'number' && scrollLeft >= 0) ||
       (typeof scrollTop === 'number' && scrollTop >= 0)
     ) {
-      this.setState(prevState => {
-        const stateUpdate = Grid._getScrollToPositionStateUpdate({
-          prevState,
-          scrollLeft,
-          scrollTop,
-        });
-        if (stateUpdate) {
-          stateUpdate.needToResetStyleCache = false;
-          return stateUpdate;
-        }
-        return null;
+      const stateUpdate = Grid._getScrollToPositionStateUpdate({
+        prevState: this.state,
+        scrollLeft,
+        scrollTop,
       });
+      if (stateUpdate) {
+        stateUpdate.needToResetStyleCache = false;
+        this.setState(stateUpdate);
+      }
     }
 
     // setting the ref's scrollLeft and scrollTop.
@@ -1433,19 +1430,17 @@ class Grid extends React.PureComponent<Props, State> {
    * Useful for animating position changes.
    */
   scrollToPosition({scrollLeft, scrollTop}: ScrollPosition) {
-    this.setState(prevState => {
-      const stateUpdate = Grid._getScrollToPositionStateUpdate({
-        prevState,
-        scrollLeft,
-        scrollTop,
-      });
-
-      if (stateUpdate) {
-        stateUpdate.needToResetStyleCache = false;
-        return stateUpdate;
-      }
-      return null;
+    const stateUpdate = Grid._getScrollToPositionStateUpdate({
+      prevState: this.state,
+      scrollLeft,
+      scrollTop,
     });
+
+    if (stateUpdate) {
+      stateUpdate.needToResetStyleCache = false;
+      this.setState(stateUpdate);
+    }
+    return null;
   }
 
   static _wrapSizeGetter(value: CellSize): CellSizeGetter {
@@ -1527,8 +1522,8 @@ class Grid extends React.PureComponent<Props, State> {
     );
     if (stateUpdate) {
       stateUpdate.needToResetStyleCache = false;
+      this.setState(stateUpdate);
     }
-    this.setState(stateUpdate);
   }
 
   static _getCalculatedScrollTop(nextProps: Props, prevState: State) {
@@ -1623,8 +1618,8 @@ class Grid extends React.PureComponent<Props, State> {
     );
     if (stateUpdate) {
       stateUpdate.needToResetStyleCache = false;
+      this.setState(stateUpdate);
     }
-    this.setState(stateUpdate);
   }
 
   _onScroll = (event: Event) => {


### PR DESCRIPTION
fixes: #1119 

react 15 throws warning when `setState` is called with `null` or `{}`
