### PR TITLE
Recompute range when total size and consequentely safe offset is changed

### DIFF
--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -132,15 +132,29 @@ export default class ScalingCellSizeAndPositionManager {
     containerSize,
     offset, // safe
   }: ContainerSizeAndOffset): VisibleCellRange {
-    offset = this._safeOffsetToOffset({
+    let safeOffset = this._safeOffsetToOffset({
       containerSize,
       offset,
     });
-
-    return this._cellSizeAndPositionManager.getVisibleCellRange({
+    let range = this._cellSizeAndPositionManager.getVisibleCellRange({
       containerSize,
-      offset,
+      offset: safeOffset,
     });
+    while (true) {
+      const safeOffset1 = this._safeOffsetToOffset({
+        containerSize,
+        offset,
+      });
+      if (safeOffset === safeOffset1) {
+        break;
+      }
+      safeOffset = safeOffset1;
+      range = this._cellSizeAndPositionManager.getVisibleCellRange({
+        containerSize,
+        offset: safeOffset,
+      });
+    }
+    return range;
   }
 
   resetCell(index: number): void {

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -140,7 +140,7 @@ export default class ScalingCellSizeAndPositionManager {
       containerSize,
       offset: safeOffset,
     });
-    while (true) {
+    for (;;) {
       const safeOffset1 = this._safeOffsetToOffset({
         containerSize,
         offset,


### PR DESCRIPTION
This fix is needed to avoid to show the wrong range in presence of a dynamic height list with an huge count of rows (i.e. a total height in pixel greater than browser limit).

- [x] The existing test suites (`npm test`) all pass

yarn test succeeds without any failure

- [ ] For any new features or bug fixes, both positive and negative test cases have been added

- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).

yarn prettier is ok

- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).
