### PR TITLE
Update peer deps to include React 17 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "9.22.3",
+  "version": "9.22.4",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -146,8 +146,8 @@
     "react-lifecycles-compat": "^3.0.4"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0-alpha",
-    "react-dom": "^15.3.0 || ^16.0.0-alpha"
+    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Much has changed in the main branch since the last release and I don't know how safe it is to release it. This release was made from the v9.22.3 release tag, and only changes peer dependencies to support React 17 and 18.