### PR TITLE
Fix Markdown formatting bug in Grid.md

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -93,10 +93,10 @@ Useful for animating position changes.
 
 The Grid component supports the following static class names
 
-| Property                                     | Description           |
-| :------------------------------------------- | :-------------------- |
-| ReactVirtualized\_\_Grid                     | Main (outer) element  |
-| ReactVirtualized**Grid**innerScrollContainer | Inner scrollable area |
+| Property                                         | Description           |
+| :----------------------------------------------- | :-------------------- |
+| ReactVirtualized\_\_Grid                         | Main (outer) element  |
+| ReactVirtualized\_\_Grid\_\_innerScrollContainer | Inner scrollable area |
 
 ### cellRangeRenderer
 


### PR DESCRIPTION
Hi,

I noticed that the class names for `<Grid>` seem to have a formatting error where the `__Grid__` part of the class name has been converted into bold text. Looking at an inspector, it seems that the correct classname for a Grid's inner scrollable area is `ReactVirtualized__Grid__innerScrollContainer`, but it shows on the current documentation as ReactVirtualized**Grid**innerScrollContainer.

I wasn't sure if `Grid.md` was generated from some other file, but I made the change to escape `__string__` in this PR.

Thanks,
Ian