### PR TITLE
removing sideEffects in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
   "jsnext:main": "dist/es/index.js",
-  "sideEffects": false,
   "license": "MIT",
   "scripts": {
     "build:types": "flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/WindowScroller dist/es/WindowScroller && flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/AutoSizer dist/es/AutoSizer",


### PR DESCRIPTION
closes: #1135 

`sideEffects: false` causes webpack css-loader to drop css files when importing

- [x] The existing test suites (`npm test`) all pass
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).