### PR TITLE
Fix #1004 Update MultiGrid width and height when cell width or height is changed by getter function

### DIFF
--- a/source/MultiGrid/MultiGrid.jest.js
+++ b/source/MultiGrid/MultiGrid.jest.js
@@ -309,8 +309,8 @@ describe('MultiGrid', () => {
       expect(bottomLeftAfter.style.getPropertyValue('width')).toEqual('75px');
       expect(bottomRightAfter.style.getPropertyValue('width')).toEqual('325px');
     });
-	
-	it('should update the MultiGrid width when cell height changes by getter function', () => {
+
+    it('should update the MultiGrid width when cell height changes by getter function', () => {
       let rowHeights = [30, 30, 30, 30, 30];
       function getRowHeight({index}) {
         return rowHeights[index] || 30;
@@ -347,13 +347,13 @@ describe('MultiGrid', () => {
       expect(bottomLeft.style.getPropertyValue('height')).toEqual('250px');
       expect(bottomRight.style.getPropertyValue('height')).toEqual('250px');
     });
-	
-	it('should update the MultiGrid width when cell width changes by getter function', () => {
+
+    it('should update the MultiGrid width when cell width changes by getter function', () => {
       let columnWidths = [100, 100, 100, 100, 100];
       function getCoumnWidth({index}) {
         return columnWidths[index];
       }
-      
+
       let multiGrid;
       let rendered = findDOMNode(
         render(
@@ -376,7 +376,7 @@ describe('MultiGrid', () => {
       expect(topRight.style.getPropertyValue('width')).toEqual('300px');
       expect(bottomLeft.style.getPropertyValue('width')).toEqual('100px');
       expect(bottomRight.style.getPropertyValue('width')).toEqual('300px');
-      
+
       columnWidths = [80, 100, 100, 100, 100];
       multiGrid.recomputeGridSize();
 

--- a/source/MultiGrid/MultiGrid.jest.js
+++ b/source/MultiGrid/MultiGrid.jest.js
@@ -309,6 +309,82 @@ describe('MultiGrid', () => {
       expect(bottomLeftAfter.style.getPropertyValue('width')).toEqual('75px');
       expect(bottomRightAfter.style.getPropertyValue('width')).toEqual('325px');
     });
+	
+	it('should update the MultiGrid width when cell height changes by getter function', () => {
+      let rowHeights = [30, 30, 30, 30, 30];
+      function getRowHeight({index}) {
+        return rowHeights[index] || 30;
+      }
+
+      let multiGrid;
+      let rendered = findDOMNode(
+        render(
+          getMarkup({
+            fixedColumnCount: 1,
+            fixedRowCount: 1,
+            rowHeight: getRowHeight,
+            columnWidth: 100,
+            ref: ref => {
+              multiGrid = ref;
+            },
+          }),
+        ),
+      );
+
+      let grids = rendered.querySelectorAll('.ReactVirtualized__Grid');
+      expect(grids.length).toEqual(4);
+      let [topLeft, topRight, bottomLeft, bottomRight] = grids;
+      expect(topLeft.style.getPropertyValue('height')).toEqual('30px');
+      expect(topRight.style.getPropertyValue('height')).toEqual('30px');
+      expect(bottomLeft.style.getPropertyValue('height')).toEqual('270px');
+      expect(bottomRight.style.getPropertyValue('height')).toEqual('270px');
+
+      rowHeights = [50, 30, 30, 30, 30];
+      multiGrid.recomputeGridSize();
+
+      expect(topLeft.style.getPropertyValue('height')).toEqual('50px');
+      expect(topRight.style.getPropertyValue('height')).toEqual('50px');
+      expect(bottomLeft.style.getPropertyValue('height')).toEqual('250px');
+      expect(bottomRight.style.getPropertyValue('height')).toEqual('250px');
+    });
+	
+	it('should update the MultiGrid width when cell width changes by getter function', () => {
+      let columnWidths = [100, 100, 100, 100, 100];
+      function getCoumnWidth({index}) {
+        return columnWidths[index];
+      }
+      
+      let multiGrid;
+      let rendered = findDOMNode(
+        render(
+          getMarkup({
+            fixedColumnCount: 1,
+            fixedRowCount: 1,
+            rowHeight: 30,
+            columnWidth: getCoumnWidth,
+            ref: ref => {
+              multiGrid = ref;
+            },
+          }),
+        ),
+      );
+
+      let grids = rendered.querySelectorAll('.ReactVirtualized__Grid');
+      expect(grids.length).toEqual(4);
+      let [topLeft, topRight, bottomLeft, bottomRight] = grids;
+      expect(topLeft.style.getPropertyValue('width')).toEqual('100px');
+      expect(topRight.style.getPropertyValue('width')).toEqual('300px');
+      expect(bottomLeft.style.getPropertyValue('width')).toEqual('100px');
+      expect(bottomRight.style.getPropertyValue('width')).toEqual('300px');
+      
+      columnWidths = [80, 100, 100, 100, 100];
+      multiGrid.recomputeGridSize();
+
+      expect(topLeft.style.getPropertyValue('width')).toEqual('80px');
+      expect(topRight.style.getPropertyValue('width')).toEqual('320px');
+      expect(bottomLeft.style.getPropertyValue('width')).toEqual('80px');
+      expect(bottomRight.style.getPropertyValue('width')).toEqual('320px');
+    });
   });
 
   describe('scrollToColumn and scrollToRow', () => {

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -156,15 +156,18 @@ class MultiGrid extends React.PureComponent {
         columnIndex: adjustedColumnIndex,
         rowIndex,
       });
-	  
+
     const oldLeftGridWidth = this._leftGridWidth;
     const oldTopGridHeight = this._topGridHeight;
     this._leftGridWidth = null;
     this._topGridHeight = null;
     this._maybeCalculateCachedStyles(true);
-	if (oldLeftGridWidth !== this._leftGridWidth || oldTopGridHeight !== this._topGridHeight) {
-       this.forceUpdate();
-     }
+    if (
+      oldLeftGridWidth !== this._leftGridWidth ||
+      oldTopGridHeight !== this._topGridHeight
+    ) {
+      this.forceUpdate();
+    }
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -156,10 +156,15 @@ class MultiGrid extends React.PureComponent {
         columnIndex: adjustedColumnIndex,
         rowIndex,
       });
-
+	  
+    const oldLeftGridWidth = this._leftGridWidth;
+    const oldTopGridHeight = this._topGridHeight;
     this._leftGridWidth = null;
     this._topGridHeight = null;
     this._maybeCalculateCachedStyles(true);
+	if (oldLeftGridWidth !== this._leftGridWidth || oldTopGridHeight !== this._topGridHeight) {
+       this.forceUpdate();
+     }
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {


### PR DESCRIPTION
Based on an existing pull request for this same issue (https://github.com/bvaughn/react-virtualized/pull/1007), I made the requested changes since the original pull request has not been updated in a long time.

Essentially this fixes the issue in MultiGrid where if you had a fixed column/row and the width/height of a cell within the fixed column/row changed, it would not update the grid to reflect the new width/height.

There are 2 tests to cover the height and width scenarios (the tests are from the first pull request). 