### PR TITLE
Fix bug in WindowScroller::updatePosition

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  launch: {
+    headless: process.env.HEADLESS !== 'false',
+    devtools: process.env.DEVTOOLS === 'true',
+  },
+};

--- a/source/WindowScroller/WindowScroller.header-resize.e2e.js
+++ b/source/WindowScroller/WindowScroller.header-resize.e2e.js
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jest-environment-puppeteer
+ */
+
+const bootstrap = async () => {
+  const page = await global.browser.newPage();
+  const scripts = [
+    './node_modules/react/umd/react.development.js',
+    './node_modules/react-dom/umd/react-dom.development.js',
+    './dist/umd/react-virtualized.js',
+  ];
+
+  for (const path of scripts) {
+    await page.addScriptTag({path});
+  }
+
+  return page;
+};
+
+const renderWindowScroller = () => {
+  const {render} = window.ReactDOM;
+  const {createElement, useState, useEffect} = window.React;
+  const {WindowScroller} = window.ReactVirtualized;
+
+  const container = document.createElement('div');
+  container.id = 'container';
+  document.body.appendChild(container);
+  document.body.style.margin = 0;
+
+  function Header({height}) {
+    return createElement('div', {style: {height, backgroundColor: 'red'}});
+  }
+
+  function App() {
+    const [height, setHeight] = useState(100);
+    window.setHeaderHeight = setHeight;
+    useEffect(() => () => (window.setHeaderHeight = null));
+
+    return createElement(
+      'div',
+      {},
+      createElement(Header, {height}),
+      createElement(
+        WindowScroller,
+        {
+          updateScrollTopOnUpdatePosition: true,
+          ref: windowScroller => {
+            window.windowScroller = windowScroller;
+          },
+          onScroll: window.scrollFn,
+          onResize: window.resizeFn,
+        },
+        ({width, scrollTop}) => {
+          console.log({scrollTop});
+          window.windowScrollerScrollTop = scrollTop;
+          return createElement('div', {
+            style: {
+              width,
+              height: 3000,
+              backgroundColor: 'yellow',
+            },
+          });
+        },
+      ),
+    );
+  }
+
+  render(
+    createElement(
+      'div',
+      {'data-test-id': 'main-container'},
+      createElement(App, {}),
+    ),
+    container,
+  );
+};
+
+jest.setTimeout(1200000);
+
+const delay = time => new Promise(resolve => setTimeout(resolve, time));
+
+test('will react to header height updates if notified through updatePosition', async () => {
+  const page = await bootstrap();
+  const scrollFn = jest.fn();
+  const resizeFn = jest.fn();
+  await page.exposeFunction('scrollFn', scrollFn);
+  await page.exposeFunction('resizeFn', resizeFn);
+
+  await page.setViewport({width: 400, height: 600});
+  await page.evaluate(renderWindowScroller);
+
+  const el = await page.$('[data-test-id="main-container"]');
+  expect(el).not.toBeNull();
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await delay(500);
+
+  {
+    const scrollTop = await page.evaluate(() => window.windowScrollerScrollTop);
+    expect(scrollTop).toEqual(100);
+  }
+  await delay(500);
+
+  // Update the header height
+  await page.evaluate(() => {
+    console.log('change header height');
+    window.setHeaderHeight(200);
+  });
+  await delay(500);
+
+  // await jestPuppeteer.pa();
+
+  await page.evaluate(() => {
+    console.log('update position');
+    window.windowScroller.updatePosition();
+  });
+  await delay(500);
+
+  // await jestPuppeteer.debug();
+
+  // Despite header updates, we'd expect the scrollTop to be the same.
+  {
+    const scrollTop = await page.evaluate(() => window.windowScrollerScrollTop);
+    expect(scrollTop).toEqual(100);
+  }
+});
+
+test('will properly process scroll events after header height updates', async () => {
+  const page = await bootstrap();
+  const scrollFn = jest.fn();
+  const resizeFn = jest.fn();
+  await page.exposeFunction('scrollFn', scrollFn);
+  await page.exposeFunction('resizeFn', resizeFn);
+
+  await page.setViewport({width: 400, height: 600});
+  await page.evaluate(renderWindowScroller);
+
+  const el = await page.$('[data-test-id="main-container"]');
+  expect(el).not.toBeNull();
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await delay(500);
+
+  {
+    const scrollTop = await page.evaluate(() => window.windowScrollerScrollTop);
+    expect(scrollTop).toEqual(100);
+  }
+  await delay(500);
+
+  // Update the header height
+  await page.evaluate(() => {
+    window.setHeaderHeight(200);
+  });
+  await delay(500);
+
+  await page.evaluate(() => {
+    window.windowScroller.updatePosition();
+  });
+  await delay(500);
+  // This is only 50px under the first position
+  await page.evaluate(() => window.scrollTo(0, 350));
+
+  {
+    const scrollTop = await page.evaluate(() => window.windowScrollerScrollTop);
+    expect(scrollTop).toEqual(150);
+  }
+});

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -47,6 +47,9 @@ type Props = {
 
   /** Width used for server-side rendering */
   serverWidth: number,
+
+  /** Force scrollTop updates when .updatePosition is called, fixing forced header height change updates */
+  updateScrollTopOnUpdatePosition?: boolean,
 };
 
 type State = {
@@ -119,7 +122,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
       });
     }
 
-    if (this.props.updateScrollTopOnUpdatePosition) {
+    if (this.props.updateScrollTopOnUpdatePosition === true) {
       this.__handleWindowScrollEvent();
     }
   }

--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -118,6 +118,10 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
         width: dimensions.width,
       });
     }
+
+    if (this.props.updateScrollTopOnUpdatePosition) {
+      this.__handleWindowScrollEvent();
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Hello, I'm opening this PR to fix a bug found in the `WindowScroller::updatePosition` method.

I've pushed a full sandbox reproduction of the bug, with documentation of what is the problem and the fix to https://codesandbox.io/s/7mdt8. I'd be happy to discuss the problem further on a video-call and or send you a video-recording I've of it through e-mail.

In summary, the bug happens when trying to react to "header height" changes with `WindowScroller`. The documentation points to calling `WindowScroller::updatePosition`, however, while that updates the cached position on the `WindowScroller` instance variables, it does not update the `scrollTop` state variable. This causes virtual-lists linked to it to not properly render immediately after a header height change; only after a subsequent scroll event.

I've added E2E tests which reproduce the error and a prop that fixes it by forcing a scroll event handler call.

There're tests for the prop being true/false so we can see that when it's false the problem exists but when true the problem is fixed.

The fix is essentially flagged by this prop and would be opt-in. I'm not sure if that's the best way.