### PR TITLE
docs(badge): npm badge links to npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [<img src="https://cloud.githubusercontent.com/assets/29597/11737732/0ca1e55e-9f91-11e5-97f3-098f2f8ed866.png" alt="React virtualized" data-canonical-src="https://cloud.githubusercontent.com/assets/29597/11737732/0ca1e55e-9f91-11e5-97f3-098f2f8ed866.png" width="330" height="100" />](http://bvaughn.github.io/react-virtualized/)
 
-![NPM version](https://img.shields.io/npm/v/react-virtualized.svg?style=flat)
+[![NPM version](https://img.shields.io/npm/v/react-virtualized.svg?style=flat)](https://www.npmjs.com/package/react-virtualized)
 ![NPM license](https://img.shields.io/npm/l/react-virtualized.svg?style=flat)
 [![NPM total downloads](https://img.shields.io/npm/dt/react-virtualized.svg?style=flat)](https://npmcharts.com/compare/react-virtualized?minimal=true)
 [![NPM monthly downloads](https://img.shields.io/npm/dm/react-virtualized.svg?style=flat)](https://npmcharts.com/compare/react-virtualized?minimal=true)


### PR DESCRIPTION
npm badges often link to the npm package description for convenience.  I noticed this because I clicked the badge to view the npm package description page.

##### Testing

1. In the PR diff, click the "Display the rich diff" button to see Markdown rendered correctly.

**Before submitting a pull request,** please complete the following checklist:

- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bvaughn/react-virtualized/1146)
<!-- Reviewable:end -->
