### PR TITLE
add optional aria property to read changes in selection

### DIFF
--- a/source/ArrowKeyStepper/ArrowKeyStepper.example.js
+++ b/source/ArrowKeyStepper/ArrowKeyStepper.example.js
@@ -108,7 +108,8 @@ export default class ArrowKeyStepperExample extends React.PureComponent<
           scrollToRow={scrollToRow}>
           {({onSectionRendered, scrollToColumn, scrollToRow}) => (
             <div>
-              <ContentBoxParagraph>
+              <ContentBoxParagraph
+                aria={`row: ${scrollToRow}, column: ${scrollToColumn}`}>
                 {`Most-recently-stepped column: ${scrollToColumn}, row: ${scrollToRow}`}
               </ContentBoxParagraph>
 

--- a/source/demo/ContentBox.js
+++ b/source/demo/ContentBox.js
@@ -42,6 +42,13 @@ export function ContentBoxHeader({text, sourceLink, docsLink}) {
   );
 }
 
-export function ContentBoxParagraph({children}) {
-  return <div className={styles.Paragraph}>{children}</div>;
+export function ContentBoxParagraph({aria, children}) {
+  return (
+    <div
+      aria-label={aria}
+      aria-live={aria ? 'assertive' : null}
+      className={styles.Paragraph}>
+      {aria ? <div aria-hidden="true">{children}</div> : children}
+    </div>
+  );
 }


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)

**Description:**
Navigation with arrow keys did not read out the row or column on the table for screen readers. I added an optional "aria" prop to the ContentBoxParagraph to read any updates made when switching to a new box. In this example, I added an aria-label of "row: 0, column: 0".
