### PR TITLE
Bugfix: `MultiGrid` renders extra cells for scrollbar spacing, but for the wrong scroll direction

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -626,9 +626,7 @@ class MultiGrid extends React.PureComponent {
     const additionalRowCount = showHorizontalScrollbar ? 1 : 0,
       height = this._getBottomGridHeight(props),
       width = this._getLeftGridWidth(props),
-      scrollbarSize = showHorizontalScrollbar
-        ? this.state.scrollbarSize
-        : 0,
+      scrollbarSize = showHorizontalScrollbar ? this.state.scrollbarSize : 0,
       gridWidth = hideBottomLeftGridScrollbar ? width + scrollbarSize : width;
 
     const bottomLeftGrid = (

--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -617,16 +617,16 @@ class MultiGrid extends React.PureComponent {
       rowCount,
       hideBottomLeftGridScrollbar,
     } = props;
-    const {showVerticalScrollbar} = this.state;
+    const {showHorizontalScrollbar} = this.state;
 
     if (!fixedColumnCount) {
       return null;
     }
 
-    const additionalRowCount = showVerticalScrollbar ? 1 : 0,
+    const additionalRowCount = showHorizontalScrollbar ? 1 : 0,
       height = this._getBottomGridHeight(props),
       width = this._getLeftGridWidth(props),
-      scrollbarSize = this.state.showVerticalScrollbar
+      scrollbarSize = showHorizontalScrollbar
         ? this.state.scrollbarSize
         : 0,
       gridWidth = hideBottomLeftGridScrollbar ? width + scrollbarSize : width;
@@ -729,16 +729,16 @@ class MultiGrid extends React.PureComponent {
       scrollLeft,
       hideTopRightGridScrollbar,
     } = props;
-    const {showHorizontalScrollbar, scrollbarSize} = this.state;
+    const {showVerticalScrollbar, scrollbarSize} = this.state;
 
     if (!fixedRowCount) {
       return null;
     }
 
-    const additionalColumnCount = showHorizontalScrollbar ? 1 : 0,
+    const additionalColumnCount = showVerticalScrollbar ? 1 : 0,
       height = this._getTopGridHeight(props),
       width = this._getRightGridWidth(props),
-      additionalHeight = showHorizontalScrollbar ? scrollbarSize : 0;
+      additionalHeight = showVerticalScrollbar ? scrollbarSize : 0;
 
     let gridHeight = height,
       style = this._topRightGridStyle;


### PR DESCRIPTION
## **Background:**
`MultiGrid` occasionally renders extra cells (sometimes as rows, sometimes as columns) to create extra room for scrollbars.

## **Bug:**
Even without a horizontal scroll bar present, `MultiGrid` is rendering an extra row, which creates an awkward extra space at the bottom of the page. 

## **Steps to Reproduce:**
On the official [MultiGrid Example](https://bvaughn.github.io/react-virtualized/#/components/MultiGrid) 
1. Set the column count to an amount that doesn't require horizontal scrolling on your screen (I had to break out React DevTools to adjust this, since it's not adjustable via the UI).
2. On the pinned columns, scroll down as far as you can go.
3. See extra space at the bottom.

<img width="1266" alt="Screen Shot 2021-03-11 at 7 03 46 PM" src="https://user-images.githubusercontent.com/1036549/110871512-8acafd00-829c-11eb-8028-bfaac3798e66.png">
(I added a red background to the empty cells)

## **What's Happening:**
It turns out `_renderBottomLeftGrid` is looking at `showVerticalScrollbar` when determining whether it should create an extra row. This is incorrect, because the extra **row** should account for the **horizontal** scrollbar, not the vertical one (this makes sense: horizontal scrolling creates a scrollbar at the **bottom** of the table). Similarly, `_renderTopRightGrid` is looking at `showHorizontalScrollbar` when adding an extra column, whereas it should be looking at `showVerticalScrollbar`.

## **Solution:**
This is a fairly simple fix; I just swapped out which boolean each grid is looking at to determine whether it needs an extra row/column.

## **Contribution Checklist:**
- [x] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).
