### PR TITLE
Remove pinnng scrollTop to 0

### DIFF
--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -133,6 +133,41 @@ describe('WindowScroller', () => {
     delete document.documentElement.getBoundingClientRect;
   });
 
+  it('should have negative scrollTop values if there is content above the WindowScroller on initial render', () => {
+    const renderFn = jest.fn();
+
+    // Simulate scrolled documentElement
+    const component = render(
+      getMarkup({
+        headerElements: <div style={{height: 501}} />,
+        renderFn,
+      }),
+    );
+    expect(renderFn).lastCalledWith(
+      expect.objectContaining({
+        scrollTop: -501,
+      }),
+    );
+  });
+
+  it('should have negative scrollTop values if there is content above the WindowScroller and there is a scroll', () => {
+    const renderFn = jest.fn();
+
+    // Simulate scrolled documentElement
+    const component = render(
+      getMarkup({
+        headerElements: <div style={{height: 501}} />,
+        renderFn,
+      }),
+    );
+    simulateWindowScroll({scrollY: 1});
+    expect(renderFn).lastCalledWith(
+      expect.objectContaining({
+        scrollTop: -500,
+      }),
+    );
+  });
+
   it('inherits the window height and passes it to child component', () => {
     const renderFn = jest.fn();
     const component = render(getMarkup({renderFn}));

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -239,7 +239,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
         0,
         scrollOffset.left - this._positionFromLeft,
       );
-      const scrollTop = Math.max(0, scrollOffset.top - this._positionFromTop);
+      const scrollTop = scrollOffset.top - this._positionFromTop;
 
       this.setState({
         isScrolling: true,


### PR DESCRIPTION
This is done so that if there are elements which appear above the current element, scrollOffset.top - this._positionFromTop will return a negative number thereby correctly telling the child that it is not being rendered. This allows the child to render only when it becomes necessary to do so as opposed to rendering always.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

Can add a test later if you feel necessary. I first want to see if there is a reason that this shouldnt be done.