### PR TITLE
Fix for delayed render on iOS and Mac during negative scroll bounce

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -416,9 +416,9 @@ class Grid extends React.PureComponent<Props, State> {
     scrollTop: scrollTopParam = 0,
   }: ScrollPosition) {
     // On iOS, we can arrive at negative offsets by swiping past the start.
-    // To prevent flicker here, we make playing in the negative offset zone cause nothing to happen.
+    // To prevent flicker here, we treat negative values as if they are zero
     if (scrollTopParam < 0) {
-      return;
+      scrollTopParam = 0;
     }
 
     // Prevent pointer events from interrupting a smooth scroll


### PR DESCRIPTION
Hello,

Several of our teams at Adobe are using react-virtualized as part of a native rendering platform. We have an issue where the top rows don't render when you quickly scroll up to the top on a Mac while the scroll bounce animation is causing negative scrollTop values.

This problem likely happens on the web as well IF the rendering of the rows is sufficiently slow. That may make reproducing the original bug difficult.

By removing the early return and simply treating negative values the same as zero we resolve the issue.

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).
