### PR TITLE
Fix incorrect inline style of width rendered on the server-side

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -90,7 +90,12 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
   _child: ?Element;
 
   state = {
-    ...getDimensions(this.props.scrollElement, this.props),
+    ...getDimensions(
+      this.props.serverHeight > 0 || this.props.serverWidth > 0
+        ? null
+        : this.props.scrollElement,
+      this.props,
+    ),
     isScrolling: false,
     scrollLeft: 0,
     scrollTop: 0,


### PR DESCRIPTION
When rendering on the server-side with the `WindowScroller` component,
the `serverHeight` and `serverWidth` props must be specified,
otherwise, nothing would be rendered.

Unfortunately, most of the time, we can only guess values
for these two props when rendering on the server-side.

There is a `width: ${this.state.width}px` inline style
rendered on the server-side on the inner `Grid` component,
and the value of `this.state.width` is derived from `serverWidth`.

Since the value of `serverWidth` is not likely equal to window's width,
`this.state.width` must be fixed on the client-side when the component mounted
and then triggering a re-rendering for the `WindowScroll` component
with the correct value.

But the `this.state.width` is initialized to a CORRECT value on the client-side,
that make the call to `updatePosition()` in `componentDidMount()` useless.
Hence the INCORRECT inline style would never be fixed
unless the user resizes the browser window.

This fix initialized `this.state.width` with the value of`serverWidth`
on the client-side if `serverWidth` is specified,
so that the call to `updatePosition()` in `componentDidMount()`
can actually trigger a re-rendering.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [ ] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
