### PR TITLE
Fix issue with unused import being emitted

### DIFF
--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -1,10 +1,11 @@
 // @flow
 'no babel-plugin-flow-react-proptypes';
+
 import {
   requestAnimationTimeout,
   cancelAnimationTimeout,
 } from '../../utils/requestAnimationTimeout';
-import type {WindowScroller} from '../WindowScroller.js';
+import type WindowScroller from '../WindowScroller.js';
 
 let mountedInstances = [];
 let originalBodyPointerEvents = null;

--- a/source/WindowScroller/utils/onScroll.js
+++ b/source/WindowScroller/utils/onScroll.js
@@ -1,10 +1,10 @@
 // @flow
-
+'no babel-plugin-flow-react-proptypes';
 import {
   requestAnimationTimeout,
   cancelAnimationTimeout,
 } from '../../utils/requestAnimationTimeout';
-import type WindowScroller from '../WindowScroller.js';
+import type {WindowScroller} from '../WindowScroller.js';
 
 let mountedInstances = [];
 let originalBodyPointerEvents = null;


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] The existing test suites (`npm test`) all pass
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

### Description
https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/206
https://github.com/bvaughn/react-virtualized/issues/1632
https://github.com/bvaughn/react-virtualized/issues/1212

There seems to be an issue with an unused import being emitted in the `onScroll` file as a result of the `babel-plugin-flow-react-proptypes` plugin. The unused import makes it unable to build with esbuild, and in turn Vite and Snowpack has issues. The suggested fix is to add the supression string as described in the "Suppression" section of https://github.com/brigand/babel-plugin-flow-react-proptypes at the top of the file. This should not be an issue as there are no React proptypes to be generated in this file.

What do you think? Thanks in beforehand. With friendly hellos.