### PR TITLE
When scrollToAlignment is 'auto' and list item height is greater than list height, list item will be scrolled into view with 'start' alignment instead of 'auto'.

### DIFF
--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -196,7 +196,9 @@ export default class CellSizeAndPositionManager {
         idealOffset = maxOffset - (containerSize - datum.size) / 2;
         break;
       default:
-        idealOffset = Math.max(minOffset, Math.min(maxOffset, currentOffset));
+        if (datum.size >= containerSize) idealOffset = maxOffset;
+        else
+          idealOffset = Math.max(minOffset, Math.min(maxOffset, currentOffset));
         break;
     }
 


### PR DESCRIPTION
Fixes #1263
See this issue that was added by me. This PR solves this issue.

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).
