### PR TITLE
babel-runtime does not appear to be an actual dependency of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "webpack-dev-server": "^2.9.7"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "clsx": "^1.0.1",
     "dom-helpers": "^2.4.0 || ^3.0.0",
     "loose-envify": "^1.3.0",


### PR DESCRIPTION
- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`npm run typecheck`).

The only reference to `babel-runtime` is in the comments in a single file.
