### PR TITLE
make Autosizer not pure since it always re-renders anyway because it receives children as function

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -49,7 +49,7 @@ type DetectElementResize = {
   removeResizeListener: ResizeHandler,
 };
 
-export default class AutoSizer extends React.PureComponent<Props, State> {
+export default class AutoSizer extends React.Component<Props, State> {
   static defaultProps = {
     onResize: () => {},
     disableHeight: false,


### PR DESCRIPTION
Since the suggested use of the AutoSizer is passing an inline function to it, it doesn't makes sense the AutoSizer component is pure, since it would re-render anyway:
```
  <AutoSizer>
    {({height, width}) => (
      // this is a new function on each render.
    )}
  </AutoSizer>,
```
If anybody wants to make it pure, they still can:
```
const PureAutoSizer = React.memo(AutoSizer);
```


- [ x ] The existing test suites (`npm test`) all pass
- [ x ] For any new features or bug fixes, both positive and negative test cases have been added
- [ x ] For any new features, documentation has been added
**Should i document it?**
- [ x ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ x ] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [ x ] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
