### PR TITLE
Set sideEffects field in package.json to setup Webpack tree shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,34 +107,6 @@ import 'react-virtualized/styles.css';
 
 // You can import any component you want as a named export from 'react-virtualized', eg
 import {Column, Table} from 'react-virtualized';
-
-// But if you only use a few react-virtualized components,
-// And you're concerned about increasing your application's bundle size,
-// You can directly import only the components you need, like so:
-import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
-import List from 'react-virtualized/dist/commonjs/List';
-```
-
-Note webpack 4 makes this optimization itself, see the [documentation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).
-
-If the above syntax looks too cumbersome, or you import react-virtualized components from a lot of places, you can also configure a Webpack alias. For example:
-
-```js
-// Partial webpack.config.js
-{
-  alias: {
-    'react-virtualized/List': 'react-virtualized/dist/es/List',
-  },
-  ...rest
-}
-```
-
-Then you can just import like so:
-
-```js
-import List from 'react-virtualized/List';
-
-// Now you can use <List {...props} />
 ```
 
 You can also use a global-friendly UMD build:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "module": "dist/es/index.js",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
+  "sideEffects": [
+    "*.css"
+  ],
   "scripts": {
     "build:types": "flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/WindowScroller dist/es/WindowScroller && flow-copy-source --ignore \"**/*.{jest,e2e,ssr,example}.js\" source/AutoSizer dist/es/AutoSizer",
     "build": "yarn run build:commonjs && yarn run build:css && yarn run build:es && yarn run build:demo && yarn run build:umd",


### PR DESCRIPTION
This marks any CSS files in the project as having side effects. This means Webpack won't strip out the CSS files if they've been imported as compared to marking the whole project as side effect free. 

This also lets Webpack tree shake, i.e. remove, exports that haven't been imported by consumers.
I've also removed the information in the README about direct imports and Webpack aliases for bundle size, since now bundlers will do the hard work for users.

Using this "app" with this fork linked using yarn, I compared the Webpack bundle when setting sideEffects to false, and to marking any CSS files as having side effects.
```js
import 'react-virtualized/styles.css';
import { AutoSizer } from "react-virtualized";
import React from "react";
import { render } from "react-dom";

const app = React.createElement(AutoSizer, null);

const rootElement = document.getElementById("yes");
if (rootElement) {
    render(app, rootElement);
}
```

### sideEffects: false
![Screen Shot 2020-08-14 at 3 23 52 pm](https://user-images.githubusercontent.com/5336472/90216959-4b8e1800-de43-11ea-99b4-e8ea5a4d699c.png)

### sideEffects: ["*.css"]
![Screen Shot 2020-08-14 at 3 24 19 pm](https://user-images.githubusercontent.com/5336472/90216983-5c3e8e00-de43-11ea-84a8-68fbe9f19844.png)

As you can see, the second version still includes styles.css in the bottom right as you'd expect. If you want to test this locally this is the webpack config I used.
```js
const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;

module.exports = {
    module: {
        rules: [
            {
                test: /\.css$/i,
                use: ['style-loader', 'css-loader'],
            },
        ],
    },
    plugins: [
        new BundleAnalyzerPlugin()
    ]
}
```

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).
