### PR TITLE
Fix case when scrollToPosition will not update internal state in React >= 16.4.

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -232,6 +232,8 @@ type InstanceProps = {
   prevIsScrolling: boolean,
   prevScrollToColumn: number,
   prevScrollToRow: number,
+  prevScrollLeft: ?number,
+  prevScrollTop: ?number,
 
   columnSizeAndPositionManager: ScalingCellSizeAndPositionManager,
   rowSizeAndPositionManager: ScalingCellSizeAndPositionManager,
@@ -343,6 +345,8 @@ class Grid extends React.PureComponent<Props, State> {
         prevIsScrolling: props.isScrolling === true,
         prevScrollToColumn: props.scrollToColumn,
         prevScrollToRow: props.scrollToRow,
+        prevScrollLeft: props.scrollLeft,
+        prevScrollTop: props.scrollTop,
 
         scrollbarSize: 0,
         scrollbarSizeMeasured: false,
@@ -350,8 +354,8 @@ class Grid extends React.PureComponent<Props, State> {
       isScrolling: false,
       scrollDirectionHorizontal: SCROLL_DIRECTION_FORWARD,
       scrollDirectionVertical: SCROLL_DIRECTION_FORWARD,
-      scrollLeft: 0,
-      scrollTop: 0,
+      scrollLeft: props.scrollLeft || 0,
+      scrollTop: props.scrollTop || 0,
       scrollPositionChangeReason: null,
 
       needToResetStyleCache: false,
@@ -821,6 +825,7 @@ class Grid extends React.PureComponent<Props, State> {
     prevState: State,
   ): $Shape<State> {
     const newState = {};
+    let {instanceProps} = prevState;
 
     if (
       (nextProps.columnCount === 0 && prevState.scrollLeft !== 0) ||
@@ -832,9 +837,10 @@ class Grid extends React.PureComponent<Props, State> {
       // only use scroll{Left,Top} from props if scrollTo{Column,Row} isn't specified
       // scrollTo{Column,Row} should override scroll{Left,Top}
     } else if (
-      (nextProps.scrollLeft !== prevState.scrollLeft &&
+      (nextProps.scrollLeft !== instanceProps.prevScrollLeft &&
         nextProps.scrollToColumn < 0) ||
-      (nextProps.scrollTop !== prevState.scrollTop && nextProps.scrollToRow < 0)
+      (nextProps.scrollTop !== instanceProps.prevScrollTop &&
+        nextProps.scrollToRow < 0)
     ) {
       Object.assign(
         newState,
@@ -845,8 +851,6 @@ class Grid extends React.PureComponent<Props, State> {
         }),
       );
     }
-
-    let {instanceProps} = prevState;
 
     // Initially we should not clearStyleCache
     newState.needToResetStyleCache = false;
@@ -944,6 +948,8 @@ class Grid extends React.PureComponent<Props, State> {
     instanceProps.prevRowHeight = nextProps.rowHeight;
     instanceProps.prevScrollToColumn = nextProps.scrollToColumn;
     instanceProps.prevScrollToRow = nextProps.scrollToRow;
+    instanceProps.prevScrollLeft = nextProps.scrollLeft;
+    instanceProps.prevScrollTop = nextProps.scrollTop;
 
     // getting scrollBarSize (moved from componentWillMount)
     instanceProps.scrollbarSize = nextProps.getScrollbarSize();


### PR DESCRIPTION
Fixes #1179 #1226

In cases when the Grid component is controlled (`WindowScroller`, `MultiGrid`) fields `scrollLeft `and `scrollTop` were not updated on `setState `call. `getDerivedStateFromProps`
is called before every render starting from React 16.4 and those fields were overridden by previous props.

it also fixes Lists `scrollToRow `behavior with the same problem.


**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
**This one can only be reproduced in React >= 16.4. What I should do?**
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).
