### PR TITLE
fix: findDOMNode error in CellMeasurer

### DIFF
--- a/source/CellMeasurer/CellMeasurer.js
+++ b/source/CellMeasurer/CellMeasurer.js
@@ -1,6 +1,5 @@
 /** @flow */
 import * as React from 'react';
-import {findDOMNode} from 'react-dom';
 import type {CellMeasureCache} from './types';
 
 type Children = (params: {measure: () => void}) => React.Element<*>;
@@ -30,7 +29,7 @@ type Props = {
 export default class CellMeasurer extends React.PureComponent<Props> {
   static __internalCellMeasurerFlag = false;
 
-  _child: ?Element;
+  _child: { current: null | HTMLElement } = React.createRef();
 
   componentDidMount() {
     this._maybeMeasureCell();
@@ -54,7 +53,7 @@ export default class CellMeasurer extends React.PureComponent<Props> {
   _getCellMeasurements() {
     const {cache} = this.props;
 
-    const node = this._child || findDOMNode(this);
+    const node = this._child.current;
 
     // TODO Check for a bad combination of fixedWidth and missing numeric width or vice versa with height
 


### PR DESCRIPTION
Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [ ] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)

--- 

Simply fix findDOMNode deprecated error in CellMeasurer
![Screen Shot 2024-09-06 at 4 53 59 PM](https://github.com/user-attachments/assets/e50c8be4-a72d-4822-a7ce-f08d399d309e)