### PR TITLE
Fix grid roles for accessbility

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1102,7 +1102,7 @@ describe('Grid', () => {
     });
   });
 
-  describe('styles, classNames, and ids', () => {
+  describe('styles, classNames, ids, and roles', () => {
     it('should use the expected global CSS classNames', () => {
       const rendered = findDOMNode(render(getMarkup()));
       expect(rendered.className).toEqual('ReactVirtualized__Grid');
@@ -1131,6 +1131,12 @@ describe('Grid', () => {
         rendered.querySelector('.ReactVirtualized__Grid__innerScrollContainer')
           .style.backgroundColor,
       ).toEqual('red');
+    });
+
+    it('should have the gridcell role', () => {
+      const containerStyle = {backgroundColor: 'red'};
+      const rendered = findDOMNode(render(getMarkup({containerStyle})));
+      expect(rendered.querySelectorAll('[role="gridcell"]').length).toEqual(20);
     });
   });
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -263,7 +263,7 @@ class Grid extends React.PureComponent<Props, State> {
     autoHeight: false,
     autoWidth: false,
     cellRangeRenderer: defaultCellRangeRenderer,
-    containerRole: 'rowgroup',
+    containerRole: 'row',
     containerStyle: {},
     estimatedColumnSize: 100,
     estimatedRowSize: 30,

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -1,6 +1,7 @@
 /** @flow */
 
 import type {CellRangeRendererParams} from './types';
+import React from 'react';
 
 /**
  * Default implementation of cellRangeRenderer used by Grid.
@@ -136,6 +137,10 @@ export default function defaultCellRangeRenderer({
 
       if (process.env.NODE_ENV !== 'production') {
         warnAboutMissingStyle(parent, renderedCell);
+      }
+
+      if (!renderedCell.props.role) {
+        renderedCell = React.cloneElement(renderedCell, {role: 'gridcell'});
       }
 
       renderedCells.push(renderedCell);


### PR DESCRIPTION
Related to #1199 which was said to be fixed by #1208 but the PR only addressed the issue with Tables and not Grids.
This PR fixes a default role and adds another role to each cell which allows screen readers to correctly read Grids. Without this change, screen readers don't recognize any cells within the Grid and fails to announce them (tested with Voice Over on Firefox and Chrome).

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).