### PR TITLE
Fix #1159: CollectionView scrollTop/scrollLeft

### DIFF
--- a/source/Collection/Collection.jest.js
+++ b/source/Collection/Collection.jest.js
@@ -457,7 +457,7 @@ describe('Collection', () => {
   describe(':scrollLeft and :scrollTop properties', () => {
     it('should render correctly when an initial :scrollLeft and :scrollTop properties are specified', () => {
       let indices;
-      render(
+      const collection = render(
         getMarkup({
           onSectionRendered: params => {
             indices = params.indices;
@@ -467,6 +467,9 @@ describe('Collection', () => {
         }),
       );
       compareArrays(indices, [3, 4, 5, 7, 8, 9]);
+      expect(
+        collection._collectionView.state.scrollPositionChangeReason,
+      ).toEqual('requested');
     });
 
     it('should render correctly when :scrollLeft and :scrollTop properties are updated', () => {
@@ -479,7 +482,7 @@ describe('Collection', () => {
         }),
       );
       compareArrays(indices, [0, 1, 2, 3]);
-      render(
+      const collection = render(
         getMarkup({
           onSectionRendered: params => {
             indices = params.indices;
@@ -489,6 +492,9 @@ describe('Collection', () => {
         }),
       );
       compareArrays(indices, [3, 4, 5, 7, 8, 9]);
+      expect(
+        collection._collectionView.state.scrollPositionChangeReason,
+      ).toEqual('requested');
     });
   });
 

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -193,6 +193,7 @@ class CollectionView extends React.PureComponent {
       return {
         scrollLeft: 0,
         scrollTop: 0,
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.REQUESTED,
       };
     } else if (
       nextProps.scrollLeft !== prevState.scrollLeft ||
@@ -207,6 +208,7 @@ class CollectionView extends React.PureComponent {
           nextProps.scrollTop != null
             ? nextProps.scrollTop
             : prevState.scrollTop,
+        scrollPositionChangeReason: SCROLL_POSITION_CHANGE_REASONS.REQUESTED,
       };
     }
 


### PR DESCRIPTION
Props scrollTop/scrollLeft are only applied when this.state.scrollPositionChangeReason is REQUESTED, but getDerivedStateFromProps was not setting scrollPositionChangeReason. This meant that these props were not being applied to the view.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added - N/A
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners - N/A
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

closes #1159 