### PR TITLE
unify render of fixed column grids (bottomLeft) with fixed row grids …

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -617,7 +617,7 @@ class MultiGrid extends React.PureComponent {
       rowCount,
       hideBottomLeftGridScrollbar,
     } = props;
-    const {showVerticalScrollbar} = this.state;
+    const {showVerticalScrollbar, scrollbarSize} = this.state;
 
     if (!fixedColumnCount) {
       return null;
@@ -632,12 +632,11 @@ class MultiGrid extends React.PureComponent {
       style = this._bottomLeftGridStyle;
 
     if (hideBottomLeftGridScrollbar) {
-      console.log("hideBottomLeftGridScrollbar")
       gridWidth = width + additionalWidth;
       style = {
         ...this._bottomLeftGridStyle,
-        top: 0
-      }
+        top: 0,
+      };
     }
 
     const bottomLeftGrid = (

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -626,10 +626,19 @@ class MultiGrid extends React.PureComponent {
     const additionalRowCount = showVerticalScrollbar ? 1 : 0,
       height = this._getBottomGridHeight(props),
       width = this._getLeftGridWidth(props),
-      scrollbarSize = this.state.showVerticalScrollbar
-        ? this.state.scrollbarSize
-        : 0,
-      gridWidth = hideBottomLeftGridScrollbar ? width + scrollbarSize : width;
+      additionalWidth = showVerticalScrollbar ? scrollbarSize : 0;
+
+    let gridWidth = width,
+      style = this._bottomLeftGridStyle;
+
+    if (hideBottomLeftGridScrollbar) {
+      console.log("hideBottomLeftGridScrollbar")
+      gridWidth = width + additionalWidth;
+      style = {
+        ...this._bottomLeftGridStyle,
+        top: 0
+      }
+    }
 
     const bottomLeftGrid = (
       <Grid
@@ -643,7 +652,7 @@ class MultiGrid extends React.PureComponent {
         ref={this._bottomLeftGridRef}
         rowCount={Math.max(0, rowCount - fixedRowCount) + additionalRowCount}
         rowHeight={this._rowHeightBottomGrid}
-        style={this._bottomLeftGridStyle}
+        style={style}
         tabIndex={null}
         width={gridWidth}
       />


### PR DESCRIPTION
Currently when using `ArrowKeyStepper` in conjunction with a `MultiGrid` that has fixed rows, the `bottomLeftGrid` will not update when the `scrollToColumn` or `scrollToRow` values change. All other instances of `Grid` will update.

The reason the component does not update is, unlike `topRightGrid` the `style` object is not recreated on `render` and the no other properties on the component change, thus `PureComponent` will not update the `Grid`. 

This fix is *only* for when `hideBottomLeftGridScrollbar` is set to `true`. The issue exists for both `bottomLeftGrid` and `topRightGrid` when their corresponding hide scrollbar properties are false.

This is also only a work around, but given that the code diverged from how `topRightGrid` renders, this makes things consistent between the two render methods. It's probably better to do something like set `scrollToColumn` and `scrollToRow` on both components since that value will change in these cases.

I do not think there are any test cases that need updating as this is more of an integration and code issue and the individual pieces are functioning correctly.