### PR TITLE
Create Trusted Type policy for assigning an HTML in detectElementResize.js

### DIFF
--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -187,7 +187,9 @@ export default function createDetectElementResize(nonce, hostWindow) {
           '<div class="contract-trigger"></div>';
         if (window.trustedTypes) {
           var staticPolicy = trustedTypes.createPolicy(
-            'react-virtualized-auto-sizer', {createHTML: () => resizeTriggersHtml});
+            'react-virtualized-auto-sizer',
+            {createHTML: () => resizeTriggersHtml},
+          );
           element.__resizeTriggers__.innerHTML = staticPolicy.createHTML('');
         } else {
           element.__resizeTriggers__.innerHTML = resizeTriggersHtml;

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -182,7 +182,7 @@ export default function createDetectElementResize(nonce, hostWindow) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        var resizeTriggersHtml = 
+        var resizeTriggersHtml =
           '<div class="expand-trigger"><div></div></div>' +
           '<div class="contract-trigger"></div>';
         if (window.trustedTypes) {

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -182,9 +182,13 @@ export default function createDetectElementResize(nonce, hostWindow) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        element.__resizeTriggers__.innerHTML =
-          '<div class="expand-trigger"><div></div></div>' +
-          '<div class="contract-trigger"></div>';
+        var expandTriggerDiv = document.createElement('div');
+        expandTriggerDiv.class = 'expand-trigger';
+        expandTriggerDiv.appendChild(document.createElement('div'));
+        var contractTriggerDiv = document.createElement('div');
+        contractTriggerDiv.class = 'contract-trigger';
+        element.__resizeTriggers__.appendChild(expandTriggerDiv);
+        element.__resizeTriggers__.appendChild(contractTriggerDiv);
         element.appendChild(element.__resizeTriggers__);
         resetTriggers(element);
         element.addEventListener('scroll', scrollListener, true);

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -182,13 +182,16 @@ export default function createDetectElementResize(nonce, hostWindow) {
         element.__resizeListeners__ = [];
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
-        var expandTriggerDiv = document.createElement('div');
-        expandTriggerDiv.class = 'expand-trigger';
-        expandTriggerDiv.appendChild(document.createElement('div'));
-        var contractTriggerDiv = document.createElement('div');
-        contractTriggerDiv.class = 'contract-trigger';
-        element.__resizeTriggers__.appendChild(expandTriggerDiv);
-        element.__resizeTriggers__.appendChild(contractTriggerDiv);
+        var resizeTriggersHtml = 
+          '<div class="expand-trigger"><div></div></div>' + 
+          '<div class="contract-trigger"></div>';
+        if (window.trustedTypes) {
+          var staticPolicy = trustedTypes.createPolicy(
+            'react-virtualized-auto-sizer', {createHTML: () => resizeTriggersHtml});
+          element.__resizeTriggers__.innerHTML = staticPolicy.createHTML('');
+        } else {
+          element.__resizeTriggers__.innerHTML = resizeTriggersHtml;
+        }
         element.appendChild(element.__resizeTriggers__);
         resetTriggers(element);
         element.addEventListener('scroll', scrollListener, true);

--- a/source/vendor/detectElementResize.js
+++ b/source/vendor/detectElementResize.js
@@ -183,7 +183,7 @@ export default function createDetectElementResize(nonce, hostWindow) {
         (element.__resizeTriggers__ = doc.createElement('div')).className =
           'resize-triggers';
         var resizeTriggersHtml = 
-          '<div class="expand-trigger"><div></div></div>' + 
+          '<div class="expand-trigger"><div></div></div>' +
           '<div class="contract-trigger"></div>';
         if (window.trustedTypes) {
           var staticPolicy = trustedTypes.createPolicy(


### PR DESCRIPTION
When react virtualized is used in a page where it enforces [Trusted Types](https://web.dev/trusted-types/), Trusted Types violation will trigger because there is an `innerHTML` usage in `detectElementResize.js`.

I have made a fix to create a Trusted Type policy that returns the same HTML to eliminate this Trusted Types violation.

This PR fixes https://github.com/bvaughn/react-virtualized/issues/1575.