### PR TITLE
Update masonry props and docs

### DIFF
--- a/docs/Masonry.md
+++ b/docs/Masonry.md
@@ -50,6 +50,7 @@ Phase one is repeated if the user scrolls beyond the current layout's bounds. If
 | tabIndex                   | number   |           | Optional override of tab index default; defaults to 0.                                                                                                                                                       |
 | width                      | number   |     ✓     | Width of the component; this value determines the number of visible items.                                                                                                                                   |
 | rowDirection               | string   |           | row direction of items, can be `ltr` or `rtl` defaults to `ltr`                                                                                                                                              |
+| scrollTop                  | number   |           | Forced vertical scroll offset; can be used to synchronize scrolling between components                                                                                                                       |
 
 ## Public Methods
 

--- a/source/Masonry/Masonry.js
+++ b/source/Masonry/Masonry.js
@@ -29,6 +29,7 @@ type Props = {
   tabIndex: number,
   width: number,
   rowDirection: string,
+  scrollTop?: number,
 };
 
 type State = {


### PR DESCRIPTION
Hey react-virtualized team 👋 

Here's a small change to the documentation and type definition of the `Masonry` component. I noticed that the component allows for a `scrollTop` prop to be passed in, but that prop wasn't listed in the documentation. I also noticed that the prop was not listed in the props type definition, so I added it there as well. Let me know if these changes are suitable, I'm available to make updates to my changes if needed. Thanks for your work on project, cheers 👍