### PR TITLE
Add onColumnClick to Table

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -22,6 +22,7 @@ This component expects explicit `width` and `height` parameters.
 | height | Number | ✓ | Fixed/available height for out DOM element |
 | id | String |  | Optional custom id to attach to root `Table` element. |
 | noRowsRenderer | Function |  | Callback used to render placeholder content when :rowCount is 0 |
+| onColumnClick | Function |  | Callback invoked when a user clicks on a table column. `({ columnData: any, dataKey: string, event: Event }): void` |
 | onHeaderClick | Function |  | Callback invoked when a user clicks on a table header. `({ columnData: any, dataKey: string, event: Event }): void` |
 | onRowClick | Function |  | Callback invoked when a user clicks on a table row. `({ event: Event, index: number, rowData: any }): void` |
 | onRowDoubleClick | Function |  | Callback invoked when a user double-clicks on a table row. `({ event: Event, index: number, rowData: any }): void` |

--- a/source/Table/Table.jest.js
+++ b/source/Table/Table.jest.js
@@ -702,6 +702,30 @@ describe('Table', () => {
     });
   });
 
+  describe('onColumnClick', () => {
+    it('should call :onColumnClick with the correct arguments when a column is clicked', () => {
+      const onColumnClick = jest.fn();
+      const rendered = findDOMNode(
+        render(
+          getMarkup({
+            onColumnClick,
+          }),
+        ),
+      );
+      const nameColumn = rendered.querySelector(
+        '.ReactVirtualized__Table__rowColumn:first-of-type',
+      );
+
+      Simulate.click(nameColumn);
+
+      expect(onColumnClick).toHaveBeenCalledTimes(1);
+      const params = onColumnClick.mock.calls[0][0];
+      expect(params.dataKey).toEqual('name');
+      expect(params.columnData.data).toEqual(123);
+      expect(params.event.type).toEqual('click');
+    });
+  });
+
   describe('onHeaderClick', () => {
     it('should call :onHeaderClick with the correct arguments when a column header is clicked and sorting is disabled', () => {
       const onHeaderClick = jest.fn();

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -85,6 +85,12 @@ export default class Table extends React.PureComponent {
     noRowsRenderer: PropTypes.func,
 
     /**
+     * Optional callback when a column is clicked.
+     * ({ columnData: any, dataKey: string }): void
+     */
+    onColumnClick: PropTypes.func,
+
+    /**
      * Optional callback when a column's header is clicked.
      * ({ columnData: any, dataKey: string }): void
      */
@@ -426,6 +432,7 @@ export default class Table extends React.PureComponent {
   }
 
   _createColumn({column, columnIndex, isScrolling, parent, rowData, rowIndex}) {
+    const {onColumnClick} = this.props;
     const {
       cellDataGetter,
       cellRenderer,
@@ -447,6 +454,10 @@ export default class Table extends React.PureComponent {
       rowIndex,
     });
 
+    const onClick = event => {
+      onColumnClick && onColumnClick({columnData, dataKey, event});
+    };
+
     const style = this._cachedColumnStyles[columnIndex];
 
     const title = typeof renderedCell === 'string' ? renderedCell : null;
@@ -459,6 +470,7 @@ export default class Table extends React.PureComponent {
         aria-describedby={id}
         className={cn('ReactVirtualized__Table__rowColumn', className)}
         key={'Row' + rowIndex + '-' + 'Col' + columnIndex}
+        onClick={onClick}
         role="gridcell"
         style={style}
         title={title}>


### PR DESCRIPTION
This change adds `onColumnClick` to `Table`, works the same way as `onHeaderClick`.

I was attaching `onClick` in my `Column` `cellRenderer`, but it doesn't work when the cell is empty. Attaching to the `div` in `_createColumn` works regardless. 