### PR TITLE
Issue #1317: Improve Masonry cellPositioner reset signature

### DIFF
--- a/source/Masonry/createCellPositioner.js
+++ b/source/Masonry/createCellPositioner.js
@@ -9,8 +9,8 @@ type createCellPositionerParams = {
 };
 
 type resetParams = {
-  columnCount: number,
-  columnWidth: number,
+  columnCount?: number,
+  columnWidth?: number,
   spacer?: number,
 };
 
@@ -55,9 +55,15 @@ export default function createCellPositioner({
   }
 
   function reset(params: resetParams): void {
-    columnCount = params.columnCount;
-    columnWidth = params.columnWidth;
-    spacer = params.spacer;
+    if (params.columnCount) {
+      columnCount = params.columnCount;
+    }
+    if (params.columnWidth) {
+      columnWidth = params.columnWidth;
+    }
+    if (params.spacer) {
+      spacer = params.spacer;
+    }
 
     initOrResetDerivedValues();
   }


### PR DESCRIPTION
Improves the masonry cellPositioner signature per #1317. I made all the parameters optional and updated the flow signature to reflect this change.

I'm unsure if there's any documentation change needed.

I could add tests for this but it seems like this method is more of a helper and have no tests currently.

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).