### PR TITLE
Split Table._setScrollbarWidth by adding public function Table.getScrollbarWidth

### DIFF
--- a/docs/Table.md
+++ b/docs/Table.md
@@ -61,6 +61,10 @@ This may be appropriate if the underlying row data has changed but the row sizes
 
 Gets offset for a given row and alignment.
 
+##### getScrollbarWidth
+
+Gets the scrollbar width used to pad the table-header.
+
 ##### measureAllRows
 Pre-measure all rows in a `Table`.
 

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -337,6 +337,17 @@ export default class Table extends React.PureComponent {
     }
   }
 
+  getScrollbarWidth() {
+    if (this.Grid) {
+      const Grid = findDOMNode(this.Grid);
+      const clientWidth = Grid.clientWidth || 0;
+      const offsetWidth = Grid.offsetWidth || 0;
+      return offsetWidth - clientWidth;
+    }
+
+    return 0;
+  }
+
   componentDidMount() {
     this._setScrollbarWidth();
   }
@@ -726,13 +737,8 @@ export default class Table extends React.PureComponent {
   }
 
   _setScrollbarWidth() {
-    if (this.Grid) {
-      const Grid = findDOMNode(this.Grid);
-      const clientWidth = Grid.clientWidth || 0;
-      const offsetWidth = Grid.offsetWidth || 0;
-      const scrollbarWidth = offsetWidth - clientWidth;
+    const scrollbarWidth = this.getScrollbarWidth();
 
-      this.setState({scrollbarWidth});
-    }
+    this.setState({scrollbarWidth});
   }
 }


### PR DESCRIPTION
For uses where a custom (external) header-row has to be used, there's little support for matching its width to the `Table`'s width. Most of it can be circumvented by summing `Column` widths, but there's no way to get the `scrollbarWidth` used since the method `_setScrollbarWidth` does both the calculation and `setState` parts.

With this change, implementations that rely on matching this repo's internal `_setScrollbarWidth` function with an external (almost identical) function could instead use `getScrollbarWidth`.