### PR TITLE
Do not use innerHTML when detecting element resize

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -182,9 +182,13 @@ export default function createDetectElementResize(nonce, hostWindow) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        element.__resizeTriggers__.innerHTML =
-          '<div class="expand-trigger"><div></div></div>' +
-          '<div class="contract-trigger"></div>';
+        var expandTrigger = doc.createElement('div');
+        expandTrigger.className = 'expand-trigger';
+        expandTrigger.appendChild(doc.createElement('div'));
+        var contractTrigger = doc.createElement('div');
+        contractTrigger.className = 'contract-trigger';
+        element.__resizeTriggers__.appendChild(expandTrigger);
+        element.__resizeTriggers__.appendChild(contractTrigger);
         element.appendChild(element.__resizeTriggers__);
         resetTriggers(element);
         element.addEventListener('scroll', scrollListener, true);


### PR DESCRIPTION
use of `Element.innerHTML` will throw an error if the page uses Trusted Types.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
