### PR TITLE
fix(Table): aria-readonly is not allowed on rowgroup

### DIFF
--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -416,6 +416,7 @@ export default class Table extends React.PureComponent {
 
         <Grid
           {...this.props}
+          aria-readonly={null}
           autoContainerWidth
           className={clsx('ReactVirtualized__Table__Grid', gridClassName)}
           cellRenderer={this._createRow}


### PR DESCRIPTION
Closes #1313

Didn't find any existing test for aria-readonly so I'm not sure if you even want tests for this.