### PR TITLE
fix: masonry scroll handler should rely on event.currentTarget issue#1414

### DIFF
--- a/source/Masonry/Masonry.js
+++ b/source/Masonry/Masonry.js
@@ -410,7 +410,7 @@ class Masonry extends React.PureComponent<Props, State> {
   _onScroll = event => {
     const {height} = this.props;
 
-    const eventScrollTop = event.target.scrollTop;
+    const eventScrollTop = event.currentTarget.scrollTop;
 
     // When this component is shrunk drastically, React dispatches a series of back-to-back scroll events,
     // Gradually converging on a scrollTop that is within the bounds of the new, smaller height.


### PR DESCRIPTION
https://github.com/bvaughn/react-virtualized/issues/1414

The scroll handler should rely only on the scrolltop of event.currentTarget as any of the descendant elements' scroll event will propagate up to the container element. Relying on event.target seems incorrect.

Added a test case which fails if event.target.scrolltop is used.

Also, updated the function `simulateScroll` in spec file. As passing currentTarget to `Simulate` is not supported ( https://github.com/facebook/react/issues/4950 ), changed the `simulateScroll` function to set the scrollTop on the desired element.