### PR TITLE
use 'registerChild' as ref in registerChild example

### DIFF
--- a/docs/CellMeasurer.md
+++ b/docs/CellMeasurer.md
@@ -150,6 +150,7 @@ function cellRenderer ({ columnIndex, key, parent, rowIndex, style }) {
     >
       {({registerChild}) => (
         <div
+          ref={registerChild}
           style={{
             ...style,
             height: 35,


### PR DESCRIPTION
In the `registerChild` example in CellMeasurer, we never use `registerChild`. From looking around some, I believe one valid use is to pass it as `ref={registerChild}`, which I do here.

I'm still quite unsure of this PR but it seems to match most of the examples I've found. And the current state of the docs seems quite weird/confusing, as we introduce this param then don't use it. I hope this PR makes sense, & please forgive me if not.

One example of another user here following this pattern is this comment: https://github.com/bvaughn/react-virtualized/issues/1572#issuecomment-1155080288

- [X] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).

