### PR TITLE
chore: Add support for react ^17.0.0 and ^18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,8 +147,8 @@
     "react-lifecycles-compat": "^3.0.4"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.1",
-    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.1"
+    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Adds React ^17 and React ^18 as allowed peer dependencies, so that apps using this library can upgrade React without having to [override](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) any dependencies.

This pull request should superseed https://github.com/bvaughn/react-virtualized/pull/1656.

- [x] The existing test suites (`npm test`) all pass
- [x] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [x] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).