### PR TITLE
fix for #998 Reseting scrollUp/scrollLeft to scrollToRow/scrollToColumn incorrectly

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -654,6 +654,56 @@ describe('Grid', () => {
       expect(node.scrollTop).toBe(1920);
     });
 
+    it('should not restore scrollLeft when scrolling left and recomputeGridSize with columnIndex smaller than scrollToColumn', () => {
+      const props = {
+        columnWidth: 50,
+        columnCount: 100,
+        height: 100,
+        rowCount: 100,
+        rowHeight: 20,
+        scrollToColumn: 50,
+        scrollToRow: 50,
+        width: 100,
+      };
+      const grid = render(getMarkup(props));
+
+      expect(grid.state.scrollLeft).toEqual(2450);
+
+      simulateScroll({grid, scrollLeft: 2250});
+      expect(grid.state.scrollLeft).toEqual(2250);
+      expect(grid.state.scrollDirectionHorizontal).toEqual(
+        SCROLL_DIRECTION_BACKWARD,
+      );
+
+      grid.recomputeGridSize({columnIndex: 30});
+      expect(grid.state.scrollLeft).toEqual(2250);
+    });
+
+    it('should not restore scrollTop when scrolling up and recomputeGridSize with rowIndex smaller than scrollToRow', () => {
+      const props = {
+        columnWidth: 50,
+        columnCount: 100,
+        height: 100,
+        rowCount: 100,
+        rowHeight: 20,
+        scrollToColumn: 50,
+        scrollToRow: 50,
+        width: 100,
+      };
+      const grid = render(getMarkup(props));
+
+      expect(grid.state.scrollTop).toEqual(920);
+
+      simulateScroll({grid, scrollTop: 720});
+      expect(grid.state.scrollTop).toEqual(720);
+      expect(grid.state.scrollDirectionVertical).toEqual(
+        SCROLL_DIRECTION_BACKWARD,
+      );
+
+      grid.recomputeGridSize({rowIndex: 20});
+      expect(grid.state.scrollTop).toEqual(720);
+    });
+
     it('should restore scroll offset for column when row count increases from 0 (and vice versa)', () => {
       const props = {
         columnWidth: 50,

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -543,8 +543,15 @@ class Grid extends React.PureComponent<Props, State> {
     // In this case the cDU handler can't know if they changed.
     // Store this flag to let the next cDU pass know it needs to recompute the scroll offset.
     this._recomputeScrollLeftFlag =
-      scrollToColumn >= 0 && columnIndex <= scrollToColumn;
-    this._recomputeScrollTopFlag = scrollToRow >= 0 && rowIndex <= scrollToRow;
+      scrollToColumn >= 0 &&
+      (this.state.scrollDirectionHorizontal === SCROLL_DIRECTION_FORWARD
+        ? columnIndex <= scrollToColumn
+        : columnIndex >= scrollToColumn);
+    this._recomputeScrollTopFlag =
+      scrollToRow >= 0 &&
+      (this.state.scrollDirectionVertical === SCROLL_DIRECTION_FORWARD
+        ? rowIndex <= scrollToRow
+        : rowIndex >= scrollToRow);
 
     // Clear cell cache in case we are scrolling;
     // Invalid row heights likely mean invalid cached content as well.


### PR DESCRIPTION
The original fix #1001 for the issue #998 is reverted because of failing tests due to upgrading to React 16. I create two tests to verify that scrollUp/scrollLeft are not reset to scrollToRow/scrollToColumn when recompute grid size with index less than scrollToIndex.

closes #998 


**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
