### PR TITLE
Allow users to override default table row styles

### DIFF
--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -392,11 +392,11 @@ export default class Table extends React.PureComponent {
             className: cn('ReactVirtualized__Table__headerRow', rowClass),
             columns: this._getHeaderColumns(),
             style: {
-              ...rowStyleObject,
               height: headerHeight,
               overflow: 'hidden',
               paddingRight: scrollbarWidth,
               width: width,
+              ...rowStyleObject,
             },
           })}
 
@@ -613,10 +613,10 @@ export default class Table extends React.PureComponent {
     const className = cn('ReactVirtualized__Table__row', rowClass);
     const flattenedStyle = {
       ...style,
-      ...rowStyleObject,
       height: this._getRowHeight(index),
       overflow: 'hidden',
       paddingRight: scrollbarWidth,
+      ...rowStyleObject,
     };
 
     return rowRenderer({


### PR DESCRIPTION
This allows users to override default row styles on tables with a style object.

Since the object was spread before the defaults, there was no way to override them, and users had to use a class.

Fixes  #1171 

I looked if this change should be made in other places, and didn't see anything, but please let me know if I missed something!