### PR TITLE
docs(CellMeasurer): fix `import` statement

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -116,7 +116,7 @@ To support this, a function-child is passed to `CellMeasurer` which then receive
 
 ```jsx
 import React from 'react';
-import { CellMeasurer, CellMeasurerCache, Grid } from 'react-virtualized';
+import { CellMeasurer, CellMeasurerCache, List } from 'react-virtualized';
 
 // In this example, average cell height is assumed to be about 50px.
 // This value will be used for the initial `Grid` layout.


### PR DESCRIPTION
The `Grid` component isn't used in this example, it was probably a remnant of copy-pasting or something.

As a side note, the `CellMeasurer` [example](https://bvaughn.github.io/react-virtualized/#/wizard) in the wizard seems to be outdated and doesn't work with the recommended props. Just figured I'd mention it as it through me for a loop, if you'd like me to create a ticket I'd be happy to.