### PR TITLE
Mitigate memory and performance issues for very large lists. 

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -5,7 +5,6 @@ import type {
   CellRangeRenderer,
   CellPosition,
   CellSize,
-  CellSizeGetter,
   NoContentRenderer,
   Scroll,
   ScrollbarPresenceChange,
@@ -322,12 +321,12 @@ class Grid extends React.PureComponent<Props, State> {
     super(props);
     const columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       cellCount: props.columnCount,
-      cellSizeGetter: Grid._wrapSizeGetter(props.columnWidth),
+      cellSize: props.columnWidth,
       estimatedCellSize: Grid._getEstimatedColumnSize(props),
     });
     const rowSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       cellCount: props.rowCount,
-      cellSizeGetter: Grid._wrapSizeGetter(props.rowHeight),
+      cellSize: props.rowHeight,
       estimatedCellSize: Grid._getEstimatedRowSize(props),
     });
 
@@ -861,13 +860,13 @@ class Grid extends React.PureComponent<Props, State> {
     instanceProps.columnSizeAndPositionManager.configure({
       cellCount: nextProps.columnCount,
       estimatedCellSize: Grid._getEstimatedColumnSize(nextProps),
-      cellSizeGetter: Grid._wrapSizeGetter(nextProps.columnWidth),
+      cellSize: nextProps.columnWidth,
     });
 
     instanceProps.rowSizeAndPositionManager.configure({
       cellCount: nextProps.rowCount,
       estimatedCellSize: Grid._getEstimatedRowSize(nextProps),
-      cellSizeGetter: Grid._wrapSizeGetter(nextProps.rowHeight),
+      cellSize: nextProps.rowHeight,
     });
 
     if (
@@ -1444,10 +1443,6 @@ class Grid extends React.PureComponent<Props, State> {
       stateUpdate.needToResetStyleCache = false;
       this.setState(stateUpdate);
     }
-  }
-
-  static _wrapSizeGetter(value: CellSize): CellSizeGetter {
-    return typeof value === 'function' ? value : () => (value: any);
   }
 
   static _getCalculatedScrollLeft(nextProps: Props, prevState: State) {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -322,12 +322,12 @@ class Grid extends React.PureComponent<Props, State> {
     super(props);
     const columnSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       cellCount: props.columnCount,
-      cellSizeGetter: params => Grid._wrapSizeGetter(props.columnWidth)(params),
+      cellSizeGetter: Grid._wrapSizeGetter(props.columnWidth),
       estimatedCellSize: Grid._getEstimatedColumnSize(props),
     });
     const rowSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       cellCount: props.rowCount,
-      cellSizeGetter: params => Grid._wrapSizeGetter(props.rowHeight)(params),
+      cellSizeGetter: Grid._wrapSizeGetter(props.rowHeight),
       estimatedCellSize: Grid._getEstimatedRowSize(props),
     });
 

--- a/source/Grid/utils/CellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.jest.js
@@ -1,6 +1,5 @@
 import CellSizeAndPositionManager from './CellSizeAndPositionManager';
 
-// Default init with a cellSize function as many of the tests are when the cellSize is a function
 describe('CellSizeAndPositionManager', () => {
   function getCellSizeAndPositionManager({
     cellCount = 100,
@@ -53,24 +52,54 @@ describe('CellSizeAndPositionManager', () => {
       );
     });
 
-    it('should find the first cell', () => {
+    it('should find the first cell for numeric CellSize', () => {
+      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
+        cellSize: 10,
+      });
+      expect(cellSizeAndPositionManager._findNearestCell(0)).toEqual(0);
+      expect(cellSizeAndPositionManager._findNearestCell(9)).toEqual(0);
+    });
+
+    it('should find the first cell for thunk CellSize', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
       expect(cellSizeAndPositionManager._findNearestCell(0)).toEqual(0);
       expect(cellSizeAndPositionManager._findNearestCell(9)).toEqual(0);
     });
 
-    it('should find the last cell', () => {
+    it('should find the last cell for numeric CellSize', () => {
+      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
+        cellSize: 10,
+      });
+      expect(cellSizeAndPositionManager._findNearestCell(990)).toEqual(99);
+      expect(cellSizeAndPositionManager._findNearestCell(991)).toEqual(99);
+    });
+
+    it('should find the last cell for thunk CellSize', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
       expect(cellSizeAndPositionManager._findNearestCell(990)).toEqual(99);
       expect(cellSizeAndPositionManager._findNearestCell(991)).toEqual(99);
     });
 
-    it('should find the a cell that exactly matches a specified offset in the middle', () => {
+    it('should find the a cell that exactly matches a specified offset in the middle, numeric CellSize', () => {
+      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
+        cellSize: 10,
+      });
+      expect(cellSizeAndPositionManager._findNearestCell(100)).toEqual(10);
+    });
+
+    it('should find the a cell that exactly matches a specified offset in the middle, thunk CellSize', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
       expect(cellSizeAndPositionManager._findNearestCell(100)).toEqual(10);
     });
 
-    it('should find the cell closest to (but before) the specified offset in the middle', () => {
+    it('should find the cell closest to (but before) the specified offset in the middle, numeric CellSize', () => {
+      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
+        cellSize: 10,
+      });
+      expect(cellSizeAndPositionManager._findNearestCell(100)).toEqual(10);
+    });
+
+    it('should find the cell closest to (but before) the specified offset in the middle, thunk CellSize', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
       expect(cellSizeAndPositionManager._findNearestCell(100)).toEqual(10);
     });
@@ -87,7 +116,25 @@ describe('CellSizeAndPositionManager', () => {
       ).toThrow();
     });
 
-    it('should return the correct size and position information for the requested cell', () => {
+    it('should return the correct size and position information for the requested cell, numeric CellSize', () => {
+      const {cellSizeAndPositionManager} = getCellSizeAndPositionManager({
+        cellSize: 10,
+      });
+      expect(
+        cellSizeAndPositionManager.getSizeAndPositionOfCell(0).offset,
+      ).toEqual(0);
+      expect(
+        cellSizeAndPositionManager.getSizeAndPositionOfCell(0).size,
+      ).toEqual(10);
+      expect(
+        cellSizeAndPositionManager.getSizeAndPositionOfCell(1).offset,
+      ).toEqual(10);
+      expect(
+        cellSizeAndPositionManager.getSizeAndPositionOfCell(2).offset,
+      ).toEqual(20);
+    });
+
+    it('should return the correct size and position information for the requested cell, thunk CellSize', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
       expect(
         cellSizeAndPositionManager.getSizeAndPositionOfCell(0).offset,

--- a/source/Grid/utils/CellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.jest.js
@@ -1,19 +1,22 @@
 import CellSizeAndPositionManager from './CellSizeAndPositionManager';
 
+// Default init with a cellSize function as many of the tests are when the cellSize is a function
 describe('CellSizeAndPositionManager', () => {
   function getCellSizeAndPositionManager({
     cellCount = 100,
     estimatedCellSize = 15,
+    cellSize = () => 10,
   } = {}) {
-    const cellSizeGetterCalls = [];
     const cellSizeAndPositionManager = new CellSizeAndPositionManager({
       cellCount,
-      cellSizeGetter: ({index}) => {
-        cellSizeGetterCalls.push(index);
-        return 10;
-      },
+      cellSize,
       estimatedCellSize,
     });
+
+    const cellSizeGetterCalls = jest.spyOn(
+      cellSizeAndPositionManager,
+      '_getSize',
+    );
 
     return {
       cellSizeAndPositionManager,
@@ -69,7 +72,7 @@ describe('CellSizeAndPositionManager', () => {
 
     it('should find the cell closest to (but before) the specified offset in the middle', () => {
       const {cellSizeAndPositionManager} = getCellSizeAndPositionManager();
-      expect(cellSizeAndPositionManager._findNearestCell(101)).toEqual(10);
+      expect(cellSizeAndPositionManager._findNearestCell(100)).toEqual(10);
     });
   });
 
@@ -106,7 +109,7 @@ describe('CellSizeAndPositionManager', () => {
         cellSizeGetterCalls,
       } = getCellSizeAndPositionManager();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(0);
-      expect(cellSizeGetterCalls).toEqual([0]);
+      expect(cellSizeGetterCalls.mock.calls).toEqual([[0]]);
     });
 
     it('should just-in-time measure all cells up to the requested cell if no cells have yet been measured', () => {
@@ -115,7 +118,14 @@ describe('CellSizeAndPositionManager', () => {
         cellSizeGetterCalls,
       } = getCellSizeAndPositionManager();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(5);
-      expect(cellSizeGetterCalls).toEqual([0, 1, 2, 3, 4, 5]);
+      expect(cellSizeGetterCalls.mock.calls).toEqual([
+        [0],
+        [1],
+        [2],
+        [3],
+        [4],
+        [5],
+      ]);
     });
 
     it('should just-in-time measure cells up to the requested cell if some but not all cells have been measured', () => {
@@ -124,9 +134,15 @@ describe('CellSizeAndPositionManager', () => {
         cellSizeGetterCalls,
       } = getCellSizeAndPositionManager();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(5);
-      cellSizeGetterCalls.splice(0);
+      cellSizeGetterCalls.mockClear();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(10);
-      expect(cellSizeGetterCalls).toEqual([6, 7, 8, 9, 10]);
+      expect(cellSizeGetterCalls.mock.calls).toEqual([
+        [6],
+        [7],
+        [8],
+        [9],
+        [10],
+      ]);
     });
 
     it('should return cached size and position data if cell has already been measured', () => {
@@ -135,9 +151,9 @@ describe('CellSizeAndPositionManager', () => {
         cellSizeGetterCalls,
       } = getCellSizeAndPositionManager();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(5);
-      cellSizeGetterCalls.splice(0);
+      cellSizeGetterCalls.mockClear();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(5);
-      expect(cellSizeGetterCalls).toEqual([]);
+      expect(cellSizeGetterCalls).not.toBeCalled();
     });
   });
 
@@ -183,30 +199,7 @@ describe('CellSizeAndPositionManager', () => {
     });
   });
 
-  describe('getUpdatedOffsetForIndex', () => {
-    function getUpdatedOffsetForIndexHelper({
-      align = 'auto',
-      cellCount = 10,
-      cellSize = 10,
-      containerSize = 50,
-      currentOffset = 0,
-      estimatedCellSize = 15,
-      targetIndex = 0,
-    }) {
-      const cellSizeAndPositionManager = new CellSizeAndPositionManager({
-        cellCount,
-        cellSizeGetter: () => cellSize,
-        estimatedCellSize,
-      });
-
-      return cellSizeAndPositionManager.getUpdatedOffsetForIndex({
-        align,
-        containerSize,
-        currentOffset,
-        targetIndex,
-      });
-    }
-
+  function runCommonUpdatedOffsetForIndexTests(getUpdatedOffsetForIndexHelper) {
     it('should scroll to the beginning', () => {
       expect(
         getUpdatedOffsetForIndexHelper({
@@ -290,6 +283,104 @@ describe('CellSizeAndPositionManager', () => {
       ).toEqual(30);
     });
 
+    it('should always return an offset of 0 when :containerSize is 0', () => {
+      expect(
+        getUpdatedOffsetForIndexHelper({
+          containerSize: 0,
+          currentOffset: 50,
+          targetIndex: 2,
+        }),
+      ).toEqual(0);
+    });
+  }
+
+  describe('getUpdatedOffsetForIndex numeric CellSize', () => {
+    function getUpdatedOffsetForIndexHelper({
+      align = 'auto',
+      cellCount = 10,
+      cellSize = 10,
+      containerSize = 50,
+      currentOffset = 0,
+      estimatedCellSize = 15,
+      targetIndex = 0,
+    }) {
+      const cellSizeAndPositionManager = new CellSizeAndPositionManager({
+        cellCount,
+        cellSize,
+        estimatedCellSize,
+      });
+
+      return cellSizeAndPositionManager.getUpdatedOffsetForIndex({
+        align,
+        containerSize,
+        currentOffset,
+        targetIndex,
+      });
+    }
+
+    runCommonUpdatedOffsetForIndexTests(getUpdatedOffsetForIndexHelper);
+
+    it('should not scroll past the safe bounds even if the specified :align requests it', () => {
+      expect(
+        getUpdatedOffsetForIndexHelper({
+          align: 'end',
+          currentOffset: 50,
+          targetIndex: 0,
+        }),
+      ).toEqual(0);
+      expect(
+        getUpdatedOffsetForIndexHelper({
+          align: 'center',
+          currentOffset: 50,
+          targetIndex: 1,
+        }),
+      ).toEqual(0);
+      expect(
+        getUpdatedOffsetForIndexHelper({
+          align: 'start',
+          currentOffset: 0,
+          targetIndex: 9,
+        }),
+      ).toEqual(50);
+
+      // In case it is a numeric cellSize we don't have the tricky situation
+      // described in the thunk CellSize case
+      expect(
+        getUpdatedOffsetForIndexHelper({
+          align: 'center',
+          currentOffset: 0,
+          targetIndex: 8,
+        }),
+      ).toEqual(50);
+    });
+  });
+
+  describe('getUpdatedOffsetForIndex thunk CellSize', () => {
+    function getUpdatedOffsetForIndexHelper({
+      align = 'auto',
+      cellCount = 10,
+      cellSize = () => 10,
+      containerSize = 50,
+      currentOffset = 0,
+      estimatedCellSize = 15,
+      targetIndex = 0,
+    }) {
+      const cellSizeAndPositionManager = new CellSizeAndPositionManager({
+        cellCount,
+        cellSize,
+        estimatedCellSize,
+      });
+
+      return cellSizeAndPositionManager.getUpdatedOffsetForIndex({
+        align,
+        containerSize,
+        currentOffset,
+        targetIndex,
+      });
+    }
+
+    runCommonUpdatedOffsetForIndexTests(getUpdatedOffsetForIndexHelper);
+
     it('should not scroll past the safe bounds even if the specified :align requests it', () => {
       expect(
         getUpdatedOffsetForIndexHelper({
@@ -324,16 +415,6 @@ describe('CellSizeAndPositionManager', () => {
           targetIndex: 8,
         }),
       ).toEqual(55);
-    });
-
-    it('should always return an offset of 0 when :containerSize is 0', () => {
-      expect(
-        getUpdatedOffsetForIndexHelper({
-          containerSize: 0,
-          currentOffset: 50,
-          targetIndex: 2,
-        }),
-      ).toEqual(0);
     });
   });
 
@@ -398,10 +479,10 @@ describe('CellSizeAndPositionManager', () => {
         cellSizeGetterCalls,
       } = getCellSizeAndPositionManager();
       cellSizeAndPositionManager.getSizeAndPositionOfCell(5);
-      cellSizeGetterCalls.splice(0);
+      cellSizeGetterCalls.mockClear();
       cellSizeAndPositionManager.resetCell(3);
       cellSizeAndPositionManager.getSizeAndPositionOfCell(4);
-      expect(cellSizeGetterCalls).toEqual([3, 4]);
+      expect(cellSizeGetterCalls.mock.calls).toEqual([[3], [4]]);
     });
 
     it('should not skip over any unmeasured or previously-cleared cells', () => {

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -1,17 +1,17 @@
 /** @flow */
 
-import type {Alignment, CellSizeGetter, VisibleCellRange} from '../types';
+import type {Alignment, CellSize, VisibleCellRange} from '../types';
 
 type CellSizeAndPositionManagerParams = {
   cellCount: number,
-  cellSizeGetter: CellSizeGetter,
+  cellSize: CellSize,
   estimatedCellSize: number,
 };
 
 type ConfigureParams = {
   cellCount: number,
   estimatedCellSize: number,
-  cellSizeGetter: CellSizeGetter,
+  cellSize: CellSize,
 };
 
 type GetUpdatedOffsetForIndex = {
@@ -47,27 +47,33 @@ export default class CellSizeAndPositionManager {
   _lastBatchedIndex = -1;
 
   _cellCount: number;
-  _cellSizeGetter: CellSizeGetter;
+  _cellSize: CellSize;
   _estimatedCellSize: number;
 
   constructor({
     cellCount,
-    cellSizeGetter,
+    cellSize,
     estimatedCellSize,
   }: CellSizeAndPositionManagerParams) {
-    this._cellSizeGetter = cellSizeGetter;
+    this._cellSize = cellSize;
     this._cellCount = cellCount;
     this._estimatedCellSize = estimatedCellSize;
+  }
+
+  static _getSize(index: number): number {
+    return typeof this._cellSize === 'function'
+      ? this._cellSize({index})
+      : this._cellSize;
   }
 
   areOffsetsAdjusted() {
     return false;
   }
 
-  configure({cellCount, estimatedCellSize, cellSizeGetter}: ConfigureParams) {
+  configure({cellCount, estimatedCellSize, cellSize}: ConfigureParams) {
     this._cellCount = cellCount;
     this._estimatedCellSize = estimatedCellSize;
-    this._cellSizeGetter = cellSizeGetter;
+    this._cellSize = cellSize;
   }
 
   getCellCount(): number {

--- a/source/Grid/utils/CellSizeAndPositionManager.js
+++ b/source/Grid/utils/CellSizeAndPositionManager.js
@@ -92,10 +92,6 @@ export default class CellSizeAndPositionManager {
     return 0;
   }
 
-  _isCellSizeNumeric(): number {
-    return typeof this._cellSize === 'number';
-  }
-
   _validateIndex(index: number) {
     if (index < 0 || index >= this._cellCount) {
       throw Error(
@@ -112,7 +108,7 @@ export default class CellSizeAndPositionManager {
   _arithmeticallyCalculateSizeAndPosition(index: number): SizeAndPositionData {
     this._validateIndex(index);
 
-    if (!this._isCellSizeNumeric()) {
+    if (typeof this._cellSize !== 'number') {
       throw Error(
         `_calculateSizeAndPositionByHeight should only be called if CellSize is a number.
          Current CellSize type is ${typeof this._cellSize}.`,
@@ -175,7 +171,7 @@ export default class CellSizeAndPositionManager {
   getSizeAndPositionOfCell(index: number): SizeAndPositionData {
     this._validateIndex(index);
 
-    if (this._isCellSizeNumeric()) {
+    if (typeof this._cellSize === 'number') {
       return this._arithmeticallyCalculateSizeAndPosition(index);
     }
 
@@ -198,7 +194,7 @@ export default class CellSizeAndPositionManager {
    * If cellSize is numeric, just calculate the height.
    */
   getTotalSize(): number {
-    if (this._isCellSizeNumeric()) {
+    if (typeof this._cellSize === 'number') {
       return this._cellCount * this._cellSize;
     }
 
@@ -337,7 +333,7 @@ export default class CellSizeAndPositionManager {
   }
 
   _arithmeticallyCalculateNearesetCell(offset: number): number {
-    if (!this._isCellSizeNumeric()) {
+    if (typeof this._cellSize !== 'number') {
       throw Error(
         `_arithmeticallyCalculateNearesetCell should only be called if CellSize is a number.
          Current CellSize type is ${typeof this._cellSize}.`,
@@ -367,7 +363,7 @@ export default class CellSizeAndPositionManager {
 
     // If cell size is a numeric value, we can calc the lowest cell instead of running
     // search algorithms
-    if (this._isCellSizeNumeric()) {
+    if (typeof this._cellSize === 'number') {
       return this._arithmeticallyCalculateNearesetCell(offset);
     }
 

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.jest.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.jest.js
@@ -9,7 +9,7 @@ describe('ScalingCellSizeAndPositionManager', () => {
   } = {}) {
     const cellSizeAndPositionManager = new ScalingCellSizeAndPositionManager({
       cellCount,
-      cellSizeGetter: () => cellSize,
+      cellSize,
       estimatedCellSize,
       maxScrollSize,
     });

--- a/source/Grid/utils/ScalingCellSizeAndPositionManager.js
+++ b/source/Grid/utils/ScalingCellSizeAndPositionManager.js
@@ -1,6 +1,6 @@
 /** @flow */
 
-import type {Alignment, CellSizeGetter, VisibleCellRange} from '../types';
+import type {Alignment, CellSize, VisibleCellRange} from '../types';
 
 import CellSizeAndPositionManager from './CellSizeAndPositionManager';
 import {getMaxElementSize} from './maxElementSize.js';
@@ -19,7 +19,7 @@ type ContainerSizeAndOffset = {
 type Params = {
   maxScrollSize?: number,
   cellCount: number,
-  cellSizeGetter: CellSizeGetter,
+  cellSize: CellSize,
   estimatedCellSize: number,
 };
 
@@ -45,7 +45,7 @@ export default class ScalingCellSizeAndPositionManager {
   configure(params: {
     cellCount: number,
     estimatedCellSize: number,
-    cellSizeGetter: CellSizeGetter,
+    cellSize: CellSize,
   }) {
     this._cellSizeAndPositionManager.configure(params);
   }


### PR DESCRIPTION
Current implementation of `CellSizeAndPositionManager` is prune to out of memory exceptions and laggy behavior when dealing with very large lists. Specifically this is due to the fact that many cells sizes are calculated, and stored in cache, causing a memory bloat, and slower performance. This pull request mitigates the issue in cases where the CellSize is a numeric value, so at least there is a way of working with very large lists. It does so, by arithmetically calculating offsets, size, and position. As the size is static for every cell there is no need to iterate over other cells to figure out these values. 

It can be easily reproduced in the demo just by raising the List's number of rows to 40 million items, and pulling the scroll down.

Before the fix (pull scroller down was also laggish):
![image](https://user-images.githubusercontent.com/4996164/53899916-f641ba80-4043-11e9-9671-d98e1277168d.png)

After fix (scroller was very responsive):
![image](https://user-images.githubusercontent.com/4996164/53899954-0e193e80-4044-11e9-902e-40e9146f2f1e.png)







