### PR TITLE
Add event to onScrollToChange function args

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -180,10 +180,11 @@ export default class ArrowKeyStepperExample extends React.PureComponent<
         key={key}
         onClick={
           this.state.isClickable &&
-          (() =>
+          (event =>
             this._selectCell({
               scrollToColumn: columnIndex,
               scrollToRow: rowIndex,
+              event,
             }))
         }
         style={style}>

--- a/source/ArrowKeyStepper/ArrowKeyStepper.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.js
@@ -29,7 +29,7 @@ type Props = {
   scrollToRow: number,
 };
 
-type State = ScrollIndices & {
+type State = $Diff<ScrollIndices, {event: Event}> & {
   instanceProps: {
     prevScrollToColumn: number,
     prevScrollToRow: number,
@@ -156,7 +156,7 @@ class ArrowKeyStepper extends React.PureComponent<Props, State> {
     ) {
       event.preventDefault();
 
-      this._updateScrollState({scrollToColumn, scrollToRow});
+      this._updateScrollState({scrollToColumn, scrollToRow, event});
     }
   };
 
@@ -176,11 +176,11 @@ class ArrowKeyStepper extends React.PureComponent<Props, State> {
     return this.props.isControlled ? this.props : this.state;
   }
 
-  _updateScrollState({scrollToColumn, scrollToRow}: ScrollIndices) {
+  _updateScrollState({scrollToColumn, scrollToRow, event}: ScrollIndices) {
     const {isControlled, onScrollToChange} = this.props;
 
     if (typeof onScrollToChange === 'function') {
-      onScrollToChange({scrollToColumn, scrollToRow});
+      onScrollToChange({scrollToColumn, scrollToRow, event});
     }
 
     if (!isControlled) {

--- a/source/ArrowKeyStepper/types.js
+++ b/source/ArrowKeyStepper/types.js
@@ -3,4 +3,5 @@
 export type ScrollIndices = {
   scrollToColumn: number,
   scrollToRow: number,
+  event: Event,
 };


### PR DESCRIPTION
Hi, 
I thought it might increase the controllability if we pass the event as an argument to `onScrollToChange` function. For example; if we want to use `event.shiftKey | event.ctrlKey` for a different behavior.

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).
