### PR TITLE
AutoSizer support for multi window added

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -64,7 +64,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
 
   _parentNode: ?HTMLElement;
   _autoSizer: ?HTMLElement;
-  _window?: Window;
+  _window: ?Window;
   _detectElementResize: DetectElementResize;
 
   componentDidMount() {

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -170,7 +170,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       const height = this._parentNode.offsetHeight || 0;
       const width = this._parentNode.offsetWidth || 0;
 
-      const style = (this._window && this._window.getComputedStyle(this._parentNode)) || {};
+      const style = ((this._window || window).getComputedStyle(this._parentNode)) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
       const paddingRight = parseInt(style.paddingRight, 10) || 0;
       const paddingTop = parseInt(style.paddingTop, 10) || 0;

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -87,7 +87,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       // See issue #41
       this._detectElementResize = createDetectElementResize(
         nonce,
-        this._window
+        this._window,
       );
       this._detectElementResize.addResizeListener(
         this._parentNode,
@@ -170,7 +170,8 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       const height = this._parentNode.offsetHeight || 0;
       const width = this._parentNode.offsetWidth || 0;
 
-      const style = ((this._window || window).getComputedStyle(this._parentNode)) || {};
+      const style =
+        ((this._window || window).getComputedStyle(this._parentNode)) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
       const paddingRight = parseInt(style.paddingRight, 10) || 0;
       const paddingTop = parseInt(style.paddingTop, 10) || 0;

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -64,7 +64,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
 
   _parentNode: ?HTMLElement;
   _autoSizer: ?HTMLElement;
-  _window: ?Window;
+  _window: ?any; // uses any instead of Window because Flow doesn't have window type
   _detectElementResize: DetectElementResize;
 
   componentDidMount() {

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -170,8 +170,8 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       const height = this._parentNode.offsetHeight || 0;
       const width = this._parentNode.offsetWidth || 0;
 
-      const style =
-        ((this._window || window).getComputedStyle(this._parentNode)) || {};
+      const window = this._window || window;
+      const style = window.getComputedStyle(this._parentNode) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
       const paddingRight = parseInt(style.paddingRight, 10) || 0;
       const paddingTop = parseInt(style.paddingTop, 10) || 0;

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -170,8 +170,8 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       const height = this._parentNode.offsetHeight || 0;
       const width = this._parentNode.offsetWidth || 0;
 
-      const window = this._window || window;
-      const style = window.getComputedStyle(this._parentNode) || {};
+      const win = this._window || window;
+      const style = win.getComputedStyle(this._parentNode) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
       const paddingRight = parseInt(style.paddingRight, 10) || 0;
       const paddingTop = parseInt(style.paddingTop, 10) || 0;

--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -64,6 +64,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
 
   _parentNode: ?HTMLElement;
   _autoSizer: ?HTMLElement;
+  _window?: Window;
   _detectElementResize: DetectElementResize;
 
   componentDidMount() {
@@ -80,10 +81,14 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       // This handles edge-cases where the component has already been unmounted before its ref has been set,
       // As well as libraries like react-lite which have a slightly different lifecycle.
       this._parentNode = this._autoSizer.parentNode;
+      this._window = this._autoSizer.parentNode.ownerDocument.defaultView;
 
       // Defer requiring resize handler in order to support server-side rendering.
       // See issue #41
-      this._detectElementResize = createDetectElementResize(nonce);
+      this._detectElementResize = createDetectElementResize(
+        nonce,
+        this._window
+      );
       this._detectElementResize.addResizeListener(
         this._parentNode,
         this._onResize,
@@ -165,7 +170,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       const height = this._parentNode.offsetHeight || 0;
       const width = this._parentNode.offsetWidth || 0;
 
-      const style = window.getComputedStyle(this._parentNode) || {};
+      const style = (this._window && this._window.getComputedStyle(this._parentNode)) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;
       const paddingRight = parseInt(style.paddingRight, 10) || 0;
       const paddingTop = parseInt(style.paddingTop, 10) || 0;

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -8,6 +8,7 @@
  * 2) Defer initialization code via a top-level function wrapper (to support SSR).
  * 3) Avoid unnecessary reflows by not measuring size for scroll events bubbling from children.
  * 4) Add nonce for style element.
+ * 5) Added support for injecting custom window object
  **/
 
 export default function createDetectElementResize(nonce, hostWindow) {

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -10,10 +10,12 @@
  * 4) Add nonce for style element.
  **/
 
-export default function createDetectElementResize(nonce) {
+export default function createDetectElementResize(nonce, hostWindow) {
   // Check `document` and `window` in case of server-side rendering
   var _window;
-  if (typeof window !== 'undefined') {
+  if (typeof hostWindow !== "undefined") {
+    _window = hostWindow;
+  } else if (typeof window !== 'undefined') {
     _window = window;
   } else if (typeof self !== 'undefined') {
     _window = self;
@@ -21,7 +23,7 @@ export default function createDetectElementResize(nonce) {
     _window = global;
   }
 
-  var attachEvent = typeof document !== 'undefined' && document.attachEvent;
+  var attachEvent = typeof _window.document !== 'undefined' && _window.document.attachEvent;
 
   if (!attachEvent) {
     var requestFrame = (function() {
@@ -105,7 +107,7 @@ export default function createDetectElementResize(nonce) {
       ),
       pfx = '';
     {
-      var elm = document.createElement('fakeelement');
+      var elm = _window.document.createElement('fakeelement');
       if (elm.style.animationName !== undefined) {
         animation = true;
       }

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -13,7 +13,7 @@
 export default function createDetectElementResize(nonce, hostWindow) {
   // Check `document` and `window` in case of server-side rendering
   var _window;
-  if (typeof hostWindow !== "undefined") {
+  if (typeof hostWindow !== 'undefined') {
     _window = hostWindow;
   } else if (typeof window !== 'undefined') {
     _window = window;

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -24,7 +24,8 @@ export default function createDetectElementResize(nonce, hostWindow) {
     _window = global;
   }
 
-  var attachEvent = typeof _window.document !== 'undefined' && _window.document.attachEvent;
+  var attachEvent =
+    typeof _window.document !== 'undefined' && _window.document.attachEvent;
 
   if (!attachEvent) {
     var requestFrame = (function() {


### PR DESCRIPTION
If `AutoSizer` is used in multi window enviroment, where the React app is running in a main window/process and renders content to a different child window, `AutoSizer` will not work properly because it's using the main window object and not the child one, who's dimensions we need.

This PR fixes the issue by detecting the current window in AutoSizer from `this._autoSizer.parentNode.ownerDocument.defaultView;`, which has the reference to proper window object and passing it to `detectElementResize`. In case that `defaultView` is `undefined` we fallback to default window object detection.
