### PR TITLE
Use sparse array for cell position caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "babel-runtime": "^6.26.0",
     "clsx": "^1.0.1",
     "dom-helpers": "^2.4.0 || ^3.0.0",
+    "linear-layout-vector": "0.0.1",
     "loose-envify": "^1.3.0",
     "prop-types": "^15.6.0",
     "react-lifecycles-compat": "^3.0.4"

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -1,5 +1,6 @@
 /** @flow */
 
+import LinearLayoutVector from 'linear-layout-vector';
 import type {Alignment, CellSizeGetter, VisibleCellRange} from '../types';
 
 type CellSizeAndPositionManagerParams = {
@@ -38,13 +39,10 @@ type SizeAndPositionData = {
 export default class CellSizeAndPositionManager {
   // Cache of size and position data for cells, mapped by cell index.
   // Note that invalid values may exist in this map so only rely on cells up to this._lastMeasuredIndex
-  _cellSizeAndPositionData = {};
+  _layoutVector: LinearLayoutVector;
 
   // Measurements for cells up to this index can be trusted; cells afterward should be estimated.
   _lastMeasuredIndex = -1;
-
-  // Used in deferred mode to track which cells have been queued for measurement.
-  _lastBatchedIndex = -1;
 
   _cellCount: number;
   _cellSizeGetter: CellSizeGetter;
@@ -58,6 +56,9 @@ export default class CellSizeAndPositionManager {
     this._cellSizeGetter = cellSizeGetter;
     this._cellCount = cellCount;
     this._estimatedCellSize = estimatedCellSize;
+    this._layoutVector = new LinearLayoutVector();
+    this._layoutVector.setLength(cellCount);
+    this._layoutVector.setDefaultSize(estimatedCellSize);
   }
 
   areOffsetsAdjusted() {
@@ -68,6 +69,8 @@ export default class CellSizeAndPositionManager {
     this._cellCount = cellCount;
     this._estimatedCellSize = estimatedCellSize;
     this._cellSizeGetter = cellSizeGetter;
+    this._layoutVector.setLength(cellCount);
+    this._layoutVector.setDefaultSize(estimatedCellSize);
   }
 
   getCellCount(): number {
@@ -96,50 +99,42 @@ export default class CellSizeAndPositionManager {
         `Requested index ${index} is outside of range 0..${this._cellCount}`,
       );
     }
-
+    const vector = this._layoutVector;
     if (index > this._lastMeasuredIndex) {
-      let lastMeasuredCellSizeAndPosition = this.getSizeAndPositionOfLastMeasuredCell();
-      let offset =
-        lastMeasuredCellSizeAndPosition.offset +
-        lastMeasuredCellSizeAndPosition.size;
+      const token = {index: this._lastMeasuredIndex + 1};
 
-      for (var i = this._lastMeasuredIndex + 1; i <= index; i++) {
-        let size = this._cellSizeGetter({index: i});
-
+      for (var i = token.index; i <= index; token.index = ++i) {
+        const size = this._cellSizeGetter(token);
         // undefined or NaN probably means a logic error in the size getter.
         // null means we're using CellMeasurer and haven't yet measured a given index.
-        if (size === undefined || isNaN(size)) {
+        if (size === undefined || size !== size) {
           throw Error(`Invalid size returned for cell ${i} of value ${size}`);
-        } else if (size === null) {
-          this._cellSizeAndPositionData[i] = {
-            offset,
-            size: 0,
-          };
-
-          this._lastBatchedIndex = index;
-        } else {
-          this._cellSizeAndPositionData[i] = {
-            offset,
-            size,
-          };
-
-          offset += size;
-
-          this._lastMeasuredIndex = index;
+        } else if (size !== null) {
+          vector.setItemSize(i, size);
         }
       }
+      this._lastMeasuredIndex = Math.min(index, this._cellCount - 1);
     }
 
-    return this._cellSizeAndPositionData[index];
+    return {
+      offset: vector.start(index),
+      size: vector.getItemSize(index),
+    };
   }
 
   getSizeAndPositionOfLastMeasuredCell(): SizeAndPositionData {
-    return this._lastMeasuredIndex >= 0
-      ? this._cellSizeAndPositionData[this._lastMeasuredIndex]
-      : {
-          offset: 0,
-          size: 0,
-        };
+    const index = this._lastMeasuredIndex;
+    if (index <= 0) {
+      return {
+        offset: 0,
+        size: 0,
+      };
+    }
+    const vector = this._layoutVector;
+    return {
+      offset: vector.start(index),
+      size: vector.getItemSize(index),
+    };
   }
 
   /**
@@ -148,14 +143,8 @@ export default class CellSizeAndPositionManager {
    * As cells are measured, the estimate will be updated.
    */
   getTotalSize(): number {
-    const lastMeasuredCellSizeAndPosition = this.getSizeAndPositionOfLastMeasuredCell();
-    const totalSizeOfMeasuredCells =
-      lastMeasuredCellSizeAndPosition.offset +
-      lastMeasuredCellSizeAndPosition.size;
-    const numUnmeasuredCells = this._cellCount - this._lastMeasuredIndex - 1;
-    const totalSizeOfUnmeasuredCells =
-      numUnmeasuredCells * this._estimatedCellSize;
-    return totalSizeOfMeasuredCells + totalSizeOfUnmeasuredCells;
+    const lastIndex = this._cellCount - 1;
+    return lastIndex >= 0 ? this._layoutVector.end(lastIndex) : 0;
   }
 
   /**
@@ -206,31 +195,15 @@ export default class CellSizeAndPositionManager {
   }
 
   getVisibleCellRange(params: GetVisibleCellRangeParams): VisibleCellRange {
-    let {containerSize, offset} = params;
-
-    const totalSize = this.getTotalSize();
-
-    if (totalSize === 0) {
+    if (this.getTotalSize() === 0) {
       return {};
     }
 
-    const maxOffset = offset + containerSize;
-    const start = this._findNearestCell(offset);
-
-    const datum = this.getSizeAndPositionOfCell(start);
-    offset = datum.offset + datum.size;
-
-    let stop = start;
-
-    while (offset < maxOffset && stop < this._cellCount - 1) {
-      stop++;
-
-      offset += this.getSizeAndPositionOfCell(stop).size;
-    }
-
+    const {containerSize, offset} = params;
+    const maxOffset = offset + containerSize - 1;
     return {
-      start,
-      stop,
+      start: this._findNearestCell(offset),
+      stop: this._findNearestCell(maxOffset),
     };
   }
 
@@ -241,45 +214,6 @@ export default class CellSizeAndPositionManager {
    */
   resetCell(index: number): void {
     this._lastMeasuredIndex = Math.min(this._lastMeasuredIndex, index - 1);
-  }
-
-  _binarySearch(high: number, low: number, offset: number): number {
-    while (low <= high) {
-      const middle = low + Math.floor((high - low) / 2);
-      const currentOffset = this.getSizeAndPositionOfCell(middle).offset;
-
-      if (currentOffset === offset) {
-        return middle;
-      } else if (currentOffset < offset) {
-        low = middle + 1;
-      } else if (currentOffset > offset) {
-        high = middle - 1;
-      }
-    }
-
-    if (low > 0) {
-      return low - 1;
-    } else {
-      return 0;
-    }
-  }
-
-  _exponentialSearch(index: number, offset: number): number {
-    let interval = 1;
-
-    while (
-      index < this._cellCount &&
-      this.getSizeAndPositionOfCell(index).offset < offset
-    ) {
-      index += interval;
-      interval *= 2;
-    }
-
-    return this._binarySearch(
-      Math.min(index, this._cellCount - 1),
-      Math.floor(index / 2),
-      offset,
-    );
   }
 
   /**
@@ -293,21 +227,27 @@ export default class CellSizeAndPositionManager {
       throw Error(`Invalid offset ${offset} specified`);
     }
 
+    const vector = this._layoutVector;
+    const lastIndex = this._cellCount - 1;
     // Our search algorithms find the nearest match at or below the specified offset.
     // So make sure the offset is at least 0 or no match will be found.
-    offset = Math.max(0, offset);
+    const targetOffset = Math.max(0, Math.min(offset, vector.start(lastIndex)));
+    // First interrogate the constant-time lookup table
+    let nearestCellIndex = vector.indexOf(targetOffset);
 
-    const lastMeasuredCellSizeAndPosition = this.getSizeAndPositionOfLastMeasuredCell();
-    const lastMeasuredIndex = Math.max(0, this._lastMeasuredIndex);
-
-    if (lastMeasuredCellSizeAndPosition.offset >= offset) {
-      // If we've already measured cells within this range just use a binary search as it's faster.
-      return this._binarySearch(lastMeasuredIndex, 0, offset);
-    } else {
-      // If we haven't yet measured this high, fallback to an exponential search with an inner binary search.
-      // The exponential search avoids pre-computing sizes for the full set of cells as a binary search would.
-      // The overall complexity for this approach is O(log n).
-      return this._exponentialSearch(lastMeasuredIndex, offset);
+    // If we haven't yet measured this high, compute sizes for each cell up to the desired offset.
+    while (nearestCellIndex > this._lastMeasuredIndex) {
+      // Measure all the cells up to the one we want to find presently.
+      // Do this before the last-index check to ensure the sparse array
+      // is fully populated.
+      this.getSizeAndPositionOfCell(nearestCellIndex);
+      // No need to search and compare again if we're at the end.
+      if (nearestCellIndex === lastIndex) {
+        return nearestCellIndex;
+      }
+      nearestCellIndex = vector.indexOf(targetOffset);
     }
+
+    return nearestCellIndex;
   }
 }

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -231,7 +231,7 @@ export default class CellSizeAndPositionManager {
     const lastIndex = this._cellCount - 1;
     // Our search algorithms find the nearest match at or below the specified offset.
     // So make sure the offset is at least 0 or no match will be found.
-    const targetOffset = Math.max(0, Math.min(offset, vector.start(lastIndex)));
+    let targetOffset = Math.max(0, Math.min(offset, vector.start(lastIndex)));
     // First interrogate the constant-time lookup table
     let nearestCellIndex = vector.indexOf(targetOffset);
 
@@ -246,6 +246,14 @@ export default class CellSizeAndPositionManager {
         return nearestCellIndex;
       }
       nearestCellIndex = vector.indexOf(targetOffset);
+      // Guard in case `getSizeAndPositionOfCell` didn't fully measure to
+      // the nearestCellIndex. This might happen scrolling quickly down
+      // and back up on large lists -- possible race with React or DOM?
+      if (nearestCellIndex === -1) {
+        nearestCellIndex = this._lastMeasuredIndex;
+        this._lastMeasuredIndex = nearestCellIndex - 1;
+        targetOffset = Math.max(0, Math.min(offset, vector.start(lastIndex)));
+      }
     }
 
     return nearestCellIndex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5641,6 +5641,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linear-layout-vector@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
+  integrity sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA=
+
 lint-staged@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.0.4.tgz#1aa7f27427e4c4c85d4d6524ac98aac10cbaf1b8"


### PR DESCRIPTION
This PR swaps out the hash based cell position caches and the underlying binary search with a constant-time [sparse array](https://github.com/trxcllnt/linear-layout-vector/blob/master/index.js) linear layout vector implementation.

The vector stores element sizes in a single dimension. Sizes are stored in blocks with power-of-two length. The vector supports constant-time `(index) => position` lookup, update, insertion, and removal by shifting the index to find the block index, then a mask (mod) to find the cell index.

Reverse lookup `(position) => index` is currently linear with respect to the number of blocks/size of each block. Flamegraphs indicate that on a table with 1MM rows and with the default block_size of 128, this amounts to about 0.15-1ms (150-1000 microseconds) per call when scrolling at the end of the list. If avoiding linear scans is an issue on principle, it would be possible to cache and invalidate the block sizes' prefix sum, and implement this lookup as a binary search again. The block size can also be intelligently tuned based on total element count for a classic space/time trade-off.

This change means the following methods are now `O(1)`:
```
getSizeAndPositionOfCell
getSizeAndPositionOfLastMeasuredCell
getUpdatedOffsetForIndex
```

`getVisibleCellRange` is `O(n)`, where `n=num_blocks`

The biggest practical benefit is that cell dimensions are stable across invalidation. After initial measurement the scrollbars won't jump around, as you can see in this screen capture I uploaded to youtube. The first half is rendering a MultiGrid with `react-virtualized@9.21.0`, and the second half is rendering the same MultiGrid with the current PR. You can find the source for this demo [here](https://github.com/trxcllnt/arrow-viewer/blob/484acdbf56f084e9a1fc24f86743cd7a3d919ffc/src/App.tsx#L12).

[![react virtualized scrolling](https://user-images.githubusercontent.com/178183/51802675-2f933900-2201-11e9-8bcd-018e1a278dd3.png)](http://www.youtube.com/watch?v=8hzP8AZMqp4 "react virtualized scrolling")





- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

