### PR TITLE
refactor(InfiniteLoader.js): replace inefficient abuse of reduce

### DIFF
--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -134,9 +134,12 @@ export default class InfiniteLoader extends React.PureComponent {
     });
 
     // For memoize comparison
-    const squashedUnloadedRanges = [].concat(...unloadedRanges.map(
-      ({startIndex, stopIndex}) => [startIndex, stopIndex]
-    ));
+    const squashedUnloadedRanges = [].concat(
+      ...unloadedRanges.map(({startIndex, stopIndex}) => [
+        startIndex,
+        stopIndex,
+      ]),
+    );
 
     this._loadMoreRowsMemoizer({
       callback: () => {

--- a/source/InfiniteLoader/InfiniteLoader.js
+++ b/source/InfiniteLoader/InfiniteLoader.js
@@ -134,11 +134,9 @@ export default class InfiniteLoader extends React.PureComponent {
     });
 
     // For memoize comparison
-    const squashedUnloadedRanges = unloadedRanges.reduce(
-      (reduced, unloadedRange) =>
-        reduced.concat([unloadedRange.startIndex, unloadedRange.stopIndex]),
-      [],
-    );
+    const squashedUnloadedRanges = [].concat(...unloadedRanges.map(
+      ({startIndex, stopIndex}) => [startIndex, stopIndex]
+    ));
 
     this._loadMoreRowsMemoizer({
       callback: () => {


### PR DESCRIPTION
Unless VMs specifically optimize this, doing `concat` inside of `reduce` is wasteful because it creates an array of length 1, then an array of length 2, etc. costing `O(n^2)` time and space.  `[].concat(...stuff.map(...))` does the same thing in `O(n)` time and space.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [ ] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
