### PR TITLE
Upgrade to dom-helpers@5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "clsx": "^1.0.1",
-    "dom-helpers": "^2.4.0 || ^3.0.0",
+    "dom-helpers": "^5.0.0",
     "loose-envify": "^1.3.0",
     "prop-types": "^15.6.0",
     "react-lifecycles-compat": "^3.0.4"

--- a/source/Collection/Collection.jest.js
+++ b/source/Collection/Collection.jest.js
@@ -2,7 +2,7 @@
  * Tests Collection and CollectionView.
  * @flow
  */
-import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
+import getScrollbarSize from 'dom-helpers/scrollbarSize';
 import * as React from 'react';
 import {findDOMNode} from 'react-dom';
 import {Simulate} from 'react-dom/test-utils';

--- a/source/Collection/CollectionView.js
+++ b/source/Collection/CollectionView.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import {polyfill} from 'react-lifecycles-compat';
 import createCallbackMemoizer from '../utils/createCallbackMemoizer';
-import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
+import getScrollbarSize from 'dom-helpers/scrollbarSize';
 
 // @TODO Merge Collection and CollectionView
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -28,7 +28,7 @@ import defaultOverscanIndicesGetter, {
 } from './defaultOverscanIndicesGetter';
 import updateScrollIndexHelper from './utils/updateScrollIndexHelper';
 import defaultCellRangeRenderer from './defaultCellRangeRenderer';
-import scrollbarSize from 'dom-helpers/util/scrollbarSize';
+import scrollbarSize from 'dom-helpers/scrollbarSize';
 import {polyfill} from 'react-lifecycles-compat';
 import {
   requestAnimationTimeout,

--- a/source/ScrollSync/ScrollSync.example.js
+++ b/source/ScrollSync/ScrollSync.example.js
@@ -10,7 +10,7 @@ import Grid from '../Grid';
 import ScrollSync from './ScrollSync';
 import clsx from 'clsx';
 import styles from './ScrollSync.example.css';
-import scrollbarSize from 'dom-helpers/util/scrollbarSize';
+import scrollbarSize from 'dom-helpers/scrollbarSize';
 
 const LEFT_COLOR_FROM = hexToRgb('#471061');
 const LEFT_COLOR_TO = hexToRgb('#BC3959');

--- a/source/jest-setup.js
+++ b/source/jest-setup.js
@@ -1,4 +1,4 @@
-jest.mock('dom-helpers/util/scrollbarSize', () => {
+jest.mock('dom-helpers/scrollbarSize', () => {
   return function getScrollbarSize() {
     return 20;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,13 @@
   dependencies:
     "@babel/types" "7.0.0-beta.31"
 
+"@babel/runtime@^7.5.5":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
+  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
@@ -2397,6 +2404,11 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2676,10 +2688,13 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-"dom-helpers@^2.4.0 || ^3.0.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.0.tgz#70af056e6b1507a71084abc1aac0f93a23f7ea1c"
-  integrity sha1-cK8FbmsVB6cQhKvBqsD5OiP36hw=
+dom-helpers@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.0.tgz#57a726de04abcc2a8bbfe664b3e21c584bde514e"
+  integrity sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    csstype "^2.6.6"
 
 dom-serializer@0:
   version "0.1.0"
@@ -7673,6 +7688,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@0.9.8:
   version "0.9.8"


### PR DESCRIPTION
The breaking change was the dropped support of IE8 (not supported here) and a change in export layout: https://github.com/react-bootstrap/dom-helpers/blob/master/CHANGELOG.md#500-2019-08-30.

Depending on how you look at it, some may consider this upgrade to be a breaking change from this project's perspective (for those who are using older versions of `dom-helpers`, they may now have multiple versions in their bundles - old versions are incompatible with v5).
