### PR TITLE
MultiGrid: Fix extra row being added to the bottom left table when there is a vertical scrollbar, but there is no horizontal one (#1337)

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -617,13 +617,13 @@ class MultiGrid extends React.PureComponent {
       rowCount,
       hideBottomLeftGridScrollbar,
     } = props;
-    const {showVerticalScrollbar} = this.state;
+    const {showHorizontalScrollbar} = this.state;
 
     if (!fixedColumnCount) {
       return null;
     }
 
-    const additionalRowCount = showVerticalScrollbar ? 1 : 0,
+    const additionalRowCount = showHorizontalScrollbar ? 1 : 0,
       height = this._getBottomGridHeight(props),
       width = this._getLeftGridWidth(props),
       scrollbarSize = this.state.showVerticalScrollbar
@@ -791,13 +791,13 @@ class MultiGrid extends React.PureComponent {
 
   _rowHeightBottomGrid = ({index}) => {
     const {fixedRowCount, rowCount, rowHeight} = this.props;
-    const {scrollbarSize, showVerticalScrollbar} = this.state;
+    const {scrollbarSize, showHorizontalScrollbar} = this.state;
 
     // An extra cell is added to the count
     // This gives the smaller Grid extra room for offset,
     // In case the main (bottom right) Grid has a scrollbar
     // If no scrollbar, the extra space is overflow:hidden anyway
-    if (showVerticalScrollbar && index === rowCount - fixedRowCount) {
+    if (showHorizontalScrollbar && index === rowCount - fixedRowCount) {
       return scrollbarSize;
     }
 


### PR DESCRIPTION
Fixes #1337

For some reason variables related to the vertical scrollbar were used to adjust the row count and the last row height. Now using the state of the horizontal scrollbar.