### PR TITLE
Fix undefined height during 1st render of WindowScroller when using scrollElement={domElement} (#1158)

### DIFF
--- a/source/WindowScroller/WindowScroller.jest.js
+++ b/source/WindowScroller/WindowScroller.jest.js
@@ -146,6 +146,25 @@ describe('WindowScroller', () => {
     );
   });
 
+  it('inherits the scrollElement height and passes it to child component', () => {
+    const renderFn = jest.fn();
+    const scrollElement = document.createElement('div');
+    scrollElement.getBoundingClientRect = () =>
+      Object.defineProperties(
+        {},
+        {
+          height: {enumerable: false, value: 200},
+          width: {enumerable: false, value: 250},
+        },
+      );
+    const component = render(getMarkup({renderFn, scrollElement}));
+
+    expect(component.state.height).toEqual(200);
+    renderFn.mock.calls.forEach(call =>
+      expect(call[0]).toEqual(expect.objectContaining({height: 200})),
+    );
+  });
+
   it('should restore pointerEvents on body after IS_SCROLLING_TIMEOUT', async () => {
     render(getMarkup());
     document.body.style.pointerEvents = 'all';

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -89,12 +89,17 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
   _detectElementResize: DetectElementResize;
   _child: ?Element;
 
-  state = {
-    ...getDimensions(this.props.scrollElement, this.props),
-    isScrolling: false,
-    scrollLeft: 0,
-    scrollTop: 0,
-  };
+  constructor(props: Props) {
+    super(props);
+    const {height, width} = getDimensions(props.scrollElement, props);
+    this.state = {
+      height,
+      width,
+      isScrolling: false,
+      scrollLeft: 0,
+      scrollTop: 0,
+    };
+  }
 
   updatePosition(scrollElement: ?Element = this.props.scrollElement) {
     const {onResize} = this.props;


### PR DESCRIPTION
Fix for #1158. Added test case.