### PR TITLE
CellMeasurer: add registerChild render prop

### DIFF
--- a/source/CellMeasurer/CellMeasurer.DynamicHeightList.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamicHeightList.example.js
@@ -59,8 +59,8 @@ export default class DynamicHeightList extends React.PureComponent {
         key={key}
         rowIndex={index}
         parent={parent}>
-        {({measure}) => (
-          <div className={classNames} style={style}>
+        {({measure, registerChild}) => (
+          <div ref={registerChild} className={classNames} style={style}>
             <img
               onLoad={measure}
               src={source}

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -30,6 +30,8 @@ type Props = {
 export default class CellMeasurer extends React.PureComponent<Props> {
   static __internalCellMeasurerFlag = false;
 
+  _child: ?Element;
+
   componentDidMount() {
     this._maybeMeasureCell();
   }

--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -42,14 +42,17 @@ export default class CellMeasurer extends React.PureComponent<Props> {
     const {children} = this.props;
 
     return typeof children === 'function'
-      ? children({measure: this._measure})
+      ? children({
+          measure: this._measure,
+          registerChild: this._registerChild,
+        })
       : children;
   }
 
   _getCellMeasurements() {
     const {cache} = this.props;
 
-    const node = findDOMNode(this);
+    const node = this._child || findDOMNode(this);
 
     // TODO Check for a bad combination of fixedWidth and missing numeric width or vice versa with height
 
@@ -143,6 +146,18 @@ export default class CellMeasurer extends React.PureComponent<Props> {
           rowIndex,
         });
       }
+    }
+  };
+
+  _registerChild = element => {
+    if (element && !(element instanceof Element)) {
+      console.warn(
+        'CellMeasurer registerChild expects to be passed Element or null',
+      );
+    }
+    this._child = element;
+    if (element) {
+      this._maybeMeasureCell();
     }
   };
 }


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

## Motivation

This enables a way to use `CellMeasurer` without `findDOMNode`, e.g. in React `StrictMode`. Here's an example usage:

```
<CellMeasurer {...}>
  {({registerChild}) => <div ref={registerChild} />}
</CellMeasurer>
```