### PR TITLE
Expose container ref in Grid

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -97,6 +97,9 @@ type Props = {
   /** Unfiltered props for the Grid container. */
   containerProps?: Object,
 
+  /** Callback to access container ref. */
+  containerRef?: (ref: Element) => void,
+
   /** ARIA role for the cell-container.  */
   containerRole: string,
 
@@ -1381,6 +1384,9 @@ class Grid extends React.PureComponent<Props, State> {
 
   _setScrollingContainerRef = (ref: Element) => {
     this._scrollingContainer = ref;
+    if (this.props.containerRef) {
+      this.props.containerRef(ref);
+    }
   };
 
   /**


### PR DESCRIPTION
Hey!

I need to be able to imperatively call `ref.scroll({ left: n, behavior: 'smooth' })` on the container of a virtualized grid based on users clicking a button - at present the lib doesn't have any way to expose that ref, think the simple approach here should work? Is this something you'd support?

Not sure if this really counts as a feature which needs testing or documentation, so I've left those for now.

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).