### PR TITLE
Update bug fix in #1642 to also reset isScrolling

### DIFF
--- a/source/WindowScroller/WindowScroller.js
+++ b/source/WindowScroller/WindowScroller.js
@@ -124,6 +124,7 @@ export default class WindowScroller extends React.PureComponent<Props, State> {
 
     if (this.props.updateScrollTopOnUpdatePosition === true) {
       this.__handleWindowScrollEvent();
+      this.__resetIsScrolling();
     }
   }
 


### PR DESCRIPTION
After further testing, I've found that after `handleWindowScrollEvent`
is called we also need to force the `isScrolling` state variable to turn
back to false (otherwise there might be issues with rendering rows that
depend on `isScrolling`).
