### PR TITLE
Add parentRenderer - It helps with complex animations

### DIFF
--- a/docs/Masonry.md
+++ b/docs/Masonry.md
@@ -29,6 +29,7 @@ Phase one is repeated if the user scrolls beyond the current layout's bounds. If
 | cellMeasurerCache | mixed | ✓ | Caches item measurements. Default sizes help `Masonry` decide how many images to batch-measure. Learn more [here](CellMeasurer.md#cellmeasurercache). |
 | cellPositioner | function | ✓ | Positions a cell given an index: `(index: number) => ({ left: number, top: number })`. [Learn more](#createmasonrycellpositioner) |
 | cellRenderer | function | ✓ | Responsible for rendering a cell given an index. [Learn more](#cellrenderer) |
+| parentRenderer | function |  | Responsible for rendering a custom parent component. [Learn more](#parentRenderer) |
 | className | string |  | Optional custom CSS class name to attach to root `Masonry` element. |
 | height | number | ✓ | Height of the component; this value determines the number of visible items. |
 | id | string |  | Optional custom id to attach to root `Masonry` element. |
@@ -77,6 +78,23 @@ function cellRenderer ({
         {/* Your content goes here */}
       </div>
     </CellMeasurer>
+  );
+}
+```
+
+### parentRenderer
+
+Responsible for rendering a custom parent component. This function accepts the following named parameters:
+
+```jsx
+function parentRenderer ({
+  isScrolling, // The Grid is currently being scrolled
+  children,    // Your cells passed as an array
+}) {
+  return (
+    <MyCustomParentComponent>
+      {children}
+    </MyCustomParentComponent>
   );
 }
 ```

--- a/source/Masonry/Masonry.js
+++ b/source/Masonry/Masonry.js
@@ -12,6 +12,7 @@ import type {AnimationTimeoutId} from '../utils/requestAnimationTimeout';
 
 type Props = {
   autoHeight: boolean,
+  parentRenderer: ?ParentRenderer,
   cellCount: number,
   cellMeasurerCache: CellMeasurerCache,
   cellPositioner: Positioner,
@@ -173,6 +174,7 @@ class Masonry extends React.PureComponent<Props, State> {
   render() {
     const {
       autoHeight,
+      parentRenderer,
       cellCount,
       cellMeasurerCache,
       cellRenderer,
@@ -301,7 +303,7 @@ class Masonry extends React.PureComponent<Props, State> {
             pointerEvents: isScrolling ? 'none' : '',
             position: 'relative',
           }}>
-          {children}
+          {parentRenderer ? parentRenderer({children, isScrolling}) : children}
         </div>
       </div>
     );
@@ -457,6 +459,11 @@ export type CellMeasurerCache = {
   getHeight: (index: number) => number,
   getWidth: (index: number) => number,
 };
+
+type ParentRenderer = (params: {|
+  children: Array,
+  isScrolling: boolean,
+|}) => mixed;
 
 type CellRenderer = (params: {|
   index: number,


### PR DESCRIPTION
Sometimes we need a custom parent to manage complex animations, using libraries like https://github.com/joshwcomeau/react-flip-move.

Libraries like FlipMove do not create a new DOM element, so we can use it with Masonry, wrapping our cells without side effects.