### PR TITLE
Adding role list to List component

### DIFF
--- a/source/List/List.js
+++ b/source/List/List.js
@@ -98,6 +98,7 @@ type Props = {
 
 export default class List extends React.PureComponent<Props> {
   static defaultProps = {
+    'aria-label': 'list',
     autoHeight: false,
     estimatedRowSize: 30,
     onScroll: () => {},
@@ -204,6 +205,7 @@ export default class List extends React.PureComponent<Props> {
         onSectionRendered={this._onSectionRendered}
         ref={this._setRef}
         scrollToRow={scrollToIndex}
+        role="list"
       />
     );
   }


### PR DESCRIPTION
Added role=list for the List component as currently it has role="grid" which is creating accessibility issue in mac voiceover. 
Here is the issue ticket - https://github.com/bvaughn/react-virtualized/issues/1657
