### PR TITLE
Table: Add `key` to RowRendererParams type definition

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -149,6 +149,7 @@ This function accepts the following named parameters:
 |:---|:---|
 | className | Row-level class name |
 | columns | Array of React nodes |
+| key | Unique key within array of rendered rows |
 | index | Row index |
 | isScrolling | Boolean flag indicating if `Table` is currently being scrolled |
 | onRowClick | Optional row `onClick` handler |

--- a/source/Table/types.js
+++ b/source/Table/types.js
@@ -33,6 +33,7 @@ export type RowRendererParams = {
   columns: Array<any>,
   index: number,
   isScrolling: boolean,
+  key: string,
   onRowClick: ?Function,
   onRowDoubleClick: ?Function,
   onRowMouseOver: ?Function,


### PR DESCRIPTION
`defaultRowRenderer` accepts a type of `RowRendererParams` and destructures `key`, which isn't present in the type definition.  This pull request updates the type definition and the `Table` documentation for `rowRenderer`.