### PR TITLE
Issue #1316: ability to set Column width + remove required

### DIFF
--- a/source/Table/Column.js
+++ b/source/Table/Column.js
@@ -78,7 +78,7 @@ export default class Column extends React.Component {
     style: PropTypes.object,
 
     /** Flex basis (width) for this column; This value can grow or shrink based on :flexGrow and :flexShrink properties. */
-    width: PropTypes.number.isRequired,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };
 
   static defaultProps = {

--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -673,7 +673,10 @@ export default class Table extends React.PureComponent {
    * Determines the flex-shrink, flex-grow, and width values for a cell (header or column).
    */
   _getFlexStyleForColumn(column, customStyle = {}) {
-    const flexValue = `${column.props.flexGrow} ${column.props.flexShrink} ${column.props.width}px`;
+    const w = column.props.width;
+    const flexValue = `${column.props.flexGrow} ${column.props.flexShrink} ${
+      w != null ? (isNaN(w) ? w : w + 'px') : 'auto'
+    }`;
 
     const style = {
       ...customStyle,


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

See: https://github.com/bvaughn/react-virtualized/issues/1316

This patch changes the following:
- removes **required** from Column's `width` and assigns **auto** to `flex-basis` by default;
- allows to use any string and number value for Column's `width`.

