### PR TITLE
issue/696 : Multigrid falls out of sync with 50k+ items when scrollbars are on.

### DIFF
--- a/source/MultiGrid/MultiGrid.jest.js
+++ b/source/MultiGrid/MultiGrid.jest.js
@@ -299,7 +299,7 @@ describe('MultiGrid', () => {
       ] = gridsAfter;
       expect(topLeftAfter.style.getPropertyValue('height')).toEqual('125px');
       expect(topRightAfter.style.getPropertyValue('height')).toEqual('125px');
-      expect(bottomLeftAfter.style.getPropertyValue('height')).toEqual('175px');
+      expect(bottomLeftAfter.style.getPropertyValue('height')).toEqual('225px');
       expect(bottomRightAfter.style.getPropertyValue('height')).toEqual(
         '175px',
       );

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -470,9 +470,11 @@ class MultiGrid extends React.PureComponent {
       };
     }
 
+    const {showHorizontalScrollbar} = this.state;
     if (
       resetAll ||
-      styleBottomLeftGrid !== this._lastRenderedStyleBottomLeftGrid
+      styleBottomLeftGrid !== this._lastRenderedStyleBottomLeftGrid ||
+      showHorizontalScrollbar !== this._lastRenderedShowHorizontalScrollbar
     ) {
       this._bottomLeftGridStyle = {
         left: 0,
@@ -481,6 +483,16 @@ class MultiGrid extends React.PureComponent {
         position: 'absolute',
         ...styleBottomLeftGrid,
       };
+
+      // When bottomRightGrid has scrollbar add height style to bottomLeftGrid
+      // to compensate the difference of grids containers height,
+      // which appears due scrollbar size.
+      // Without of this, bottomLeftGrid cannot be scrolled to such position as
+      // bottomRightGrid, which happens at the end of the grid.
+      if (showHorizontalScrollbar) {
+        const {scrollbarSize} = this.state;
+        this._bottomLeftGridStyle.height = `calc(100% - ${scrollbarSize}px)`;
+      }
     }
 
     if (
@@ -532,6 +544,7 @@ class MultiGrid extends React.PureComponent {
     this._lastRenderedStyleTopLeftGrid = styleTopLeftGrid;
     this._lastRenderedStyleTopRightGrid = styleTopRightGrid;
     this._lastRenderedWidth = width;
+    this._lastRenderedShowHorizontalScrollbar = showHorizontalScrollbar;
   }
 
   _prepareForRender() {
@@ -617,14 +630,12 @@ class MultiGrid extends React.PureComponent {
       rowCount,
       hideBottomLeftGridScrollbar,
     } = props;
-    const {showVerticalScrollbar} = this.state;
 
     if (!fixedColumnCount) {
       return null;
     }
 
-    const additionalRowCount = showVerticalScrollbar ? 1 : 0,
-      height = this._getBottomGridHeight(props),
+    const height = this._getBottomGridHeight(props),
       width = this._getLeftGridWidth(props),
       scrollbarSize = this.state.showVerticalScrollbar
         ? this.state.scrollbarSize
@@ -641,7 +652,7 @@ class MultiGrid extends React.PureComponent {
         height={height}
         onScroll={enableFixedColumnScroll ? this._onScrollTop : undefined}
         ref={this._bottomLeftGridRef}
-        rowCount={Math.max(0, rowCount - fixedRowCount) + additionalRowCount}
+        rowCount={Math.max(0, rowCount - fixedRowCount)}
         rowHeight={this._rowHeightBottomGrid}
         style={this._bottomLeftGridStyle}
         tabIndex={null}


### PR DESCRIPTION
- Remove additionalRowCount.
- When bottomRightGrid has scrollbar add height style to bottomLeftGrid
   to compensate the difference of grids containers height,
   which appears due scrollbar size.
- Fix MultiGrid test.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [+] The existing test suites (`npm test`) all pass
- [+] For any new features or bug fixes, both positive and negative test cases have been added
- [+] For any new features, documentation has been added
- [+] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [+] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [+] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
