### PR TITLE
add scrollerProps to Grid

### DIFF
--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -221,6 +221,9 @@ type Props = {
 
   /** Width of Grid; this property determines the number of visible (vs virtualized) columns.  */
   width: number,
+
+  /** scroller props */
+  scrollerProps?: Object,
 };
 
 type InstanceProps = {
@@ -976,6 +979,7 @@ class Grid extends React.PureComponent<Props, State> {
       style,
       tabIndex,
       width,
+      scrollerProps,
     } = this.props;
     const {instanceProps, needToResetStyleCache} = this.state;
 
@@ -1056,6 +1060,7 @@ class Grid extends React.PureComponent<Props, State> {
         tabIndex={tabIndex}>
         {childrenToDisplay.length > 0 && (
           <div
+            {...scrollerProps}
             className="ReactVirtualized__Grid__innerScrollContainer"
             role={containerRole}
             style={{


### PR DESCRIPTION
Maybe this might be useful for integration with [`downshift`](https://github.com/downshift-js/downshift/blob/master/README.md)?

https://stackoverflow.com/questions/77761029/is-getmenuprops-necessary-in-react-downshift-autocomplete-library

I tested this out by publishing the module to `@lancejpollard/react-virtualized`, and it seems to work (see the answer in that link)!