### PR TITLE
Table: Update of Scroll Width in the next macrotask

### DIFF
--- a/source/Table/Table.js
+++ b/source/Table/Table.js
@@ -263,6 +263,7 @@ export default class Table extends React.PureComponent {
     this._onScroll = this._onScroll.bind(this);
     this._onSectionRendered = this._onSectionRendered.bind(this);
     this._setRef = this._setRef.bind(this);
+    this._updateTimeoutHandle = null;
   }
 
   forceUpdateGrid() {
@@ -353,7 +354,21 @@ export default class Table extends React.PureComponent {
   }
 
   componentDidUpdate() {
-    this._setScrollbarWidth();
+    if (this._updateTimeoutHandle) {
+      clearTimeout(this._updateTimeoutHandle);
+    }
+
+    // We move this update to separated macro-task in order to not create long executed tasks
+    this._updateTimeoutHandle = setTimeout(() => {
+      this._updateTimeoutHandle = null;
+      this._setScrollbarWidth();
+    }, 0);
+  }
+
+  componentWillUnmount() {
+    if (this._updateTimeoutHandle) {
+      clearTimeout(this._updateTimeoutHandle);
+    }
   }
 
   render() {


### PR DESCRIPTION
I measured the performance of our project website. And the longest task contained recalculation of scrollbar width. And it was one of the causes why this rerendering macro-task took > 100ms.

So I thought - scrollbar width it's something that we can update in the next macrotask - it should not cause any bugs.

This PR is about moving of recalculation of scrollbar width to future macrotask.